### PR TITLE
Fix: Postgres WAL does not truncate / confirmed_flush_lsn dows not change.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@ flexible messaging model and an intuitive client API.</description>
     <flink.version>1.6.0</flink.version>
     <scala.binary.version>2.11</scala.binary.version>
     <scala-library.version>2.11.12</scala-library.version>
-    <debezium.version>1.0.3.Final</debezium.version>
+    <debezium.version>1.0.0.Final</debezium.version>
     <jsonwebtoken.version>0.11.1</jsonwebtoken.version>
     <opencensus.version>0.18.0</opencensus.version>
     <hbase.version>2.3.0</hbase.version>


### PR DESCRIPTION
Downgrading debezium to the same version as apache.

### Motivation

pulsar's connector uses debezium 1.0.0
luna 2.7 uses 1.0.3 https://debezium.io/releases/1.0/release-notes
I tested (locally):
luna 2.7.2 (debezium 1.0.3) => no confirmed_flush_lsn updates
apache 2.7 snapshot upgraded to debezium 1.0.3 => no confirmed_flush_lsn updates
apache 2.7 snapshot with debezium 1.0.0 => confirmed_flush_lsn updates

### Modifications

Downgraded debezium

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): yes, downgrades a dependency
