### PR TITLE
ES Sink add non-bulk index/delete with retry

### DIFF
--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClient.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClient.java
@@ -265,6 +265,10 @@ public class ElasticSearchClient implements AutoCloseable {
         }
     }
 
+    public boolean indexDocumentWithRetry(Record<GenericObject> record, Pair<String, String> idAndDoc) {
+        return retry(() -> indexDocument(record, idAndDoc), "index document");
+    }
+
     /**
      * Index an elasticsearch document and ack the record.
      * @param record
@@ -291,7 +295,7 @@ public class ElasticSearchClient implements AutoCloseable {
                 return false;
             }
         } catch (final Exception ex) {
-            log.error("index failed id=" + idAndDoc.getLeft(), ex);
+            log.warn("index failed id=" + idAndDoc.getLeft(), ex);
             record.fail();
             throw ex;
         }
@@ -312,6 +316,10 @@ public class ElasticSearchClient implements AutoCloseable {
             record.fail();
             throw e;
         }
+    }
+
+    public boolean deleteDocumentWithRetry(Record<GenericObject> record, String id) {
+        return retry(() -> deleteDocument(record, id), "delete document");
     }
 
     /**

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
@@ -93,7 +93,7 @@ public class ElasticSearchSink implements Sink<GenericObject> {
                                 if (elasticSearchConfig.isBulkEnabled()) {
                                     elasticsearchClient.bulkDelete(record, idAndDoc.getLeft());
                                 } else {
-                                    elasticsearchClient.deleteDocument(record, idAndDoc.getLeft());
+                                    elasticsearchClient.deleteDocumentWithRetry(record, idAndDoc.getLeft());
                                 }
                             }
                             break;
@@ -107,7 +107,7 @@ public class ElasticSearchSink implements Sink<GenericObject> {
                     if (elasticSearchConfig.isBulkEnabled()) {
                         elasticsearchClient.bulkIndex(record, idAndDoc);
                     } else {
-                        elasticsearchClient.indexDocument(record, idAndDoc);
+                        elasticsearchClient.indexDocumentWithRetry(record, idAndDoc);
                     }
                 }
             } catch (JsonProcessingException jsonProcessingException) {


### PR DESCRIPTION
### Motivation

In the Elasticsearch Sink, add index/delete retry before failing the write operation.

### Modifications

non-bulk index/delete elasticsearch documents with retry according to the retry configuration.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

* Add unit test for index/delete with retry

### Does this pull request potentially affect one of the following parts: No

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Doc generated with the FieldDoc annotation)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


