### PR TITLE
[pulsar-io] KCA: handle whatever KeyValue getNativeObject() returns: org.apache.pulsar.io.core.KeyValue or org.apache.pulsar.common.schema.KeyValue

### DIFF
--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
@@ -53,7 +53,6 @@ import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.schema.GenericObject;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
-import org.apache.pulsar.io.core.KeyValue;
 import org.apache.pulsar.io.core.Sink;
 import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.kafka.connect.schema.KafkaConnectData;
@@ -269,11 +268,25 @@ public class KafkaConnectSink implements Sink<GenericObject> {
                 && sourceRecord.getSchema().getSchemaInfo() != null
                 && sourceRecord.getSchema().getSchemaInfo().getType() == SchemaType.KEY_VALUE) {
             KeyValueSchema kvSchema = (KeyValueSchema) sourceRecord.getSchema();
-            KeyValue kv = (KeyValue) sourceRecord.getValue().getNativeObject();
             keySchema = PulsarSchemaToKafkaSchema.getKafkaConnectSchema(kvSchema.getKeySchema());
             valueSchema = PulsarSchemaToKafkaSchema.getKafkaConnectSchema(kvSchema.getValueSchema());
-            key = kv.getKey();
-            value = kv.getValue();
+
+            Object nativeObject = sourceRecord.getValue().getNativeObject();
+
+            if (nativeObject instanceof org.apache.pulsar.common.schema.KeyValue) {
+                org.apache.pulsar.common.schema.KeyValue kv = (org.apache.pulsar.common.schema.KeyValue) nativeObject;
+                key = kv.getKey();
+                value = kv.getValue();
+            } else if (nativeObject instanceof org.apache.pulsar.io.core.KeyValue) {
+                org.apache.pulsar.io.core.KeyValue kv = (org.apache.pulsar.io.core.KeyValue) nativeObject;
+                key = kv.getKey();
+                value = kv.getValue();
+            } else if (nativeObject != null) {
+                throw new IllegalStateException("Cannot extract KeyValue data from " + nativeObject.getClass());
+            } else {
+                key = null;
+                value = null;
+            }
         } else {
             if (sourceRecord.getMessage().get().hasBase64EncodedKey()) {
                 key = sourceRecord.getMessage().get().getKeyBytes();

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
@@ -43,7 +43,6 @@ import org.apache.pulsar.client.impl.schema.JSONSchema;
 import org.apache.pulsar.client.util.MessageIdUtils;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.source.PulsarRecord;
-import org.apache.pulsar.io.core.KeyValue;
 import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.kafka.connect.schema.KafkaConnectData;
 import org.apache.pulsar.io.kafka.connect.schema.PulsarSchemaToKafkaSchema;
@@ -60,6 +59,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.AbstractMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -341,7 +341,7 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
 
     private GenericRecord getGenericRecord(Object value, Schema schema) {
         final GenericRecord rec;
-        if(value instanceof GenericRecord) {
+        if (value instanceof GenericRecord) {
             rec = (GenericRecord) value;
         } else {
             rec = MockGenericObjectWrapper.builder()
@@ -504,13 +504,89 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
     }
 
     @Test
-    public void KeyValueSchemaTest() throws Exception {
-        KeyValue<Integer, String> kv = new KeyValue<>(11, "value");
+    public void coreKeyValueSchemaTest() throws Exception {
+        org.apache.pulsar.io.core.KeyValue<Integer, String> kv =
+                new org.apache.pulsar.io.core.KeyValue<>(11, "value");
         SinkRecord sinkRecord = recordSchemaTest(kv, Schema.KeyValue(Schema.INT32, Schema.STRING), 11, "INT32", "value", "STRING");
         String val = (String) sinkRecord.value();
         Assert.assertEquals(val, "value");
         int key = (int) sinkRecord.key();
         Assert.assertEquals(key, 11);
+    }
+
+    @Test
+    public void schemaKeyValueSchemaTest() throws Exception {
+        org.apache.pulsar.common.schema.KeyValue<Integer, String> kv =
+                new org.apache.pulsar.common.schema.KeyValue<>(11, "value");
+        SinkRecord sinkRecord = recordSchemaTest(kv, Schema.KeyValue(Schema.INT32, Schema.STRING), 11, "INT32", "value", "STRING");
+        String val = (String) sinkRecord.value();
+        Assert.assertEquals(val, "value");
+        int key = (int) sinkRecord.key();
+        Assert.assertEquals(key, 11);
+    }
+
+    @Test
+    public void nullKeyValueSchemaTest() throws Exception {
+        props.put("kafkaConnectorSinkClass", SchemaedFileStreamSinkConnector.class.getCanonicalName());
+
+        KafkaConnectSink sink = new KafkaConnectSink();
+        sink.open(props, context);
+
+        Message msg = mock(MessageImpl.class);
+        // value is null
+        when(msg.getValue()).thenReturn(null);
+        when(msg.getKey()).thenReturn("key");
+        when(msg.hasKey()).thenReturn(true);
+        when(msg.getMessageId()).thenReturn(new MessageIdImpl(1, 0, 0));
+
+        final AtomicInteger status = new AtomicInteger(0);
+        Record<GenericObject> record = PulsarRecord.<String>builder()
+                .topicName("fake-topic")
+                .message(msg)
+                .schema(Schema.KeyValue(Schema.INT32, Schema.STRING))
+                .ackFunction(status::incrementAndGet)
+                .failFunction(status::decrementAndGet)
+                .build();
+
+        sink.write(record);
+        sink.flush();
+
+        // expect fail
+        assertEquals(status.get(), -1);
+
+        sink.close();
+    }
+
+    @Test
+    public void wrongKeyValueSchemaTest() throws Exception {
+        props.put("kafkaConnectorSinkClass", SchemaedFileStreamSinkConnector.class.getCanonicalName());
+
+        KafkaConnectSink sink = new KafkaConnectSink();
+        sink.open(props, context);
+
+        Message msg = mock(MessageImpl.class);
+        // value is of a wrong/unsupported type
+        when(msg.getValue()).thenReturn(new AbstractMap.SimpleEntry<>(11, "value"));
+        when(msg.getKey()).thenReturn("key");
+        when(msg.hasKey()).thenReturn(true);
+        when(msg.getMessageId()).thenReturn(new MessageIdImpl(1, 0, 0));
+
+        final AtomicInteger status = new AtomicInteger(0);
+        Record<GenericObject> record = PulsarRecord.<String>builder()
+                .topicName("fake-topic")
+                .message(msg)
+                .schema(Schema.KeyValue(Schema.INT32, Schema.STRING))
+                .ackFunction(status::incrementAndGet)
+                .failFunction(status::decrementAndGet)
+                .build();
+
+        sink.write(record);
+        sink.flush();
+
+        // expect fail
+        assertEquals(status.get(), -1);
+
+        sink.close();
     }
 
     @Test


### PR DESCRIPTION
Same as https://github.com/apache/pulsar/pull/15025

### Motivation

KCA is confused between two KeyValue classes that we have: `org.apache.pulsar.common.schema.KeyValue` and `org.apache.pulsar.io.core.KeyValue`

`getNativeObject()` returns `common.schema.KeyValue` while the KCA expects `io.core.KeyValue`.
As result, sink fails with `ClassCastException: class org.apache.pulsar.common.schema.KeyValue cannot be cast to class org.apache.pulsar.io.core.KeyValue`

Long term it makes sense to get rid of the `io.core.KeyValue` (in the pulsar-io only) and replace its uses with newer `common.schema.KeyValue` (TBD)

### Modifications

For now I added support for both KeyValue types so the change can be cherry-picked into the older branches easily.

### Verifying this change

Added unit tests

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)
