### PR TITLE
LoadManager: do not try to shed the load on heartbeat namespace

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/OverloadShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/OverloadShedder.java
@@ -105,7 +105,7 @@ public class OverloadShedder implements LoadSheddingStrategy {
                             final String namespaceName = LoadManagerShared.getNamespaceNameFromBundleName(e.getKey());
                             boolean isHeartbeat  = NamespaceService.isHeartBeatNamespace(namespaceName);
                             if (isHeartbeat) {
-                                log.info("Skipping Heartbeat bundle {}", e.getKey());
+                                log.debug("Skipping Heartbeat bundle {}", e.getKey());
                             }
                             return !isHeartbeat;
                         }).map((e) -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
@@ -107,7 +107,7 @@ public class ThresholdShedder implements LoadSheddingStrategy {
                     final String namespaceName = LoadManagerShared.getNamespaceNameFromBundleName(e.getKey());
                     boolean isHeartbeat  = NamespaceService.isHeartBeatNamespace(namespaceName);
                     if (isHeartbeat) {
-                        log.info("Skipping Heartbeat bundle {}", e.getKey());
+                        log.debug("Skipping Heartbeat bundle {}", e.getKey());
                     }
                     return !isHeartbeat;
                 }).filter(e ->

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1341,10 +1341,18 @@ public class NamespaceService implements AutoCloseable {
         return String.format(SLA_NAMESPACE_FMT, config.getClusterName(), host, port);
     }
 
+    public static boolean isHeartBeatNamespace(String namespace) {
+        Matcher m = HEARTBEAT_NAMESPACE_PATTERN.matcher(namespace);
+        if (m.matches()) {
+            return true;
+        }
+        return false;
+    }
+
     public static String checkHeartbeatNamespace(ServiceUnitId ns) {
         Matcher m = HEARTBEAT_NAMESPACE_PATTERN.matcher(ns.getNamespaceObject().toString());
         if (m.matches()) {
-            LOG.debug("SLAMonitoring namespace matched the lookup namespace {}", ns.getNamespaceObject().toString());
+            LOG.debug("Heartbeat namespace matched the lookup namespace {}", ns.getNamespaceObject().toString());
             return String.format("http://%s", m.group(1));
         } else {
             return null;


### PR DESCRIPTION
The heartbeat works by using a special namespace pulsar/CLUSTER/brokerid that is always owned by the broker in the name of the namespace.
Any trial to unload that namespace to "shed the load" is deemed to fail.

Modifications:
- in the OverloadShedder and in the ThresholdShedder we are skipping that namespace, in order to cause problems

Notes:
We are doing the filtering in OverloadShedder and in ThresholdShedder and not in ModularLoadManagerImpl because in ModularLoadManagerImpl it would be too late, as the strategies maybe take into consideration the amount of resources that would be freed by unloading the bundle: we must not take those bundles into consideration.

This patch does not change how we calculate resource usage, it is simply saving the LoadManager to do something that is wrong.

To reproduce the problem:
reproducing the problem is not easy, because you have to set up a Pulsar cluster with at least 2 brokers and make it that 1 broker is overhelmed and the balancer decides to unload the heartbeat bundle.
The heartbeat bundle is created only by using "`pulsar-admin brokers heartbeat`" command