### PR TITLE
[elasticsearch] Option to disable SSL certificate validation

### DIFF
--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSslConfig.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSslConfig.java
@@ -47,9 +47,16 @@ public class ElasticSearchSslConfig implements Serializable {
     @FieldDoc(
             required = false,
             defaultValue = "true",
-            help = "Whether or not to validate node hostnames when using SSL"
+            help = "Whether or not to validate node hostnames when using SSL. Changing this value is high insecure and you should not use it in production environment."
     )
     private boolean hostnameVerification = true;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "false",
+            help = "Whether or not to disable the node certificate validation. Changing this value is high insecure and you should not use it in production environment."
+    )
+    private boolean disableCertificateValidation;
 
     @FieldDoc(
             required = false,

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/RestClient.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/RestClient.java
@@ -29,6 +29,7 @@ import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.TrustAllStrategy;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager;
@@ -177,6 +178,9 @@ public abstract class RestClient implements Closeable {
             }
             if (!Strings.isNullOrEmpty(sslConfig.getTruststorePath()) && !Strings.isNullOrEmpty(sslConfig.getTruststorePassword())) {
                 sslContextBuilder.loadTrustMaterial(new File(sslConfig.getTruststorePath()), sslConfig.getTruststorePassword().toCharArray());
+            }
+            if (sslConfig.isDisableCertificateValidation()) {
+                sslContextBuilder.loadTrustMaterial(null, TrustAllStrategy.INSTANCE);
             }
             if (!Strings.isNullOrEmpty(sslConfig.getKeystorePath()) && !Strings.isNullOrEmpty(sslConfig.getKeystorePassword())) {
                 sslContextBuilder.loadKeyMaterial(new File(sslConfig.getKeystorePath()),

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClientSslTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClientSslTests.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.io.elasticsearch;
 
+import lombok.SneakyThrows;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.utility.MountableFile;
@@ -147,6 +148,40 @@ public abstract class ElasticSearchClientSslTests extends ElasticSearchTestBase 
                             .setTruststorePassword("changeit")
                             .setKeystorePath(sslResourceDir + "/keystore.jks")
                             .setKeystorePassword("changeit"));
+            ElasticSearchClient client = new ElasticSearchClient(config);
+            testIndexExists(client);
+        }
+    }
+
+    @Test
+    public void testSslDisableCertificateValidation() throws IOException {
+        try (ElasticsearchContainer container = createElasticsearchContainer()
+                .withFileSystemBind(sslResourceDir, configDir + "/ssl")
+                .withPassword("elastic")
+                .withEnv("xpack.license.self_generated.type", "trial")
+                .withEnv("xpack.security.enabled", "true")
+                .withEnv("xpack.security.http.ssl.enabled", "true")
+                .withEnv("xpack.security.http.ssl.client_authentication", "optional")
+                .withEnv("xpack.security.http.ssl.key", configDir + "/ssl/elasticsearch.key")
+                .withEnv("xpack.security.http.ssl.certificate", configDir + "/ssl/elasticsearch.crt")
+                .withEnv("xpack.security.http.ssl.certificate_authorities", configDir + "/ssl/cacert.crt")
+                .withEnv("xpack.security.transport.ssl.enabled", "true")
+                .withEnv("xpack.security.transport.ssl.verification_mode", "certificate")
+                .withEnv("xpack.security.transport.ssl.key", configDir + "/ssl/elasticsearch.key")
+                .withEnv("xpack.security.transport.ssl.certificate", configDir + "/ssl/elasticsearch.crt")
+                .withEnv("xpack.security.transport.ssl.certificate_authorities", configDir + "/ssl/cacert.crt")
+                .waitingFor(Wait.forLogMessage(".*(Security is enabled|Active license).*", 1)
+                        .withStartupTimeout(Duration.ofMinutes(2)))) {
+            container.start();
+
+            ElasticSearchConfig config = new ElasticSearchConfig()
+                    .setElasticSearchUrl("https://" + container.getHttpHostAddress())
+                    .setIndexName(INDEX)
+                    .setUsername("elastic")
+                    .setPassword("elastic")
+                    .setSsl(new ElasticSearchSslConfig()
+                            .setEnabled(true)
+                            .setDisableCertificateValidation(true));
             ElasticSearchClient client = new ElasticSearchClient(config);
             testIndexExists(client);
         }


### PR DESCRIPTION
### Modifications

Added option to skip SSL certificate validation

`ssl: {"enabled":true, "disableCertificateValidation": true}`

default value is `false`


This option would resolve such problems like
`unable to find valid certification path to requested target`
but it opens an security hole in the network communication with the elastic instance 