### PR TITLE
Fix ES Sink default maxRetries

### DIFF
--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
@@ -112,7 +112,7 @@ public class ElasticSearchConfig implements Serializable {
             defaultValue = "-1",
             help = "The maximum number of retries for elasticsearch requests. Use -1 to disable it."
     )
-    private int maxRetries = 1;
+    private int maxRetries = -1;
 
     @FieldDoc(
             required = false,


### PR DESCRIPTION
### Motivation

Fix the ES Sink default maxRetries to -1 (in order to avoid sink restart)

### Modifications

Set the default maxRetries=-1

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts: No

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x ] `no-need-doc` 
  
  (generated doc)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


