### PR TITLE
[kinesis] Remove internal dependency: pulsar-functions-instance

### DIFF
--- a/pulsar-io/kinesis/pom.xml
+++ b/pulsar-io/kinesis/pom.xml
@@ -40,12 +40,6 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>pulsar-functions-instance</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>pulsar-io-aws</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/Utils.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/Utils.java
@@ -66,8 +66,7 @@ public class Utils {
 
     public static ByteBuffer serializeRecordToFlatBuffer(FlatBufferBuilder builder, Record<byte[]> record) {
         checkNotNull(record, "record-context can't be null");
-        final org.apache.pulsar.client.api.Message<byte[]> recordMessage =
-                record
+        final org.apache.pulsar.client.api.Message<byte[]> recordMessage = record
                         .getMessage()
                         .orElseThrow(() -> new IllegalArgumentException("record message must be present"));
         final Optional<EncryptionContext> encryptionCtx = recordMessage.getEncryptionCtx();
@@ -172,8 +171,7 @@ public class Utils {
      */
     public static String serializeRecordToJson(Record<byte[]> record) {
         checkNotNull(record, "record can't be null");
-        final org.apache.pulsar.client.api.Message<byte[]> recordMessage =
-                record
+        final org.apache.pulsar.client.api.Message<byte[]> recordMessage = record
                         .getMessage()
                         .orElseThrow(() -> new IllegalArgumentException("record message must be present"));
 

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/Utils.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/Utils.java
@@ -31,7 +31,6 @@ import java.util.Optional;
 
 import org.apache.pulsar.common.api.EncryptionContext;
 import org.apache.pulsar.functions.api.Record;
-import org.apache.pulsar.functions.source.RecordWithEncryptionContext;
 import org.apache.pulsar.io.kinesis.fbs.EncryptionCtx;
 import org.apache.pulsar.io.kinesis.fbs.EncryptionKey;
 import org.apache.pulsar.io.kinesis.fbs.KeyValue;
@@ -67,10 +66,12 @@ public class Utils {
 
     public static ByteBuffer serializeRecordToFlatBuffer(FlatBufferBuilder builder, Record<byte[]> record) {
         checkNotNull(record, "record-context can't be null");
-        Optional<EncryptionContext> encryptionCtx = (record instanceof RecordWithEncryptionContext)
-                ? ((RecordWithEncryptionContext<byte[]>) record).getEncryptionCtx()
-                : Optional.empty();
-        Map<String, String> properties = record.getProperties();
+        final org.apache.pulsar.client.api.Message<byte[]> recordMessage =
+                record
+                        .getMessage()
+                        .orElseThrow(() -> new IllegalArgumentException("record message must be present"));
+        final Optional<EncryptionContext> encryptionCtx = recordMessage.getEncryptionCtx();
+        final Map<String, String> properties = record.getProperties();
 
         int encryptionCtxOffset = -1;
         int propertiesOffset = -1;
@@ -171,6 +172,10 @@ public class Utils {
      */
     public static String serializeRecordToJson(Record<byte[]> record) {
         checkNotNull(record, "record can't be null");
+        final org.apache.pulsar.client.api.Message<byte[]> recordMessage =
+                record
+                        .getMessage()
+                        .orElseThrow(() -> new IllegalArgumentException("record message must be present"));
 
         JsonObject result = new JsonObject();
         result.addProperty(PAYLOAD_FIELD, getEncoder().encodeToString(record.getValue()));
@@ -181,9 +186,7 @@ public class Utils {
             result.add(PROPERTIES_FIELD, properties);
         }
 
-        Optional<EncryptionContext> optEncryptionCtx = (record instanceof RecordWithEncryptionContext)
-                ? ((RecordWithEncryptionContext<byte[]>) record).getEncryptionCtx()
-                : Optional.empty();
+        final Optional<EncryptionContext> optEncryptionCtx = recordMessage.getEncryptionCtx();
         if (optEncryptionCtx.isPresent()) {
             EncryptionContext encryptionCtx = optEncryptionCtx.get();
             JsonObject encryptionCtxJson = new JsonObject();

--- a/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkTest.java
+++ b/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkTest.java
@@ -22,7 +22,6 @@ import lombok.SneakyThrows;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.core.SinkContext;
 import org.awaitility.Awaitility;
-import org.jetbrains.annotations.NotNull;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -110,7 +109,6 @@ public class KinesisSinkTest {
         }
     }
 
-    @NotNull
     private Map<String, Object> createConfig() {
         final URI endpointOverride = LOCALSTACK_CONTAINER.getEndpointOverride(LocalStackContainer.Service.KINESIS);
         Map<String, Object> map = new HashMap<>();

--- a/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/UtilsTest.java
+++ b/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/UtilsTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.io.kinesis;
 
 import static java.util.Base64.getDecoder;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -38,9 +39,9 @@ import org.apache.pulsar.client.api.CompressionType;
 import org.apache.pulsar.common.api.EncryptionContext;
 import org.apache.pulsar.common.api.EncryptionContext.EncryptionKey;
 import org.apache.pulsar.functions.api.Record;
-import org.apache.pulsar.functions.source.RecordWithEncryptionContext;
 import org.apache.pulsar.io.kinesis.fbs.KeyValue;
 import org.apache.pulsar.io.kinesis.fbs.Message;
+import org.mockito.Mockito;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.collections.Maps;
@@ -203,23 +204,27 @@ public class UtilsTest {
         return new RecordImpl(data, properties, Optional.ofNullable(ctx));
     }
 
-    class RecordImpl implements RecordWithEncryptionContext<byte[]> {
+    class RecordImpl implements Record<byte[]> {
         byte[] data;
         Map<String, String> properties;
         Optional<EncryptionContext> ectx;
+        org.apache.pulsar.client.api.Message message;
 
         public RecordImpl(byte[] data, Map<String, String> properties, Optional<EncryptionContext> ectx) {
             this.data = data;
             this.properties = properties;
             this.ectx = ectx;
+            message = Mockito.mock(org.apache.pulsar.client.api.Message.class);
+            when(message.getEncryptionCtx()).thenReturn(ectx);
         }
 
         public Map<String, String> getProperties() {
             return properties;
         }
 
-        public Optional<EncryptionContext> getEncryptionCtx() {
-            return ectx;
+        @Override
+        public Optional<org.apache.pulsar.client.api.Message<byte[]>> getMessage() {
+            return Optional.of(message);
         }
 
         @Override


### PR DESCRIPTION
### Motivation
`pulsar-functions-instance` package should not be used by connector since is an implementation package

### Modifications

* Replaced usage of `org.apache.pulsar.functions.source.RecordWithEncryptionContext` with `Message.getEncryptionCtx` 
