### PR TITLE
LS-481: Elastic Search Sink - Sink infinitely tries to reconnect to ES when ES client is in a fail state and does not restart

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
@@ -1038,7 +1038,7 @@ public class PulsarFunctionLocalRunTest {
     }
 
     @Test
-    public void test() throws Throwable{
+    public void testPulsarSinkStatsByteBufferType() throws Throwable{
         runWithNarClassLoader(() -> testPulsarSinkLocalRun(null, 1, StatsNullSink.class.getName()));
     }
 

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/functions/ConsumerConfig.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/functions/ConsumerConfig.java
@@ -45,6 +45,7 @@ public class ConsumerConfig {
     private Map<String, String> consumerProperties = new HashMap<>();
     private Integer receiverQueueSize;
     private CryptoConfig cryptoConfig;
+    private boolean poolMessages;
 
     public ConsumerConfig(String schemaType) {
         this.schemaType = schemaType;

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstance.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstance.java
@@ -80,7 +80,7 @@ public class JavaInstance implements AutoCloseable {
     }
 
     public JavaExecutionResult handleMessage(Record<?> record, Object input,
-                                             BiConsumer<Record, JavaExecutionResult> asyncResultConsumer,
+                                             JavaInstanceRunnable.AsyncResultConsumer asyncResultConsumer,
                                              Consumer<Throwable> asyncFailureHandler) {
         if (context != null) {
             context.setCurrentMessageContext(record);
@@ -131,8 +131,7 @@ public class JavaInstance implements AutoCloseable {
         }
     }
 
-    private void processAsyncResults(BiConsumer<Record, JavaExecutionResult> resultConsumer)
-        throws InterruptedException {
+    private void processAsyncResults(JavaInstanceRunnable.AsyncResultConsumer resultConsumer) throws Exception {
         AsyncFuncRequest asyncResult = pendingAsyncRequests.peek();
         while (asyncResult != null && asyncResult.getProcessResult().isDone()) {
             pendingAsyncRequests.remove(asyncResult);

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -638,6 +638,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
                 if (conf.hasCryptoSpec()) {
                     consumerConfig.setCryptoConfig(CryptoUtils.convertFromSpec(conf.getCryptoSpec()));
                 }
+                consumerConfig.setPoolMessages(conf.getPoolMessages());
 
                 topicSchema.put(topic, consumerConfig);
             });

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSourceConsumerConfig.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSourceConsumerConfig.java
@@ -36,4 +36,5 @@ class PulsarSourceConsumerConfig<T> {
     private Map<String, String> consumerProperties;
     private CryptoKeyReader cryptoKeyReader;
     private ConsumerCryptoFailureAction consumerCryptoFailureAction;
+    private boolean poolMessages;
 }

--- a/pulsar-functions/proto/src/main/proto/Function.proto
+++ b/pulsar-functions/proto/src/main/proto/Function.proto
@@ -101,6 +101,7 @@ message ConsumerSpec {
     map<string, string> schemaProperties = 5;
     map<string, string> consumerProperties = 6;
     CryptoSpec cryptoSpec = 7;
+    bool poolMessages = 8;
 }
 
 message ProducerSpec {

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeSpawner.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeSpawner.java
@@ -23,7 +23,6 @@
  */
 package org.apache.pulsar.functions.runtime;
 
-import static org.apache.pulsar.common.util.Runnables.catchingAndLoggingThrowables;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
@@ -82,25 +81,23 @@ public class RuntimeSpawner implements AutoCloseable {
 
         // monitor function runtime to make sure it is running.  If not, restart the function runtime
         if (!runtimeFactory.externallyManaged() && instanceLivenessCheckFreqMs > 0) {
-            processLivenessCheckTimer = InstanceCache.getInstanceCache().getScheduledExecutorService()
-                    .scheduleAtFixedRate(catchingAndLoggingThrowables(() -> {
-                        Runtime runtime = RuntimeSpawner.this.runtime;
-                        if (runtime != null && !runtime.isAlive()) {
-                            log.error("{}/{}/{} Function Container is dead with following exception. Restarting.",
-                                    details.getTenant(),
-                                    details.getNamespace(), details.getName(), runtime.getDeathException());
-                            // Just for the sake of sanity, just destroy the runtime
-                            try {
-                                runtime.stop();
-                                runtimeDeathException = runtime.getDeathException();
-                                runtime.start();
-                            } catch (Exception e) {
-                                log.error("{}/{}/{}-{} Function Restart failed", details.getTenant(),
-                                        details.getNamespace(), details.getName(), e, e);
-                            }
-                            numRestarts++;
-                        }
-                    }), instanceLivenessCheckFreqMs, instanceLivenessCheckFreqMs, TimeUnit.MILLISECONDS);
+            processLivenessCheckTimer = InstanceCache.getInstanceCache().getScheduledExecutorService().scheduleAtFixedRate(() -> {
+                Runtime runtime = RuntimeSpawner.this.runtime;
+                if (runtime != null && !runtime.isAlive()) {
+                    log.error("{}/{}/{} Function Container is dead with following exception. Restarting.", details.getTenant(),
+                            details.getNamespace(), details.getName(), runtime.getDeathException());
+                    // Just for the sake of sanity, just destroy the runtime
+                    try {
+                        runtime.stop();
+                        runtimeDeathException = runtime.getDeathException();
+                        runtime.start();
+                    } catch (Exception e) {
+                        log.error("{}/{}/{}-{} Function Restart failed", details.getTenant(),
+                                details.getNamespace(), details.getName(), e, e);
+                    }
+                    numRestarts++;
+                }
+            }, instanceLivenessCheckFreqMs, instanceLivenessCheckFreqMs, TimeUnit.MILLISECONDS);
         }
     }
 

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -152,6 +152,7 @@ public class FunctionConfigUtils {
                     bldr.setCryptoSpec(CryptoUtils.convert(consumerConf.getCryptoConfig()));
                 }
                 bldr.putAllConsumerProperties(consumerConf.getConsumerProperties());
+                bldr.setPoolMessages(consumerConf.isPoolMessages());
                 sourceSpecBuilder.putInputSpecs(topicName, bldr.build());
             });
         }
@@ -375,6 +376,7 @@ public class FunctionConfigUtils {
             }
             consumerConfig.setRegexPattern(input.getValue().getIsRegexPattern());
             consumerConfig.setSchemaProperties(input.getValue().getSchemaPropertiesMap());
+            consumerConfig.setPoolMessages(input.getValue().getPoolMessages());
             consumerConfigMap.put(input.getKey(), consumerConfig);
         }
         functionConfig.setInputSpecs(consumerConfigMap);

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
@@ -148,6 +148,7 @@ public class SinkConfigUtils {
                     bldr.setCryptoSpec(CryptoUtils.convert(spec.getCryptoConfig()));
                 }
                 bldr.putAllConsumerProperties(spec.getConsumerProperties());
+                bldr.setPoolMessages(spec.isPoolMessages());
                 sourceSpecBuilder.putInputSpecs(topic, bldr.build());
             });
         }
@@ -277,6 +278,7 @@ public class SinkConfigUtils {
             }
             consumerConfig.setRegexPattern(input.getValue().getIsRegexPattern());
             consumerConfig.setConsumerProperties(input.getValue().getConsumerPropertiesMap());
+            consumerConfig.setPoolMessages(input.getValue().getPoolMessages());
             consumerConfigMap.put(input.getKey(), consumerConfig);
             inputs.add(input.getKey());
         }

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
@@ -58,7 +58,10 @@ public class FunctionConfigUtilsTest {
         functionConfig.setParallelism(1);
         functionConfig.setClassName(IdentityFunction.class.getName());
         Map<String, ConsumerConfig> inputSpecs = new HashMap<>();
-        inputSpecs.put("test-input", ConsumerConfig.builder().isRegexPattern(true).serdeClassName("test-serde").build());
+        inputSpecs.put("test-input", ConsumerConfig.builder()
+                .isRegexPattern(true)
+                .serdeClassName("test-serde")
+                .poolMessages(true).build());
         functionConfig.setInputSpecs(inputSpecs);
         functionConfig.setOutput("test-output");
         functionConfig.setOutputSerdeClassName("test-serde");
@@ -572,5 +575,25 @@ public class FunctionConfigUtilsTest {
         FunctionConfig functionConfig = createFunctionConfig();
         FunctionConfig newFunctionConfig = createUpdatedFunctionConfig("outputSchemaType", "avro");
         FunctionConfigUtils.validateUpdate(functionConfig, newFunctionConfig);
+    }
+
+    @Test
+    public void testPoolMessages() {
+        FunctionConfig functionConfig = createFunctionConfig();
+        Function.FunctionDetails functionDetails = FunctionConfigUtils.convert(functionConfig, null);
+        assertFalse(functionDetails.getSource().getInputSpecsMap().get("test-input").getPoolMessages());
+        FunctionConfig convertedConfig = FunctionConfigUtils.convertFromDetails(functionDetails);
+        assertFalse(convertedConfig.getInputSpecs().get("test-input").isPoolMessages());
+
+        Map<String, ConsumerConfig> inputSpecs = new HashMap<>();
+        inputSpecs.put("test-input", ConsumerConfig.builder()
+                .poolMessages(true).build());
+        functionConfig.setInputSpecs(inputSpecs);
+
+        functionDetails = FunctionConfigUtils.convert(functionConfig, null);
+        assertTrue(functionDetails.getSource().getInputSpecsMap().get("test-input").getPoolMessages());
+
+        convertedConfig = FunctionConfigUtils.convertFromDetails(functionDetails);
+        assertTrue(convertedConfig.getInputSpecs().get("test-input").isPoolMessages());
     }
 }

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
@@ -52,6 +52,7 @@ import static org.apache.pulsar.common.functions.FunctionConfig.ProcessingGuaran
 import static org.mockito.ArgumentMatchers.any;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
 
@@ -82,7 +83,11 @@ public class SinkConfigUtilsTest extends PowerMockTestCase {
         sinkConfig.setArchive("builtin://jdbc");
         sinkConfig.setSourceSubscriptionName("test-subscription");
         Map<String, ConsumerConfig> inputSpecs = new HashMap<>();
-        inputSpecs.put("test-input", ConsumerConfig.builder().isRegexPattern(true).receiverQueueSize(532).serdeClassName("test-serde").build());
+        inputSpecs.put("test-input", ConsumerConfig.builder()
+                .isRegexPattern(true)
+                .receiverQueueSize(532)
+                .serdeClassName("test-serde")
+                .poolMessages(true).build());
         sinkConfig.setInputs(Collections.singleton("test-input"));
         sinkConfig.setInputSpecs(inputSpecs);
         sinkConfig.setProcessingGuarantees(FunctionConfig.ProcessingGuarantees.ATLEAST_ONCE);
@@ -376,5 +381,24 @@ public class SinkConfigUtilsTest extends PowerMockTestCase {
             throw new RuntimeException("Something wrong with the test", e);
         }
         return sinkConfig;
+    }
+
+    @Test
+    public void testPoolMessages() throws IOException {
+        SinkConfig sinkConfig = createSinkConfig();
+        Function.FunctionDetails functionDetails = SinkConfigUtils.convert(sinkConfig, new SinkConfigUtils.ExtractedSinkDetails(null, null));
+        assertFalse(functionDetails.getSource().getInputSpecsMap().get("test-input").getPoolMessages());
+        SinkConfig convertedConfig = SinkConfigUtils.convertFromDetails(functionDetails);
+        assertFalse(convertedConfig.getInputSpecs().get("test-input").isPoolMessages());
+
+        Map<String, ConsumerConfig> inputSpecs = new HashMap<>();
+        inputSpecs.put("test-input", ConsumerConfig.builder()
+                .poolMessages(true).build());
+        sinkConfig.setInputSpecs(inputSpecs);
+
+        functionDetails = SinkConfigUtils.convert(sinkConfig, new SinkConfigUtils.ExtractedSinkDetails(null, null));
+        assertTrue(functionDetails.getSource().getInputSpecsMap().get("test-input").getPoolMessages());
+        convertedConfig = SinkConfigUtils.convertFromDetails(functionDetails);
+        assertTrue(convertedConfig.getInputSpecs().get("test-input").isPoolMessages());
     }
 }


### PR DESCRIPTION
JavaInstanceRunnable does not rethrow exception from the sink thus does not give opportunity to the sink to crash and restart.

https://github.com/datastax/pulsar/blob/190e6504ad6460c46cec36eeb80ed94e3dde409a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java#L351-L362

Cherry-picked 3 commits (only cd9356a03063653e0097f4b85d6b3546698cc325 is actually needed to fix this but it is based on two others, hard to merge cleanly)

```
Author: Boyang Jerry Peng
Date:   Tue Oct 5 22:20:55 2021 -0700

    Allow Pulsar Functions localrun to exit on error (#12278)

    Co-authored-by: Jerry Peng
    (cherry picked from commit cd9356a03063653e0097f4b85d6b3546698cc325)

Author: Boyang Jerry Peng 
Date:   Tue Aug 10 09:33:45 2021 -0700

    Allow Pulsar Functions / Sinks to pool messages (#11618)

    * Allow Pulsar Functions to pool messages

    Co-authored-by: Jerry Peng
    (cherry picked from commit 73bddae640e8b7ba7f268147b9f29cd1d43438b7)

```