### PR TITLE
[CBB-19] Remove support for CQL logical types

### DIFF
--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
@@ -251,6 +251,13 @@ public class ElasticSearchConfig implements Serializable {
     )
     private boolean copyKeyFields = false;
 
+    @FieldDoc(
+            required = false,
+            defaultValue = "true",
+            help = "If ignoreUnsupportedFields is true, unsupported AVRO fields are nullified and AVRO logical types are decoded as known AVRO types, otherwise it fails."
+    )
+    private boolean ignoreUnsupportedFields = true;
+
     public enum MalformedDocAction {
         IGNORE,
         WARN,

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
@@ -256,7 +256,7 @@ public class ElasticSearchConfig implements Serializable {
             defaultValue = "true",
             help = "If ignoreUnsupportedFields is true, unsupported AVRO fields are nullified and AVRO logical types are decoded as known AVRO types, otherwise it fails."
     )
-    private boolean ignoreUnsupportedFields = true;
+    private boolean ignoreUnsupportedFields = false;
 
     public enum MalformedDocAction {
         IGNORE,

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
@@ -175,8 +175,8 @@ public class ElasticSearchSink implements Sink<GenericObject> {
                     if (elasticSearchConfig.isCopyKeyFields() &&
                             (keySchema.getSchemaInfo().getType().equals(SchemaType.AVRO) ||
                                     keySchema.getSchemaInfo().getType().equals(SchemaType.JSON))) {
-                        JsonNode keyNode = extractJsonNode(keySchema, key);
-                        JsonNode valueNode = extractJsonNode(valueSchema, value);
+                        JsonNode keyNode = extractJsonNode(elasticSearchConfig, keySchema, key);
+                        JsonNode valueNode = extractJsonNode(elasticSearchConfig, valueSchema, value);
                         doc = stringify(JsonConverter.topLevelMerge(keyNode, valueNode));
                     } else {
                         doc = stringifyValue(valueSchema, value);
@@ -236,7 +236,7 @@ public class ElasticSearchSink implements Sink<GenericObject> {
                 return (String) val;
             case JSON:
             case AVRO:
-                return stringifyKey(extractJsonNode(schema, val));
+                return stringifyKey(extractJsonNode(elasticSearchConfig, schema, val));
             default:
                 throw new UnsupportedOperationException("Unsupported key schemaType=" + schema.getSchemaInfo().getType());
         }
@@ -264,7 +264,7 @@ public class ElasticSearchSink implements Sink<GenericObject> {
     }
 
     public String stringifyValue(Schema<?> schema, Object val) throws JsonProcessingException {
-        JsonNode jsonNode = extractJsonNode(schema, val);
+        JsonNode jsonNode = extractJsonNode(elasticSearchConfig, schema, val);
         return stringify(jsonNode);
     }
 
@@ -286,15 +286,15 @@ public class ElasticSearchSink implements Sink<GenericObject> {
         return node;
     }
 
-    public static JsonNode extractJsonNode(Schema<?> schema, Object val) {
+    public static JsonNode extractJsonNode(ElasticSearchConfig elasticSearchConfig, Schema<?> schema, Object val) {
         if (val == null)
             return null;
         switch (schema.getSchemaInfo().getType()) {
             case JSON:
                 return (JsonNode) ((GenericRecord) val).getNativeObject();
             case AVRO:
-                org.apache.avro.generic.GenericRecord node = (org.apache.avro.generic.GenericRecord) ((GenericRecord) val).getNativeObject();
-                return JsonConverter.toJson(node);
+                org.apache.avro.generic.GenericRecord node = (org.apache.avro.generic.GenericRecord) ((GenericObject) val).getNativeObject();
+                return JsonConverter.toJson(elasticSearchConfig, node);
             default:
                 throw new UnsupportedOperationException("Unsupported value schemaType=" + schema.getSchemaInfo().getType());
         }

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/JsonConverterTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/JsonConverterTests.java
@@ -35,7 +35,9 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertThrows;
 
 public class JsonConverterTests {
 


### PR DESCRIPTION
### Contribution Checklist

Fixes CBB-19

### Motivation

OSS ES Sink should not convert CQL Logical types because such conversion are use-case dependent.

### Modifications

Remove support for CQL logical types and introduce a new config option **ignoreUnsupportedFields** to silently nullify unsupported fields, or process logical types as known AVRO types.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [X] `doc` 
  
  (If this PR contains doc changes, sink config option are self-documented)


