### PR TITLE
[kca] Fix kca cherry-pick issue

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -505,6 +505,11 @@ class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable 
         return clientBuilder;
     }
 
+    @Override
+    public PulsarClient getPulsarClient() {
+        return client;
+    }
+
     private <O> Producer<O> getProducer(String topicName, Schema<O> schema) throws PulsarClientException {
         Producer<O> producer;
         if (tlPublishProducers != null) {


### PR DESCRIPTION
```
11:55:47.308 [public/default/test-source-debezium-oracle-PROCESS-jvpxwgtp-0] ERROR org.apache.pulsar.functions.instance.JavaInstanceRunnable - [public/default/test-source-debezium-oracle-PROCESS-jvpxwgtp:0] Uncaught exception in Java Instance
java.lang.UnsupportedOperationException: not implemented
	at org.apache.pulsar.functions.api.BaseContext.getPulsarClient(BaseContext.java:206) ~[java-instance.jar:?]
	at org.apache.pulsar.io.kafka.connect.AbstractKafkaConnectSource.open(AbstractKafkaConnectSource.java:113) ~[?:?]
	at org.apache.pulsar.io.kafka.connect.KafkaConnectSource.open(KafkaConnectSource.java:62) ~[?:?]
	at org.apache.pulsar.io.debezium.DebeziumSource.open(DebeziumSource.java:101) ~[?:?]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.setupInput(JavaInstanceRunnable.java:745) ~[com.datastax.oss-pulsar-functions-instance-2.8.3.1.0.6-SNAPSHOT.jar:2.8.3.1.0.6-SNAPSHOT]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.setup(JavaInstanceRunnable.java:228) ~[com.datastax.oss-pulsar-functions-instance-2.8.3.1.0.6-SNAPSHOT.jar:2.8.3.1.0.6-SNAPSHOT]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.run(JavaInstanceRunnable.java:256) [com.datastax.oss-pulsar-functions-instance-2.8.3.1.0.6-SNAPSHOT.jar:2.8.3.1.0.6-SNAPSHOT]
	at java.lang.Thread.run(Thread.java:829) [?:?]
```

I found out a cherry-pick mistake of https://github.com/apache/pulsar/pull/11056
https://github.com/datastax/pulsar/commit/1938b7cd084ed14af02033afca5a7219cc516c2a


