### PR TITLE
Keep the old behaviour with auto generated elasticsearch _id (draft)

### DIFF
--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClient.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClient.java
@@ -243,7 +243,8 @@ public class ElasticSearchClient {
             checkNotFailed();
             checkIndexExists(record.getTopicName());
             IndexRequest indexRequest = Requests.indexRequest(config.getIndexName());
-            indexRequest.id(idAndDoc.getLeft());
+            if (!Strings.isNullOrEmpty(idAndDoc.getLeft()))
+                indexRequest.id(idAndDoc.getLeft());
             indexRequest.type(config.getTypeName());
             indexRequest.source(idAndDoc.getRight(), XContentType.JSON);
 
@@ -268,7 +269,8 @@ public class ElasticSearchClient {
             checkNotFailed();
             checkIndexExists(record.getTopicName());
             IndexRequest indexRequest = Requests.indexRequest(config.getIndexName());
-            indexRequest.id(idAndDoc.getLeft());
+            if (!Strings.isNullOrEmpty(idAndDoc.getLeft()))
+                indexRequest.id(idAndDoc.getLeft());
             indexRequest.type(config.getTypeName());
             indexRequest.source(idAndDoc.getRight(), XContentType.JSON);
             IndexResponse indexResponse = client.index(indexRequest, RequestOptions.DEFAULT);

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
@@ -202,15 +202,15 @@ public class ElasticSearchConfig implements Serializable {
 
     @FieldDoc(
             required = false,
-            defaultValue = "false",
-            help = "Whether to ignore the record key to build the Elasticsearch document _id from the record value using the fields provided by the primaryFields parameter. If primaryFields is not defined, the connector use the unique pulsar messageId as the elasticsearch document id."
+            defaultValue = "true",
+            help = "Whether to ignore the record key to build the Elasticsearch document _id. If primaryFields is defined, the connector extract the primary fields from the payload to build the document _id. If no primaryFields are provided, elasticsearch auto generates a random document _id."
     )
-    private boolean keyIgnore = false;
+    private boolean keyIgnore = true;
 
     @FieldDoc(
             required = false,
             defaultValue = "id",
-            help = "The comma separated ordered list of field names used to build the Elasticsearch document _id from the record value."
+            help = "The comma separated ordered list of field names used to build the Elasticsearch document _id from the record value. If this list is a singleton, the field is converted as a string. If this list has 2 or more fields, the generated _id is a string representation of a JSON array of the field values."
     )
     private String primaryFields = "";
 
@@ -218,10 +218,10 @@ public class ElasticSearchConfig implements Serializable {
 
     @FieldDoc(
             required = false,
-            defaultValue = "DELETE",
-            help = "How to handle records with null values, possible options are IGNORE, DELETE or FAIL. Default is DELETE the Elasticsearch document."
+            defaultValue = "IGNORE",
+            help = "How to handle records with null values, possible options are IGNORE, DELETE or FAIL. Default is IGNORE the message."
     )
-    private NullValueAction nullValueAction = NullValueAction.DELETE;
+    private NullValueAction nullValueAction = NullValueAction.IGNORE;
 
     @FieldDoc(
             required = false,
@@ -283,10 +283,6 @@ public class ElasticSearchConfig implements Serializable {
 
         if (indexNumberOfReplicas < 0) {
             throw new IllegalArgumentException("indexNumberOfReplicas must be a positive integer.");
-        }
-
-        if (keyIgnore && StringUtils.isEmpty(primaryFields ) && NullValueAction.DELETE.equals(nullValueAction)) {
-            throw new IllegalArgumentException("If keyIgnore is true and primaryFields is empty, nullValueAction cannot be DELETE.");
         }
 
         if (connectTimeoutInMs < 0) {

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
@@ -55,13 +55,6 @@ public class ElasticSearchConfig implements Serializable {
     private String indexName;
 
     @FieldDoc(
-            required = false,
-            defaultValue = "false",
-            help = "Sets whether the Sink has to take into account the Schema or if it should simply copy the raw message to Elastichsearch"
-    )
-    private boolean schemaAware = false;
-
-    @FieldDoc(
         required = false,
         defaultValue = "_doc",
         help = "The type name that the connector writes messages to, with the default value set to _doc." +

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
@@ -158,11 +158,13 @@ public class ElasticSearchSink implements Sink<GenericObject> {
             }
 
             String id = null;
-            if (key != null) {
+            if (elasticSearchConfig.isKeyIgnore() == false && key != null) {
                 if (keySchema != null) {
                     id = stringifyKey(keySchema, key);
                 } else {
-                    id = key.toString();
+                    key = record.getKey().orElse(null);
+                    valueSchema = record.getSchema();
+                    value = record.getValue();
                 }
             }
 

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
@@ -82,10 +82,12 @@ public class ElasticSearchSink implements Sink<GenericObject> {
                 if (idAndDoc.getRight() == null) {
                     switch (elasticSearchConfig.getNullValueAction()) {
                         case DELETE:
-                            if (elasticSearchConfig.isBulkEnabled()) {
-                                elasticsearchClient.bulkDelete(record, idAndDoc.getLeft());
-                            } else {
-                                elasticsearchClient.deleteDocument(record, idAndDoc.getLeft());
+                            if (idAndDoc.getLeft() != null) {
+                                if (elasticSearchConfig.isBulkEnabled()) {
+                                    elasticsearchClient.bulkDelete(record, idAndDoc.getLeft());
+                                } else {
+                                    elasticsearchClient.deleteDocument(record, idAndDoc.getLeft());
+                                }
                             }
                             break;
                         case IGNORE:
@@ -173,19 +175,14 @@ public class ElasticSearchSink implements Sink<GenericObject> {
                 }
             }
 
-            if (elasticSearchConfig.isKeyIgnore()) {
-                if (doc == null || Strings.isNullOrEmpty(elasticSearchConfig.getPrimaryFields())) {
-                    // use the messageId as the doc id in last resort.
-                    id = Hex.encodeHexString(record.getMessage().get().getMessageId().toByteArray());
-                } else {
-                    try {
-                        // extract the PK from the JSON document
-                        JsonNode jsonNode = objectMapper.readTree(doc);
-                        List<String> pkFields = Arrays.asList(elasticSearchConfig.getPrimaryFields().split(","));
-                        id = stringifyKey(jsonNode, pkFields);
-                    } catch (JsonProcessingException e) {
-                        log.error("Failed to read JSON", e);
-                    }
+            if (elasticSearchConfig.isKeyIgnore() && !Strings.isNullOrEmpty(elasticSearchConfig.getPrimaryFields())) {
+                try {
+                    // extract the PK from the JSON document
+                    JsonNode jsonNode = objectMapper.readTree(doc);
+                    List<String> pkFields = Arrays.asList(elasticSearchConfig.getPrimaryFields().split(","));
+                    id = stringifyKey(jsonNode, pkFields);
+                } catch (JsonProcessingException e) {
+                    log.error("Failed to read JSON", e);
                 }
             }
 

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -107,8 +106,8 @@ public class ElasticSearchSink implements Sink<GenericObject> {
                         elasticsearchClient.indexDocument(record, idAndDoc);
                     }
                 }
-            } catch(JsonProcessingException jsonProcessingException) {
-                switch(elasticSearchConfig.getMalformedDocAction()) {
+            } catch (JsonProcessingException jsonProcessingException) {
+                switch (elasticSearchConfig.getMalformedDocAction()) {
                     case IGNORE:
                         break;
                     case WARN:
@@ -143,72 +142,65 @@ public class ElasticSearchSink implements Sink<GenericObject> {
      * @return A pair for _id and _source
      */
     public Pair<String, String> extractIdAndDocument(Record<GenericObject> record) throws JsonProcessingException {
-        if (elasticSearchConfig.isSchemaAware()) {
-            Object key = null;
-            Object value = null;
-            Schema<?> keySchema = null;
-            Schema<?> valueSchema = null;
-            if (record.getSchema() != null && record.getSchema() instanceof KeyValueSchema) {
-                KeyValueSchema<GenericObject, GenericObject> keyValueSchema = (KeyValueSchema) record.getSchema();
-                keySchema = keyValueSchema.getKeySchema();
-                valueSchema = keyValueSchema.getValueSchema();
-                KeyValue<GenericObject, GenericObject> keyValue = (KeyValue<GenericObject, GenericObject>) record.getValue().getNativeObject();
-                key = keyValue.getKey();
-                value = keyValue.getValue();
-            } else {
-                key = record.getKey().orElse(null);
-                valueSchema = record.getSchema();
-                value = record.getValue();
-            }
-
-            String id = null;
-            if (elasticSearchConfig.isKeyIgnore() == false && key != null && keySchema != null) {
-                id = stringifyKey(keySchema, key);
-            }
-
-            String doc = null;
-            if (value != null) {
-                if (valueSchema != null) {
-                    doc = stringifyValue(valueSchema, value);
-                } else {
-                    if (value instanceof byte[]) {
-                        // for BWC with the ES-Sink
-                        doc = new String( (byte[]) value);
-                    } else {
-                        doc = value.toString();
-                    }
-                }
-            }
-
-            if (doc != null && primaryFields != null) {
-                try {
-                    // extract the PK from the JSON document
-                    JsonNode jsonNode = objectMapper.readTree(doc);
-                    id = stringifyKey(jsonNode, primaryFields);
-                } catch (JsonProcessingException e) {
-                    log.error("Failed to read JSON", e);
-                    throw e;
-                }
-            }
-
-            if (log.isDebugEnabled()) {
-                SchemaType schemaType = null;
-                if (record.getSchema() != null && record.getSchema().getSchemaInfo() != null) {
-                    schemaType = record.getSchema().getSchemaInfo().getType();
-                }
-                log.debug("recordType={} schemaType={} id={} doc={}",
-                        record.getClass().getName(),
-                        schemaType,
-                        id,
-                        doc);
-            }
-            return Pair.of(id, doc);
+        Object key = null;
+        GenericObject value = null;
+        Schema<?> keySchema = null;
+        Schema<?> valueSchema = null;
+        if (record.getSchema() != null && record.getSchema() instanceof KeyValueSchema) {
+            KeyValueSchema<GenericObject, GenericObject> keyValueSchema = (KeyValueSchema) record.getSchema();
+            keySchema = keyValueSchema.getKeySchema();
+            valueSchema = keyValueSchema.getValueSchema();
+            KeyValue<GenericObject, GenericObject> keyValue = (KeyValue<GenericObject, GenericObject>) record.getValue().getNativeObject();
+            key = keyValue.getKey();
+            value = keyValue.getValue();
         } else {
-            return Pair.of(null, new String(
-                    record.getMessage()
-                            .orElseThrow(() -> new IllegalArgumentException("Record does not carry message information"))
-                            .getData(), StandardCharsets.UTF_8));
+            key = record.getKey().orElse(null);
+            valueSchema = record.getSchema();
+            value = record.getValue();
         }
+
+        String id = null;
+        if (elasticSearchConfig.isKeyIgnore() == false && key != null && keySchema != null) {
+            id = stringifyKey(keySchema, key);
+        }
+
+        String doc = null;
+        if (value != null) {
+            if (valueSchema != null) {
+                doc = stringifyValue(valueSchema, value);
+            } else {
+                if (value.getNativeObject() instanceof byte[]) {
+                    // for BWC with the ES-Sink
+                    doc = new String((byte[]) value.getNativeObject(), StandardCharsets.UTF_8);
+                } else {
+                    doc = value.getNativeObject().toString();
+                }
+            }
+        }
+
+        if (doc != null && primaryFields != null) {
+            try {
+                // extract the PK from the JSON document
+                JsonNode jsonNode = objectMapper.readTree(doc);
+                id = stringifyKey(jsonNode, primaryFields);
+            } catch (JsonProcessingException e) {
+                log.error("Failed to read JSON", e);
+                throw e;
+            }
+        }
+
+        if (log.isDebugEnabled()) {
+            SchemaType schemaType = null;
+            if (record.getSchema() != null && record.getSchema().getSchemaInfo() != null) {
+                schemaType = record.getSchema().getSchemaInfo().getType();
+            }
+            log.debug("recordType={} schemaType={} id={} doc={}",
+                    record.getClass().getName(),
+                    schemaType,
+                    id,
+                    doc);
+        }
+        return Pair.of(id, doc);
     }
 
     public String stringifyKey(Schema<?> schema, Object val) throws JsonProcessingException {

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchBWCTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchBWCTests.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.elasticsearch;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.functions.api.Record;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.testng.Assert.assertEquals;
+
+public class ElasticSearchBWCTests {
+
+    @Test
+    public void testGenericRecord() throws Exception {
+        String json = "{\"c\":\"1\",\"d\":1,\"e\":{\"a\":\"a\",\"b\":true,\"d\":1.0,\"f\":1.0,\"i\":1,\"l\":10}}";
+
+        ElasticSearchSink elasticSearchSink = new ElasticSearchSink();
+        elasticSearchSink.open(ImmutableMap.of("elasticSearchUrl", "http://localhost:9200"), null);
+        Pair<String, String> pair = elasticSearchSink.extractIdAndDocument(new Record<GenericObject>() {
+            @Override
+            public GenericObject getValue() {
+                return new GenericObject() {
+                    @Override
+                    public SchemaType getSchemaType() {
+                        return SchemaType.BYTES;
+                    }
+
+                    @Override
+                    public Object getNativeObject() {
+                        return json.getBytes(StandardCharsets.UTF_8);
+                    }
+                };
+            }
+        });
+        assertEquals(pair.getLeft(), null);
+        assertEquals(pair.getRight(), json);
+    }
+}

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchExtractTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchExtractTests.java
@@ -119,6 +119,28 @@ public class ElasticSearchExtractTests {
         Pair<String, String> pair3 = elasticSearchSink3.extractIdAndDocument(genericObjectRecord);
         assertNull(pair3.getLeft());
         assertEquals(pair3.getRight(), "{\"c\":\"1\",\"d\":1,\"e\":{\"a\":\"a\",\"b\":true,\"d\":1.0,\"f\":1.0,\"i\":1,\"l\":10}}");
+
+        // default config with null PK + null value
+        ElasticSearchSink elasticSearchSink4 = new ElasticSearchSink();
+        elasticSearchSink4.open(ImmutableMap.of("elasticSearchUrl", "http://localhost:9200"), null);
+        Pair<String, String> pair4 = elasticSearchSink3.extractIdAndDocument(new Record<GenericObject>() {
+            @Override
+            public Optional<String> getTopicName() {
+                return Optional.of("data-ks1.table1");
+            }
+
+            @Override
+            public org.apache.pulsar.client.api.Schema  getSchema() {
+                return valueSchema;
+            }
+
+            @Override
+            public GenericObject getValue() {
+                return null;
+            }
+        });
+        assertNull(pair4.getLeft());
+        assertNull(pair4.getRight());
     }
 
     @Test

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchExtractTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchExtractTests.java
@@ -123,7 +123,9 @@ public class ElasticSearchExtractTests {
 
         // default config with null PK => indexed with auto generated _id
         ElasticSearchSink elasticSearchSink3 = new ElasticSearchSink();
-        elasticSearchSink3.open(ImmutableMap.of("elasticSearchUrl", "http://localhost:9200"), null);
+        elasticSearchSink3.open(ImmutableMap.of(
+                "elasticSearchUrl", "http://localhost:9200",
+                "schemaAware", "true"), null);
         Pair<String, String> pair3 = elasticSearchSink3.extractIdAndDocument(genericObjectRecord);
         assertNull(pair3.getLeft());
         assertEquals(pair3.getRight(), "{\"c\":\"1\",\"d\":1,\"e\":{\"a\":\"a\",\"b\":true,\"d\":1.0,\"f\":1.0,\"i\":1,\"l\":10}}");
@@ -223,14 +225,15 @@ public class ElasticSearchExtractTests {
         elasticSearchSink.open(ImmutableMap.of(
                 "elasticSearchUrl", "http://localhost:9200",
                 "schemaAware", "true",
-                "keyIgnore", "false"
-        ), null);
+                "keyIgnore", "false"), null);
         Pair<String, String> pair = elasticSearchSink.extractIdAndDocument(genericObjectRecord);
         assertEquals(pair.getLeft(), "[\"1\",1]");
         assertEquals(pair.getRight(), "{\"c\":\"1\",\"d\":1,\"e\":{\"a\":\"a\",\"b\":true,\"d\":1.0,\"f\":1.0,\"i\":1,\"l\":10}}");
 
         ElasticSearchSink elasticSearchSink2 = new ElasticSearchSink();
-        elasticSearchSink2.open(ImmutableMap.of("elasticSearchUrl", "http://localhost:9200"), null);
+        elasticSearchSink2.open(ImmutableMap.of(
+                "elasticSearchUrl", "http://localhost:9200",
+                "schemaAware", "true"), null);
         Pair<String, String> pair2 = elasticSearchSink2.extractIdAndDocument(genericObjectRecord);
         assertNull(pair2.getLeft());
         assertEquals(pair2.getRight(), "{\"c\":\"1\",\"d\":1,\"e\":{\"a\":\"a\",\"b\":true,\"d\":1.0,\"f\":1.0,\"i\":1,\"l\":10}}");
@@ -240,8 +243,7 @@ public class ElasticSearchExtractTests {
         elasticSearchSink3.open(ImmutableMap.of(
                 "elasticSearchUrl", "http://localhost:9200",
                 "schemaAware", "true",
-                "keyIgnore", "false"
-        ), null);
+                "keyIgnore", "false"), null);
         Pair<String, String> pair3 = elasticSearchSink.extractIdAndDocument(new Record<GenericObject>() {
             @Override
             public Optional<String> getTopicName() {

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchExtractTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchExtractTests.java
@@ -32,6 +32,7 @@ import org.testng.annotations.Test;
 import java.util.Optional;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 public class ElasticSearchExtractTests {
 
@@ -111,6 +112,13 @@ public class ElasticSearchExtractTests {
         Pair<String, String> pair2 = elasticSearchSink2.extractIdAndDocument(genericObjectRecord);
         assertEquals(pair2.getLeft(), "[\"1\",1]");
         assertEquals(pair2.getRight(), "{\"c\":\"1\",\"d\":1,\"e\":{\"a\":\"a\",\"b\":true,\"d\":1.0,\"f\":1.0,\"i\":1,\"l\":10}}");
+
+        // default config with null PK => indexed with auto generated _id
+        ElasticSearchSink elasticSearchSink3 = new ElasticSearchSink();
+        elasticSearchSink3.open(ImmutableMap.of("elasticSearchUrl", "http://localhost:9200"), null);
+        Pair<String, String> pair3 = elasticSearchSink3.extractIdAndDocument(genericObjectRecord);
+        assertNull(pair3.getLeft());
+        assertEquals(pair3.getRight(), "{\"c\":\"1\",\"d\":1,\"e\":{\"a\":\"a\",\"b\":true,\"d\":1.0,\"f\":1.0,\"i\":1,\"l\":10}}");
     }
 
     @Test

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchExtractTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchExtractTests.java
@@ -104,7 +104,6 @@ public class ElasticSearchExtractTests {
         elasticSearchSink.open(ImmutableMap.of(
                 "elasticSearchUrl", "http://localhost:9200",
                 "primaryFields","c",
-                "schemaAware", "true",
                 "keyIgnore", "true"), null);
         Pair<String, String> pair = elasticSearchSink.extractIdAndDocument(genericObjectRecord);
         assertEquals(pair.getLeft(), "1");
@@ -115,7 +114,6 @@ public class ElasticSearchExtractTests {
         elasticSearchSink2.open(ImmutableMap.of(
                 "elasticSearchUrl", "http://localhost:9200",
                 "primaryFields","c,d",
-                "schemaAware", "true",
                 "keyIgnore", "true"), null);
         Pair<String, String> pair2 = elasticSearchSink2.extractIdAndDocument(genericObjectRecord);
         assertEquals(pair2.getLeft(), "[\"1\",1]");
@@ -123,9 +121,7 @@ public class ElasticSearchExtractTests {
 
         // default config with null PK => indexed with auto generated _id
         ElasticSearchSink elasticSearchSink3 = new ElasticSearchSink();
-        elasticSearchSink3.open(ImmutableMap.of(
-                "elasticSearchUrl", "http://localhost:9200",
-                "schemaAware", "true"), null);
+        elasticSearchSink3.open(ImmutableMap.of("elasticSearchUrl", "http://localhost:9200"), null);
         Pair<String, String> pair3 = elasticSearchSink3.extractIdAndDocument(genericObjectRecord);
         assertNull(pair3.getLeft());
         assertEquals(pair3.getRight(), "{\"c\":\"1\",\"d\":1,\"e\":{\"a\":\"a\",\"b\":true,\"d\":1.0,\"f\":1.0,\"i\":1,\"l\":10}}");
@@ -224,16 +220,13 @@ public class ElasticSearchExtractTests {
         ElasticSearchSink elasticSearchSink = new ElasticSearchSink();
         elasticSearchSink.open(ImmutableMap.of(
                 "elasticSearchUrl", "http://localhost:9200",
-                "schemaAware", "true",
                 "keyIgnore", "false"), null);
         Pair<String, String> pair = elasticSearchSink.extractIdAndDocument(genericObjectRecord);
         assertEquals(pair.getLeft(), "[\"1\",1]");
         assertEquals(pair.getRight(), "{\"c\":\"1\",\"d\":1,\"e\":{\"a\":\"a\",\"b\":true,\"d\":1.0,\"f\":1.0,\"i\":1,\"l\":10}}");
 
         ElasticSearchSink elasticSearchSink2 = new ElasticSearchSink();
-        elasticSearchSink2.open(ImmutableMap.of(
-                "elasticSearchUrl", "http://localhost:9200",
-                "schemaAware", "true"), null);
+        elasticSearchSink2.open(ImmutableMap.of("elasticSearchUrl", "http://localhost:9200"), null);
         Pair<String, String> pair2 = elasticSearchSink2.extractIdAndDocument(genericObjectRecord);
         assertNull(pair2.getLeft());
         assertEquals(pair2.getRight(), "{\"c\":\"1\",\"d\":1,\"e\":{\"a\":\"a\",\"b\":true,\"d\":1.0,\"f\":1.0,\"i\":1,\"l\":10}}");
@@ -242,7 +235,6 @@ public class ElasticSearchExtractTests {
         ElasticSearchSink elasticSearchSink3 = new ElasticSearchSink();
         elasticSearchSink3.open(ImmutableMap.of(
                 "elasticSearchUrl", "http://localhost:9200",
-                "schemaAware", "true",
                 "keyIgnore", "false"), null);
         Pair<String, String> pair3 = elasticSearchSink.extractIdAndDocument(new Record<GenericObject>() {
             @Override


### PR DESCRIPTION
If the key is null or "" (the previous behaviour of the ES sink with the provided [extractKeyValue](https://github.com/vroyer/pulsar/blob/branch-2.6/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java#L97)),  the doc is indexed with an auto generated random _id. So the default configuration is now keyIgnore=true, and nullValueAction=IGNORE.

Also add tests for null values.