### PR TITLE
KCA Sink to handle KeyValue<GenericRecord, GenericRecord>

### DIFF
--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
@@ -58,18 +58,6 @@ import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.kafka.connect.schema.KafkaConnectData;
 import org.apache.pulsar.io.kafka.connect.schema.PulsarSchemaToKafkaSchema;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Properties;
-import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
-
 import static org.apache.pulsar.io.kafka.connect.PulsarKafkaWorkerConfig.OFFSET_STORAGE_TOPIC_CONFIG;
 
 @Slf4j
@@ -275,12 +263,12 @@ public class KafkaConnectSink implements Sink<GenericObject> {
 
             if (nativeObject instanceof org.apache.pulsar.common.schema.KeyValue) {
                 org.apache.pulsar.common.schema.KeyValue kv = (org.apache.pulsar.common.schema.KeyValue) nativeObject;
-                key = kv.getKey();
-                value = kv.getValue();
+                key = KafkaConnectData.getKafkaConnectData(kv.getKey(), keySchema);
+                value = KafkaConnectData.getKafkaConnectData(kv.getValue(), valueSchema);
             } else if (nativeObject instanceof org.apache.pulsar.io.core.KeyValue) {
                 org.apache.pulsar.io.core.KeyValue kv = (org.apache.pulsar.io.core.KeyValue) nativeObject;
-                key = kv.getKey();
-                value = kv.getValue();
+                key = KafkaConnectData.getKafkaConnectData(kv.getKey(), keySchema);
+                value = KafkaConnectData.getKafkaConnectData(kv.getValue(), valueSchema);
             } else if (nativeObject != null) {
                 throw new IllegalStateException("Cannot extract KeyValue data from " + nativeObject.getClass());
             } else {

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
@@ -33,6 +33,7 @@ import org.apache.pulsar.client.api.ProducerConsumerBase;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.api.schema.Field;
 import org.apache.pulsar.client.api.schema.GenericObject;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
@@ -40,12 +41,11 @@ import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.client.impl.schema.AvroSchema;
 import org.apache.pulsar.client.impl.schema.JSONSchema;
+import org.apache.pulsar.client.impl.schema.generic.GenericAvroRecord;
 import org.apache.pulsar.client.util.MessageIdUtils;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.source.PulsarRecord;
 import org.apache.pulsar.io.core.SinkContext;
-import org.apache.pulsar.io.kafka.connect.schema.KafkaConnectData;
-import org.apache.pulsar.io.kafka.connect.schema.PulsarSchemaToKafkaSchema;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -66,6 +66,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -330,10 +331,10 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
         ObjectMapper om = new ObjectMapper();
         Map<String, Object> result = om.readValue(lines.get(0), new TypeReference<Map<String, Object>>(){});
 
-        assertEquals(result.get("key"), expectedKey);
-        assertEquals(result.get("value"), expected);
-        assertEquals(result.get("keySchema"), expectedKeySchema);
-        assertEquals(result.get("valueSchema"), expectedSchema);
+        assertEquals(expectedKey, result.get("key"));
+        assertEquals(expected, result.get("value"));
+        assertEquals(expectedKeySchema, result.get("keySchema"));
+        assertEquals(expectedSchema, result.get("valueSchema"));
 
         SinkRecord sinkRecord = sink.toSinkRecord(record);
         return sinkRecord;
@@ -343,6 +344,16 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
         final GenericRecord rec;
         if (value instanceof GenericRecord) {
             rec = (GenericRecord) value;
+        } else if (value instanceof org.apache.avro.generic.GenericRecord) {
+            org.apache.avro.generic.GenericRecord avroRecord =
+                    (org.apache.avro.generic.GenericRecord) value;
+            org.apache.avro.Schema avroSchema = (org.apache.avro.Schema) schema.getNativeSchema().get();
+            List<Field> fields = avroSchema.getFields()
+                    .stream()
+                    .map(f -> new Field(f.name(), f.pos()))
+                    .collect(Collectors.toList());
+
+            return new GenericAvroRecord(new byte[]{ 1 }, avroSchema, fields, avroRecord);
         } else {
             rec = MockGenericObjectWrapper.builder()
                     .nativeObject(value)
@@ -523,6 +534,52 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
         Assert.assertEquals(val, "value");
         int key = (int) sinkRecord.key();
         Assert.assertEquals(key, 11);
+    }
+
+    @Test
+    public void schemaKeyValueAvroSchemaTest() throws Exception {
+        AvroSchema<PulsarSchemaToKafkaSchemaTest.StructWithAnnotations> pulsarAvroSchema
+                = AvroSchema.of(PulsarSchemaToKafkaSchemaTest.StructWithAnnotations.class);
+
+        final GenericData.Record key = new GenericData.Record(pulsarAvroSchema.getAvroSchema());
+        key.put("field1", 11);
+        key.put("field2", "key");
+        key.put("field3", 101L);
+
+        final GenericData.Record value = new GenericData.Record(pulsarAvroSchema.getAvroSchema());
+        value.put("field1", 10);
+        value.put("field2", "value");
+        value.put("field3", 100L);
+
+        Map<String, Object> expectedKey = new LinkedHashMap<>();
+        expectedKey.put("field1", 11);
+        expectedKey.put("field2", "key");
+        // integer is coming back from ObjectMapper
+        expectedKey.put("field3", 101);
+
+        Map<String, Object> expectedValue = new LinkedHashMap<>();
+        expectedValue.put("field1", 10);
+        expectedValue.put("field2", "value");
+        // integer is coming back from ObjectMapper
+        expectedValue.put("field3", 100);
+
+        org.apache.pulsar.common.schema.KeyValue<GenericRecord, GenericRecord> kv =
+                new org.apache.pulsar.common.schema.KeyValue<>(
+                            getGenericRecord(key, pulsarAvroSchema),
+                            getGenericRecord(value, pulsarAvroSchema));
+
+        SinkRecord sinkRecord = recordSchemaTest(kv, Schema.KeyValue(pulsarAvroSchema, pulsarAvroSchema),
+                expectedKey, "STRUCT", expectedValue, "STRUCT");
+
+        Struct outValue = (Struct) sinkRecord.value();
+        Assert.assertEquals((int)outValue.get("field1"), 10);
+        Assert.assertEquals((String)outValue.get("field2"), "value");
+        Assert.assertEquals((long)outValue.get("field3"), 100L);
+
+        Struct outKey = (Struct) sinkRecord.key();
+        Assert.assertEquals((int)outKey.get("field1"), 11);
+        Assert.assertEquals((String)outKey.get("field2"), "key");
+        Assert.assertEquals((long)outKey.get("field3"), 101L);
     }
 
     @Test

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/SchemaedFileStreamSinkTask.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/SchemaedFileStreamSinkTask.java
@@ -20,7 +20,9 @@
 package org.apache.pulsar.io.kafka.connect;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.collect.Lists;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
@@ -37,6 +39,7 @@ import java.util.Map;
  * A FileStreamSinkTask for testing that writes data other than just a value, i.e.:
  * key, value, key and value schemas.
  */
+@Slf4j
 public class SchemaedFileStreamSinkTask extends FileStreamSinkTask {
 
     @Override
@@ -49,32 +52,28 @@ public class SchemaedFileStreamSinkTask extends FileStreamSinkTask {
                     ? new String((byte[]) record.value(), StandardCharsets.US_ASCII)
                     : record.value();
 
+            Object key = record.keySchema() == Schema.BYTES_SCHEMA
+                    ? new String((byte[]) record.key(), StandardCharsets.US_ASCII)
+                    : record.key();
+
             Map<String, Object> recOut = Maps.newHashMap();
             recOut.put("keySchema", record.keySchema().type().toString());
             recOut.put("valueSchema", record.valueSchema().type().toString());
-            recOut.put("key", record.key());
-            if (val instanceof Struct) {
-                Map<String, Object> map = Maps.newHashMap();
-                Struct struct = (Struct)val;
-
-                // no recursion needed for tests
-                for (Field f: struct.schema().fields()) {
-                    map.put(f.name(), struct.get(f));
-                }
-
-                recOut.put("value", map);
-            } else {
-                recOut.put("value", val);
-            }
+            recOut.put("key", toWritableValue(key));
+            recOut.put("value", toWritableValue(val));
 
             ObjectMapper om = new ObjectMapper();
             try {
+                String valueAsString = om.writeValueAsString(recOut);
+
+                log.info("FileSink writing {}", valueAsString);
+
                 SinkRecord toSink = new SinkRecord(record.topic(),
                         record.kafkaPartition(),
-                        record.keySchema(),
-                        record.key(),
                         Schema.STRING_SCHEMA,
-                        om.writeValueAsString(recOut),
+                        "", // blank key, real one is serialized with recOut
+                        Schema.STRING_SCHEMA,
+                        valueAsString,
                         record.kafkaOffset(),
                         record.timestamp(),
                         record.timestampType());
@@ -85,6 +84,21 @@ public class SchemaedFileStreamSinkTask extends FileStreamSinkTask {
         }
 
         super.put(out);
+    }
+
+    private Object toWritableValue(Object val) {
+        if (val instanceof Struct) {
+            Map<String, Object> map = Maps.newHashMap();
+            Struct struct = (Struct) val;
+
+            // no recursion needed for tests
+            for (Field f: struct.schema().fields()) {
+                map.put(f.name(), struct.get(f));
+            }
+            return map;
+        } else {
+            return val;
+        }
     }
 
 }


### PR DESCRIPTION

### Motivation

Support `KeyValue<GenericRecord, GenericRecord>` records in KCA sink.
Snowflake connector failed:

```
[SF_KAFKA_CONNECTOR] Detail: Error parsing SinkRecord of native converter or SinkRecord header
[SF_KAFKA_CONNECTOR] Message: Invalid type for STRUCT: class org.apache.pulsar.client.impl.schema.generic.GenericAvroRecord
	at com.snowflake.kafka.connector.internal.SnowflakeErrors.getException(SnowflakeErrors.java:291) ~[snowflake-kafka-connector-shaded-0.1.8.jar:?]
	at com.snowflake.kafka.connector.internal.SnowflakeErrors.getException(SnowflakeErrors.java:259) ~[snowflake-kafka-connector-shaded-0.1.8.jar:?]
	at com.snowflake.kafka.connector.records.RecordService.convertToJson(RecordService.java:345) ~[snowflake-kafka-connector-shaded-0.1.8.jar:?]
	at com.snowflake.kafka.connector.records.SnowflakeRecordContent.<init>(SnowflakeRecordContent.java:47) ~[snowflake-kafka-connector-shaded-0.1.8.jar:?]
	at com.snowflake.kafka.connector.internal.SnowflakeSinkServiceV1$ServiceContext.handleNativeRecord(SnowflakeSinkServiceV1.java:765) ~[snowflake-kafka-connector-shaded-0.1.8.jar:?]
	at com.snowflake.kafka.connector.internal.SnowflakeSinkServiceV1$ServiceContext.insert(SnowflakeSinkServiceV1.java:708) ~[snowflake-kafka-connector-shaded-0.1.8.jar:?]
	at com.snowflake.kafka.connector.internal.SnowflakeSinkServiceV1$ServiceContext.access$300(SnowflakeSinkServiceV1.java:395) ~[snowflake-kafka-connector-shaded-0.1.8.jar:?]
	at com.snowflake.kafka.connector.internal.SnowflakeSinkServiceV1.insert(SnowflakeSinkServiceV1.java:206) ~[snowflake-kafka-connector-shaded-0.1.8.jar:?]
	at com.snowflake.kafka.connector.internal.SnowflakeSinkServiceV1.insert(SnowflakeSinkServiceV1.java:117) ~[snowflake-kafka-connector-shaded-0.1.8.jar:?]
	at com.snowflake.kafka.connector.SnowflakeSinkTask.put(SnowflakeSinkTask.java:269) ~[snowflake-kafka-connector-shaded-0.1.8.jar:?]
	at org.apache.pulsar.io.kafka.connect.KafkaConnectSink.write(KafkaConnectSink.java:125) [pulsar-io-kafka-connect-adaptor-2.8.0.1.1.33.jar:2.8.0.1.1.33]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.sendOutputMessage(JavaInstanceRunnable.java:363) [com.datastax.oss-pulsar-functions-instance-2.8.0.1.1.34.jar:2.8.0.1.1.34]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.handleResult(JavaInstanceRunnable.java:346) [com.datastax.oss-pulsar-functions-instance-2.8.0.1.1.34.jar:2.8.0.1.1.34]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.run(JavaInstanceRunnable.java:295) [com.datastax.oss-pulsar-functions-instance-2.8.0.1.1.34.jar:2.8.0.1.1.34]
	at java.lang.Thread.run(Thread.java:829) [?:?]
```

### Modifications

Key and value from KeyValue<> need conversion to Kafka's data, if needed.
Pulsar's GenericRecord needs conversion to Kafka's Struct.

Added test.

### Verifying this change

Added unit test

### Does this pull request potentially affect one of the following parts:

No

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


