### PR TITLE
Add stripNulls setting to avoid null in Elasticsearch documents

### DIFF
--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
@@ -230,6 +230,13 @@ public class ElasticSearchConfig implements Serializable {
     )
     private MalformedDocAction malformedDocAction = MalformedDocAction.FAIL;
 
+    @FieldDoc(
+            required = false,
+            defaultValue = "true",
+            help = "If stripNulls is false, elasticsearch _source includes 'null' for empty fields (for example {\"foo\": null}), otherwise null fields are stripped."
+    )
+    private boolean stripNulls = true;
+
     public enum MalformedDocAction {
         IGNORE,
         WARN,

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfigTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfigTests.java
@@ -86,6 +86,7 @@ public class ElasticSearchConfigTests {
         assertEquals(config.getConnectionIdleTimeoutInMs(), 5L);
         assertEquals(config.getSocketTimeoutInMs(), 60000);
 
+        assertEquals(config.isStripNulls(), true);
         assertEquals(config.isSchemaEnable(), false);
         assertEquals(config.isKeyIgnore(), true);
         assertEquals(config.getMalformedDocAction(), ElasticSearchConfig.MalformedDocAction.FAIL);

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkTests.java
@@ -224,6 +224,32 @@ public class ElasticSearchSinkTests {
         }
     }
 
+    @Test(enabled = true)
+    public void testStripNullNodes() throws Exception {
+        map.put("stripNulls", true);
+        sink.open(map, mockSinkContext);
+        GenericRecord genericRecord = genericSchema.newRecordBuilder()
+                .set("name", null)
+                .set("userName", "boby")
+                .set("email", null)
+                .build();
+        String json = sink.stringifyValue(valueSchema, genericRecord);
+        assertEquals(json, "{\"userName\":\"boby\"}");
+    }
+
+    @Test(enabled = true)
+    public void testKeepNullNodes() throws Exception {
+        map.put("stripNulls", false);
+        sink.open(map, mockSinkContext);
+        GenericRecord genericRecord = genericSchema.newRecordBuilder()
+                .set("name", null)
+                .set("userName", "boby")
+                .set("email", null)
+                .build();
+        String json = sink.stringifyValue(valueSchema, genericRecord);
+        assertEquals(json, "{\"name\":null,\"userName\":\"boby\",\"email\":null}");
+    }
+
     @Test(enabled = true, expectedExceptions = PulsarClientException.InvalidMessageException.class)
     public void testNullValueFailure() throws Exception {
         String index = "testnullvaluefail";

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/JsonConverterTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/JsonConverterTests.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.io.elasticsearch;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.google.common.collect.ImmutableMap;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
@@ -40,6 +41,7 @@ public class JsonConverterTests {
     @Test
     public void testAvroToJson() throws IOException {
         Schema schema = SchemaBuilder.record("record").fields()
+                .name("n").type().longType().longDefault(10)
                 .name("l").type().longType().longDefault(10)
                 .name("i").type().intType().intDefault(10)
                 .name("b").type().booleanType().booleanDefault(true)
@@ -51,6 +53,7 @@ public class JsonConverterTests {
                 .name("map").type().optional().map().values(SchemaBuilder.builder().intType())
                 .endRecord();
         GenericRecord genericRecord = new GenericData.Record(schema);
+        genericRecord.put("n", null);
         genericRecord.put("l", 1L);
         genericRecord.put("i", 1);
         genericRecord.put("b", true);
@@ -61,6 +64,7 @@ public class JsonConverterTests {
         genericRecord.put("array", new String[] {"toto"});
         genericRecord.put("map", ImmutableMap.of("a",10));
         JsonNode jsonNode = JsonConverter.toJson(genericRecord);
+        assertEquals(jsonNode.get("n"), NullNode.getInstance());
         assertEquals(jsonNode.get("l").asLong(), 1L);
         assertEquals(jsonNode.get("i").asInt(), 1);
         assertEquals(jsonNode.get("b").asBoolean(), true);


### PR DESCRIPTION
### Motivation

Avoid null fields in Elasticsearch when using the ES Sink.

### Modifications

Add a new config settings stripNulls that remove NullNode from the JsonNode tree before converting it into a string.

### Verifying this change

Add 2 units tests to check the behaviour with stripNulls=true and stripNulls=false

### Does this pull request potentially affect one of the following parts:

Enhance the ES-Sink.

### Documentation

Self generated through the fieldDoc annotation.

