### PR TITLE
Fix/config quotes

### DIFF
--- a/docker/pulsar/scripts/apply-config-from-env-with-prefix.py
+++ b/docker/pulsar/scripts/apply-config-from-env-with-prefix.py
@@ -28,7 +28,7 @@
 import os, sys
 
 if len(sys.argv) < 3:
-    print('Usage: %s' % (sys.argv[0]))
+    print('Usage: %s [prefix] [file1.conf] [file2.conf] ...' % (sys.argv[0]))
     sys.exit(1)
 
 # Always apply env config to env scripts as well
@@ -57,7 +57,7 @@ for conf_filename in conf_files:
 
     # Update values from Env
     for k in sorted(os.environ.keys()):
-        v = os.environ[k].strip()
+        v = os.environ[k].strip().strip('\"')
 
         # Hide the value in logs if is password.
         if "password" in k:
@@ -68,14 +68,13 @@ for conf_filename in conf_files:
         if k.startswith(prefix):
             k = k[len(prefix):]
         if k in keys:
-            print('[%s] Applying config %s = %s' % (conf_filename, k, displayValue))
+            print('[%s] Applying config %s = "%s"' % (conf_filename, k, displayValue))
             idx = keys[k]
-            lines[idx] = '%s=%s\n' % (k, v)
-
+            lines[idx] = '%s="%s"\n' % (k, v)
 
     # Add new keys from Env
     for k in sorted(os.environ.keys()):
-        v = os.environ[k]
+        v = os.environ[k].strip('\"')
         if not k.startswith(prefix):
             continue
 
@@ -87,16 +86,14 @@ for conf_filename in conf_files:
 
         k = k[len(prefix):]
         if k not in keys:
-            print('[%s] Adding config %s = %s' % (conf_filename, k, displayValue))
-            lines.append('%s=%s\n' % (k, v))
+            print('[%s] Adding config %s = "%s"' % (conf_filename, k, displayValue))
+            lines.append('%s="%s"\n' % (k, v))
         else:
-            print('[%s] Updating config %s = %s' % (conf_filename, k, displayValue))
-            lines[keys[k]] = '%s=%s\n' % (k, v)
-
+            print('[%s] Updating config %s = "%s"' % (conf_filename, k, displayValue))
+            lines[keys[k]] = '%s="%s"\n' % (k, v)
 
     # Store back the updated config in the same file
     f = open(conf_filename, 'w')
     for line in lines:
         f.write(line)
     f.close()
-

--- a/docker/pulsar/scripts/apply-config-from-env-with-prefix.py
+++ b/docker/pulsar/scripts/apply-config-from-env-with-prefix.py
@@ -57,7 +57,12 @@ for conf_filename in conf_files:
 
     # Update values from Env
     for k in sorted(os.environ.keys()):
-        v = os.environ[k].strip().strip('\"')
+        v = os.environ[k].strip()
+
+        # Wrap the value in double quotes if it has spaces
+        # and isn't wrapped with quotes already
+        if " " in v and not (v.startswith('"') and v.endswith('"')):
+            v = '"%s"' % v
 
         # Hide the value in logs if is password.
         if "password" in k:
@@ -68,13 +73,19 @@ for conf_filename in conf_files:
         if k.startswith(prefix):
             k = k[len(prefix):]
         if k in keys:
-            print('[%s] Applying config %s = "%s"' % (conf_filename, k, displayValue))
+            print('[%s] Applying config %s = %s' % (conf_filename, k, displayValue))
             idx = keys[k]
-            lines[idx] = '%s="%s"\n' % (k, v)
+            lines[idx] = '%s=%s\n' % (k, v)
 
     # Add new keys from Env
     for k in sorted(os.environ.keys()):
-        v = os.environ[k].strip('\"')
+        v = os.environ[k]
+
+        # Wrap the value in double quotes if it has spaces
+        # and isn't wrapped with quotes already
+        if " " in v and not (v.startswith('"') and v.endswith('"')):
+            v = '"%s"' % v
+
         if not k.startswith(prefix):
             continue
 
@@ -86,11 +97,11 @@ for conf_filename in conf_files:
 
         k = k[len(prefix):]
         if k not in keys:
-            print('[%s] Adding config %s = "%s"' % (conf_filename, k, displayValue))
-            lines.append('%s="%s"\n' % (k, v))
+            print('[%s] Adding config %s = %s' % (conf_filename, k, displayValue))
+            lines.append('%s=%s\n' % (k, v))
         else:
-            print('[%s] Updating config %s = "%s"' % (conf_filename, k, displayValue))
-            lines[keys[k]] = '%s="%s"\n' % (k, v)
+            print('[%s] Updating config %s = %s' % (conf_filename, k, displayValue))
+            lines[keys[k]] = '%s=%s\n' % (k, v)
 
     # Store back the updated config in the same file
     f = open(conf_filename, 'w')

--- a/docker/pulsar/scripts/apply-config-from-env.py
+++ b/docker/pulsar/scripts/apply-config-from-env.py
@@ -59,7 +59,12 @@ for conf_filename in conf_files:
 
     # Update values from Env
     for k in sorted(os.environ.keys()):
-        v = os.environ[k].strip().strip('\"')
+        v = os.environ[k].strip()
+
+        # Wrap the value in double quotes if it has spaces
+        # and isn't wrapped with quotes already
+        if " " in v and not (v.startswith('"') and v.endswith('"')):
+            v = '"%s"' % v
 
         # Hide the value in logs if is password.
         if "password" in k:
@@ -70,9 +75,9 @@ for conf_filename in conf_files:
         if k.startswith(PF_ENV_PREFIX):
             k = k[len(PF_ENV_PREFIX):]
         if k in keys:
-            print('[%s] Applying config %s = "%s"' % (conf_filename, k, displayValue))
+            print('[%s] Applying config %s = %s' % (conf_filename, k, displayValue))
             idx = keys[k]
-            lines[idx] = '%s="%s"\n' % (k, v)
+            lines[idx] = '%s=%s\n' % (k, v)
 
     # Ensure we have a new-line at the end of the file, to avoid issue
     # when appending more lines to the config
@@ -80,7 +85,13 @@ for conf_filename in conf_files:
 
     # Add new keys from Env    
     for k in sorted(os.environ.keys()):
-        v = os.environ[k].strip('\"')
+        v = os.environ[k]
+
+        # Wrap the value in double quotes if it has spaces
+        # and isn't wrapped with quotes already
+        if " " in v and not (v.startswith('"') and v.endswith('"')):
+            v = '"%s"' % v
+
         if not k.startswith(PF_ENV_PREFIX):
             continue
 
@@ -92,11 +103,11 @@ for conf_filename in conf_files:
 
         k = k[len(PF_ENV_PREFIX):]
         if k not in keys:
-            print('[%s] Adding config %s = "%s"' % (conf_filename, k, displayValue))
-            lines.append('%s="%s"\n' % (k, v))
+            print('[%s] Adding config %s = %s' % (conf_filename, k, displayValue))
+            lines.append('%s=%s\n' % (k, v))
         else:
-            print('[%s] Updating config %s = "%s"' % (conf_filename, k, displayValue))
-            lines[keys[k]] = '%s="%s"\n' % (k, v)
+            print('[%s] Updating config %s = %s' % (conf_filename, k, displayValue))
+            lines[keys[k]] = '%s=%s\n' % (k, v)
 
 
     # Store back the updated config in the same file

--- a/docker/pulsar/scripts/apply-config-from-env.py
+++ b/docker/pulsar/scripts/apply-config-from-env.py
@@ -28,7 +28,7 @@
 import os, sys
 
 if len(sys.argv) < 2:
-    print('Usage: %s' % (sys.argv[0]))
+    print('Usage: %s [file1.conf] [file2.conf] ...' % (sys.argv[0]))
     sys.exit(1)
 
 # Always apply env config to env scripts as well
@@ -59,7 +59,7 @@ for conf_filename in conf_files:
 
     # Update values from Env
     for k in sorted(os.environ.keys()):
-        v = os.environ[k].strip()
+        v = os.environ[k].strip().strip('\"')
 
         # Hide the value in logs if is password.
         if "password" in k:
@@ -70,18 +70,17 @@ for conf_filename in conf_files:
         if k.startswith(PF_ENV_PREFIX):
             k = k[len(PF_ENV_PREFIX):]
         if k in keys:
-            print('[%s] Applying config %s = %s' % (conf_filename, k, displayValue))
+            print('[%s] Applying config %s = "%s"' % (conf_filename, k, displayValue))
             idx = keys[k]
-            lines[idx] = '%s=%s\n' % (k, v)
-
+            lines[idx] = '%s="%s"\n' % (k, v)
 
     # Ensure we have a new-line at the end of the file, to avoid issue
     # when appending more lines to the config
     lines.append('\n')
-    
+
     # Add new keys from Env    
     for k in sorted(os.environ.keys()):
-        v = os.environ[k]
+        v = os.environ[k].strip('\"')
         if not k.startswith(PF_ENV_PREFIX):
             continue
 
@@ -93,11 +92,11 @@ for conf_filename in conf_files:
 
         k = k[len(PF_ENV_PREFIX):]
         if k not in keys:
-            print('[%s] Adding config %s = %s' % (conf_filename, k, displayValue))
-            lines.append('%s=%s\n' % (k, v))
+            print('[%s] Adding config %s = "%s"' % (conf_filename, k, displayValue))
+            lines.append('%s="%s"\n' % (k, v))
         else:
-            print('[%s] Updating config %s = %s' % (conf_filename, k, displayValue))
-            lines[keys[k]] = '%s=%s\n' % (k, v)
+            print('[%s] Updating config %s = "%s"' % (conf_filename, k, displayValue))
+            lines[keys[k]] = '%s="%s"\n' % (k, v)
 
 
     # Store back the updated config in the same file
@@ -105,4 +104,3 @@ for conf_filename in conf_files:
     for line in lines:
         f.write(line)
     f.close()
-


### PR DESCRIPTION
Signed-off-by: Nuriel Shem-Tov <nurielst@hotmail.com>

<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

The python scripts edit the configuration files passed to it based on environment variables. When a bash type variables file gets configured, (e.g. `conf/bkenv.sh`) and the value has spaces in it, the script will end up creating a line looking like this:

```sh
BOOKIE_MEM=-Xms6g -Xmx6g -XX:MaxDirectMemorySize=2g -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ExitOnOutOfMemoryError
```
This of course will not be able to be "sourced" in bash and an error will be produced:
`/pulsar/conf/bkenv.sh: line 36: -Xmx6g: command not found`

When a value in bash contains spaces it **must be wrapped in double-quotes**.

I have previously worked on a [PR](https://github.com/datastax/pulsar-helm-chart/pull/11) which addressed duplicated values in configMaps. Back then I have noticed that in some places values for e.g. `BOOKIE_MEM` were configured with explicit double-quotes and never understood for what purpose. Now that I have discovered these python scripts I understand why the explicit double-quotes were added.

In any case, I believe it is a better approach that the python scripts properly construct the variables rather than having the users explicitly add double-quotes.

Note: This breakage was actually introduced by my PR to pulsar-helm-chart (fixing duplicated keys in configMaps). I was not aware at the time of the python scripts and [this PR](https://github.com/datastax/pulsar-helm-chart/pull/115) made me more confident that the explicitly added double-quotes are not needed anymore.

The current PR should do the following:
- check if a string has spaces
- wrap the string in double-quotes if it has spaces and is not wrapped in double-quotes already

The reason that I decided not to wrap just any string/value is that the script is used for both bash env file and files for services like bookkeeper such as `conf/bookkeeper.conf`. We should only wrap values that have spaces in them (which would naturally be used for bash env scripts).

Relevant previous PRs:

* Removal of duplicated keys in configMaps: https://github.com/datastax/pulsar-helm-chart/pull/110
* Removal of double quotes in example values: https://github.com/datastax/pulsar-helm-chart/pull/115

### Modifications

*Describe the modifications you've done.*

- Have modified two python scripts to conditionally wrap a value in double quotes when required (i.e. not already wrapped and has one or more spaces in the string).
- Appended required values example in usage output

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

Original envs file `conf/bkenv.sh`:
```
#!/bin/sh
#
# Licensed to the Apache Software Foundation (ASF) under one
# or more contributor license agreements.  See the NOTICE file
# distributed with this work for additional information
# regarding copyright ownership.  The ASF licenses this file
# to you under the Apache License, Version 2.0 (the
# "License"); you may not use this file except in compliance
# with the License.  You may obtain a copy of the License at
#
#   http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an
# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
# KIND, either express or implied.  See the License for the
# specific language governing permissions and limitations
# under the License.
#

# Set JAVA_HOME here to override the environment setting
JAVA_HOME=/opt/java/openjdk

# default settings for starting bookkeeper

# Configuration file of settings used in bookie server
BOOKIE_CONF=${BOOKIE_CONF:-"$BK_HOME/conf/bookkeeper.conf"}

# Log4j configuration file
# BOOKIE_LOG_CONF=

# Logs location
# BOOKIE_LOG_DIR=

# Memory size options
BOOKIE_MEM=${BOOKIE_MEM:-${PULSAR_MEM:-"-Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g"}}

# Garbage collection options
BOOKIE_GC=${BOOKIE_GC:-${PULSAR_GC:-"-XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC"}}

# Extra options to be passed to the jvm
BOOKIE_EXTRA_OPTS="${BOOKIE_EXTRA_OPTS:-"-Dio.netty.leakDetectionLevel=disabled ${PULSAR_EXTRA_OPTS:-"-Dio.netty.recycler.maxCapacity.default=1000 -Dio.netty.recycler.linkCapacity=1024"}"} ${BOOKIE_MEM} ${BOOKIE_GC}"

# Add extra paths to the bookkeeper classpath
# BOOKIE_EXTRA_CLASSPATH=

#Folder where the Bookie server PID file should be stored
#BOOKIE_PID_DIR=

#Wait time before forcefully kill the Bookie server instance, if the stop is not successful
#BOOKIE_STOP_TIMEOUT=

#Entry formatter class to format entries.
#ENTRY_FORMATTER_CLASS=
```

Test by setting an ENV variable:
```sh
export BOOKIE_MEM="\"-Xms6g -Xmx6g -XX:MaxDirectMemorySize=2g -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ExitOnOutOfMemoryError\""
```

Run the script, it shows the following output:
```
[./envs.sh] Applying config BOOKIE_MEM = "-Xms6g -Xmx6g -XX:MaxDirectMemorySize=2g -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ExitOnOutOfMemoryError"
```

And the line in the `conf/bkenv.sh` file becomes:
```
# Memory size options
BOOKIE_MEM="-Xms6g -Xmx6g -XX:MaxDirectMemorySize=2g -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ExitOnOutOfMemoryError"
```

Then reset the `conf/bkenv.sh` to the original state and try the following string without extra double-quotes:
```sh
export BOOKIE_MEM="-Xms6g -Xmx6g -XX:MaxDirectMemorySize=2g -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ExitOnOutOfMemoryError"
```

Result output:
```
[./envs.sh] Applying config BOOKIE_MEM = "-Xms6g -Xmx6g -XX:MaxDirectMemorySize=2g -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ExitOnOutOfMemoryError"
```

And the line becomes:
```
# Memory size options
BOOKIE_MEM="-Xms6g -Xmx6g -XX:MaxDirectMemorySize=2g -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ExitOnOutOfMemoryError"
```

Attempt with a string without spaces:
```sh
export BOOKIE_MEM="-Xms6g"
```
Result:
```
# Memory size options
BOOKIE_MEM=-Xms6g
```
And added double quotes to a string without spaces:
```sh
export BOOKIE_MEM="\"-Xms6g\""
```
Result:
```
# Memory size options
BOOKIE_MEM="-Xms6g"
```

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - **Anything that affects deployment: should not, as it attempts to address all possible configuration options. Please comment if there is something I have overlooked.**

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

# Appendix

Should you want to test the `if` evaluation locally consider the following script:

```py
import sys

string = sys.argv[1]

if " " in string and not (string.startswith('"') and string.endswith('"')):
    print("has space and not wrapped in quotes, needs to be wrapped.")
else:
    print("doesnt have space or is already wrapped in quotes, skip wrapping.")
```

Then run tests like:
```sh
$ python my-script.py "\"sdsds sdsd sdsd\""
doesnt have space or is already wrapped in quotes, skip wrapping.
$ python my-script.py "sdsds sdsd sdsd"
has space and not wrapped in quotes, needs to be wrapped.
$ python my-script.py "sdsds"
doesnt have space or is already wrapped in quotes, skip wrapping.
# etc...
```
