### PR TITLE
Offloader: add basic metrics:

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerMXBean.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerMXBean.java
@@ -127,4 +127,16 @@ public interface ManagedLedgerMXBean {
     long[] getLedgerAddEntryLatencyBuckets();
 
     StatsBuckets getInternalLedgerAddEntryLatencyBuckets();
+
+    long getOffloadLedgerOffloadOp();
+
+    long getOffloadLedgerOffloadErrors();
+
+    long getOffloadLedgerOpenOp();
+
+    long getOffloadLedgerOpenErrors();
+
+    long getOffloadLedgerDeleteOp();
+
+    long getOffloadLedgerDeleteErrors();
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerMBeanImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerMBeanImpl.java
@@ -50,6 +50,13 @@ public class ManagedLedgerMBeanImpl implements ManagedLedgerMXBean {
     private final LongAdder cursorLedgerCreateOp = new LongAdder();
     private final LongAdder cursorLedgerDeleteOp = new LongAdder();
 
+    private final LongAdder offloadLedgerOffloadOp = new LongAdder();
+    private final LongAdder offloadLedgerOffloadErrors = new LongAdder();
+    private final LongAdder offloadLedgerOpenOp = new LongAdder();
+    private final LongAdder offloadLedgerOpenErrors = new LongAdder();
+    private final LongAdder offloadLedgerDeleteOp = new LongAdder();
+    private final LongAdder offloadLedgerDeleteErrors = new LongAdder();
+
     // addEntryLatencyStatsUsec measure total latency including time entry spent while waiting in queue
     private final StatsBuckets addEntryLatencyStatsUsec = new StatsBuckets(ENTRY_LATENCY_BUCKETS_USEC);
     // ledgerAddEntryLatencyStatsUsec measure latency to persist entry into ledger
@@ -317,6 +324,55 @@ public class ManagedLedgerMBeanImpl implements ManagedLedgerMXBean {
         result.cursorLedgerCreateOp = cursorLedgerCreateOp.longValue();
         result.cursorLedgerDeleteOp = cursorLedgerDeleteOp.longValue();
         return result;
+    }
+
+    @Override
+    public long getOffloadLedgerOffloadOp() {
+        return offloadLedgerOffloadOp.longValue();
+    }
+
+    @Override
+    public long getOffloadLedgerOffloadErrors() {
+        return offloadLedgerOffloadErrors.longValue();
+    }
+
+    @Override
+    public long getOffloadLedgerOpenOp() {
+        return offloadLedgerOpenOp.longValue();
+    }
+
+    @Override
+    public long getOffloadLedgerOpenErrors() {
+        return offloadLedgerOpenErrors.longValue();
+    }
+
+    @Override
+    public long getOffloadLedgerDeleteOp() {
+        return offloadLedgerDeleteOp.longValue();
+    }
+
+    @Override
+    public long getOffloadLedgerDeleteErrors() {
+        return offloadLedgerDeleteErrors.longValue();
+    }
+
+    public void recordOffloadLedgerOffloadOp() {
+        offloadLedgerOffloadOp.increment();
+    }
+    public void recordOffloadLedgerOffloadError() {
+        offloadLedgerOffloadErrors.increment();
+    }
+    public void recordOffloadLedgerOpenOp() {
+        offloadLedgerOpenOp.increment();
+    }
+    public void recordOffloadLedgerOpenError() {
+        offloadLedgerOpenErrors.increment();
+    }
+    public void recordOffloadLedgerDeleteOp() {
+        offloadLedgerDeleteOp.increment();
+    }
+    public void recordOffloadLedgerDeleteError() {
+        offloadLedgerDeleteErrors.increment();
     }
 
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedLedgerMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedLedgerMetrics.java
@@ -23,12 +23,14 @@ import com.google.common.collect.Maps;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedLedgerMXBean;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.common.stats.Metrics;
 
+@Slf4j
 public class ManagedLedgerMetrics extends AbstractMetrics {
 
     private List<Metrics> metricsCollection;
@@ -82,6 +84,9 @@ public class ManagedLedgerMetrics extends AbstractMetrics {
 
             for (ManagedLedgerImpl ledger : ledgers) {
                 ManagedLedgerMXBean lStats = ledger.getStats();
+                log.info("aggregate metrics for ledger {} getOffloadLedgerOffloadOp {}", ledger.getName(),
+                        lStats.getOffloadLedgerOffloadOp());
+
 
                 populateAggregationMapWithSum(tempAggregatedMetricsMap, "brk_ml_AddEntryBytesRate",
                         lStats.getAddEntryBytesRate());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/ManagedLedgerStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/ManagedLedgerStats.java
@@ -28,6 +28,13 @@ public class ManagedLedgerStats {
     long offloadedStorageUsed;
     long storageLogicalSize;
 
+    long offloadLedgerOffloadOp;
+    long offloadLedgerOffloadErrors;
+    long offloadLedgerOpenOp;
+    long offloadLedgerOpenErrors;
+    long offloadLedgerDeleteOp;
+    long offloadLedgerDeleteErrors;
+
     StatsBuckets storageWriteLatencyBuckets = new StatsBuckets(ManagedLedgerMBeanImpl.ENTRY_LATENCY_BUCKETS_USEC);
     StatsBuckets storageLedgerWriteLatencyBuckets = new StatsBuckets(ManagedLedgerMBeanImpl.ENTRY_LATENCY_BUCKETS_USEC);
     StatsBuckets entrySizeBuckets = new StatsBuckets(ManagedLedgerMBeanImpl.ENTRY_SIZE_BUCKETS_BYTES);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
@@ -123,6 +123,13 @@ public class NamespaceStatsAggregator {
             stats.managedLedgerStats.storageLogicalSize = mlStats.getStoredMessagesLogicalSize();
             stats.managedLedgerStats.backlogSize = ml.getEstimatedBacklogSize();
             stats.managedLedgerStats.offloadedStorageUsed = ml.getOffloadedSize();
+            stats.managedLedgerStats.offloadLedgerOffloadOp = mlStats.getOffloadLedgerOffloadOp();
+            stats.managedLedgerStats.offloadLedgerOffloadErrors = mlStats.getOffloadLedgerOffloadErrors();
+            stats.managedLedgerStats.offloadLedgerOpenOp = mlStats.getOffloadLedgerOpenOp();
+            stats.managedLedgerStats.offloadLedgerOpenErrors = mlStats.getOffloadLedgerOpenErrors();
+            stats.managedLedgerStats.offloadLedgerDeleteOp = mlStats.getOffloadLedgerDeleteOp();
+            stats.managedLedgerStats.offloadLedgerDeleteErrors = mlStats.getOffloadLedgerDeleteErrors();
+
             stats.backlogQuotaLimit = topic.getBacklogQuota().getLimitSize();
             stats.backlogQuotaLimitTime = topic.getBacklogQuota().getLimitTime();
 
@@ -349,6 +356,18 @@ public class NamespaceStatsAggregator {
         metric(stream, cluster, namespace, "pulsar_storage_backlog_size", stats.managedLedgerStats.backlogSize);
         metric(stream, cluster, namespace, "pulsar_storage_offloaded_size",
                 stats.managedLedgerStats.offloadedStorageUsed);
+        metric(stream, cluster, namespace, "pulsar_offloader_offload_ops",
+                stats.managedLedgerStats.offloadLedgerOffloadOp);
+        metric(stream, cluster, namespace, "pulsar_offloader_offload_errors",
+                stats.managedLedgerStats.offloadLedgerOffloadErrors);
+        metric(stream, cluster, namespace, "pulsar_offloader_open_ops",
+                stats.managedLedgerStats.offloadLedgerOpenOp);
+        metric(stream, cluster, namespace, "pulsar_offloader_open_errors",
+                stats.managedLedgerStats.offloadLedgerOpenErrors);
+        metric(stream, cluster, namespace, "pulsar_offloader_delete_ops",
+                stats.managedLedgerStats.offloadLedgerDeleteOp);
+        metric(stream, cluster, namespace, "pulsar_offloader_delete_errors",
+                stats.managedLedgerStats.offloadLedgerDeleteErrors);
 
         metric(stream, cluster, namespace, "pulsar_storage_write_rate", stats.managedLedgerStats.storageWriteRate);
         metric(stream, cluster, namespace, "pulsar_storage_read_rate", stats.managedLedgerStats.storageReadRate);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
@@ -135,6 +135,18 @@ class TopicStats {
                 stats.managedLedgerStats.backlogSize, splitTopicAndPartitionIndexLabel);
         metric(stream, cluster, namespace, topic, "pulsar_storage_offloaded_size", stats.managedLedgerStats
                 .offloadedStorageUsed, splitTopicAndPartitionIndexLabel);
+        metric(stream, cluster, namespace, topic, "pulsar_offloader_offload_ops",
+                stats.managedLedgerStats.offloadLedgerOffloadOp, splitTopicAndPartitionIndexLabel);
+        metric(stream, cluster, namespace, topic, "pulsar_offloader_offload_errors",
+                stats.managedLedgerStats.offloadLedgerOffloadErrors, splitTopicAndPartitionIndexLabel);
+        metric(stream, cluster, namespace, topic, "pulsar_offloader_open_ops",
+                stats.managedLedgerStats.offloadLedgerOpenOp, splitTopicAndPartitionIndexLabel);
+        metric(stream, cluster, namespace, topic, "pulsar_offloader_open_errors",
+                stats.managedLedgerStats.offloadLedgerOpenErrors, splitTopicAndPartitionIndexLabel);
+        metric(stream, cluster, namespace, topic, "pulsar_offloader_delete_ops",
+                stats.managedLedgerStats.offloadLedgerDeleteOp, splitTopicAndPartitionIndexLabel);
+        metric(stream, cluster, namespace, topic, "pulsar_offloader_delete_errors",
+                stats.managedLedgerStats.offloadLedgerDeleteErrors, splitTopicAndPartitionIndexLabel);
         metric(stream, cluster, namespace, topic, "pulsar_storage_backlog_quota_limit", stats.backlogQuotaLimit,
                 splitTopicAndPartitionIndexLabel);
         metric(stream, cluster, namespace, topic, "pulsar_storage_backlog_quota_limit_time",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
@@ -122,6 +122,12 @@ public class TransactionAggregator {
         managedLedgerStats.storageLogicalSize = mlStats.getStoredMessagesLogicalSize();
         managedLedgerStats.backlogSize = managedLedger.getEstimatedBacklogSize();
         managedLedgerStats.offloadedStorageUsed = managedLedger.getOffloadedSize();
+        managedLedgerStats.offloadLedgerOffloadOp = mlStats.getOffloadLedgerOffloadOp();
+        managedLedgerStats.offloadLedgerOffloadErrors = mlStats.getOffloadLedgerOffloadErrors();
+        managedLedgerStats.offloadLedgerOpenOp = mlStats.getOffloadLedgerOpenOp();
+        managedLedgerStats.offloadLedgerOpenErrors = mlStats.getOffloadLedgerOpenErrors();
+        managedLedgerStats.offloadLedgerDeleteOp = mlStats.getOffloadLedgerDeleteOp();
+        managedLedgerStats.offloadLedgerDeleteErrors = mlStats.getOffloadLedgerDeleteErrors();
 
         managedLedgerStats.storageWriteLatencyBuckets
                 .addAll(mlStats.getInternalAddEntryLatencyBuckets());


### PR DESCRIPTION
- offload operations and errors
- offload open for read and errors
- offload delete operations and errors

Metrics are per-namespace

Sample metrics:
```
# TYPE pulsar_storage_backlog_size gauge
pulsar_storage_backlog_size{cluster="standalone",namespace="public/default",topic="persistent://public/default/test"} 0.0 1648645087627
# TYPE pulsar_storage_offloaded_size gauge
pulsar_storage_offloaded_size{cluster="standalone",namespace="public/default",topic="persistent://public/default/test"} 0.0 1648645087627
# TYPE pulsar_offloader_offload_ops gauge
pulsar_offloader_offload_ops{cluster="standalone",namespace="public/default",topic="persistent://public/default/test"} 1.0 1648645087627
# TYPE pulsar_offloader_offload_errors gauge
pulsar_offloader_offload_errors{cluster="standalone",namespace="public/default",topic="persistent://public/default/test"} 0.0 1648645087627
# TYPE pulsar_offloader_open_ops gauge
pulsar_offloader_open_ops{cluster="standalone",namespace="public/default",topic="persistent://public/default/test"} 0.0 1648645087627
# TYPE pulsar_offloader_open_errors gauge
pulsar_offloader_open_errors{cluster="standalone",namespace="public/default",topic="persistent://public/default/test"} 0.0 1648645087627
# TYPE pulsar_offloader_delete_ops gauge
pulsar_offloader_delete_ops{cluster="standalone",namespace="public/default",topic="persistent://public/default/test"} 0.0 1648645087627
# TYPE pulsar_offloader_delete_errors gauge
pulsar_offloader_delete_errors{cluster="standalone",namespace="public/default",topic="persistent://public/default/test"} 0.0 1648645087627
```
