### PR TITLE
[feat][elasticsearch-sink] Option to output canonical JSON

### DIFF
--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
@@ -286,6 +286,13 @@ public class ElasticSearchConfig implements Serializable {
     )
     private CompatibilityMode compatibilityMode = CompatibilityMode.AUTO;
 
+    @FieldDoc(
+            defaultValue = "false",
+            help = "If canonicalKeyFields is true and record key schema is JSON or AVRO, the serialized object will " +
+                    "not consider the properties order."
+    )
+    private boolean canonicalKeyFields = false;
+
     public enum MalformedDocAction {
         IGNORE,
         WARN,

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
@@ -21,8 +21,14 @@ package org.apache.pulsar.io.elasticsearch;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.client.api.Message;
@@ -42,9 +48,13 @@ import org.apache.pulsar.io.core.annotations.IOType;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
 @Connector(
         name = "elastic_search",
@@ -57,7 +67,8 @@ public class ElasticSearchSink implements Sink<GenericObject> {
 
     private ElasticSearchConfig elasticSearchConfig;
     private ElasticSearchClient elasticsearchClient;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper sortedObjectMapper;
     private List<String> primaryFields = null;
 
     @Override
@@ -67,6 +78,21 @@ public class ElasticSearchSink implements Sink<GenericObject> {
         elasticsearchClient = new ElasticSearchClient(elasticSearchConfig);
         if (!Strings.isNullOrEmpty(elasticSearchConfig.getPrimaryFields())) {
             primaryFields = Arrays.asList(elasticSearchConfig.getPrimaryFields().split(","));
+        }
+        if (elasticSearchConfig.isCanonicalKeyFields()) {
+            sortedObjectMapper = JsonMapper
+                    .builder()
+                            .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
+                    .nodeFactory(new JsonNodeFactory() {
+
+                        @Override
+                        public ObjectNode objectNode() {
+                            return new ObjectNode(this, new TreeMap<String, JsonNode>());
+                        }
+
+                    })
+                            .build();
+
         }
     }
 
@@ -242,13 +268,32 @@ public class ElasticSearchSink implements Sink<GenericObject> {
         }
     }
 
+
     /**
      * Convert a JsonNode to an Elasticsearch id.
      */
+
     public String stringifyKey(JsonNode jsonNode) throws JsonProcessingException {
         List<String> fields = new ArrayList<>();
         jsonNode.fieldNames().forEachRemaining(fields::add);
-        return stringifyKey(jsonNode, fields);
+        JsonNode toConvert;
+        if (fields.size() == 1) {
+            toConvert = jsonNode.get(fields.get(0));
+        } else {
+            toConvert = JsonConverter.toJsonArray(jsonNode, fields);
+        }
+
+        String serializedId;
+        if (elasticSearchConfig.isCanonicalKeyFields()) {
+            final Object obj = sortedObjectMapper.treeToValue(toConvert, Object.class);
+            serializedId = sortedObjectMapper.writeValueAsString(obj);
+        } else {
+            serializedId = objectMapper.writeValueAsString(toConvert);
+        }
+
+        return (serializedId.startsWith("\"") && serializedId.endsWith("\""))
+                ? serializedId.substring(1, serializedId.length() - 1)  // remove double quotes
+                : serializedId;
     }
 
     public String stringifyKey(JsonNode jsonNode, List<String> fields) throws JsonProcessingException {

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
@@ -186,7 +186,7 @@ public class ElasticSearchSink implements Sink<GenericObject> {
             }
 
             String id = null;
-            if (elasticSearchConfig.isKeyIgnore() == false && key != null && keySchema != null) {
+            if (!elasticSearchConfig.isKeyIgnore() && key != null && keySchema != null) {
                 id = stringifyKey(keySchema, key);
             }
 
@@ -271,6 +271,10 @@ public class ElasticSearchSink implements Sink<GenericObject> {
     public String stringifyKey(JsonNode jsonNode) throws JsonProcessingException {
         List<String> fields = new ArrayList<>();
         jsonNode.fieldNames().forEachRemaining(fields::add);
+        return stringifyKey(jsonNode, fields);
+    }
+
+    public String stringifyKey(JsonNode jsonNode, List<String> fields) throws JsonProcessingException {
         JsonNode toConvert;
         if (fields.size() == 1) {
             toConvert = jsonNode.get(fields.get(0));
@@ -289,18 +293,6 @@ public class ElasticSearchSink implements Sink<GenericObject> {
         return (serializedId.startsWith("\"") && serializedId.endsWith("\""))
                 ? serializedId.substring(1, serializedId.length() - 1)  // remove double quotes
                 : serializedId;
-    }
-
-    public String stringifyKey(JsonNode jsonNode, List<String> fields) throws JsonProcessingException {
-        if (fields.size() == 1) {
-            JsonNode singleNode = jsonNode.get(fields.get(0));
-            String id = objectMapper.writeValueAsString(singleNode);
-            return (id.startsWith("\"") && id.endsWith("\""))
-                    ? id.substring(1, id.length() - 1)  // remove double quotes
-                    : id;
-        } else {
-            return JsonConverter.toJsonArray(jsonNode, fields).toString();
-        }
     }
 
     public String stringifyValue(Schema<?> schema, Object val) throws JsonProcessingException {

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
@@ -23,12 +23,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.client.api.Message;
@@ -48,13 +46,10 @@ import org.apache.pulsar.io.core.annotations.IOType;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.TreeSet;
 
 @Connector(
         name = "elastic_search",

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
@@ -79,15 +79,13 @@ public class ElasticSearchSink implements Sink<GenericObject> {
                     .builder()
                             .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
                     .nodeFactory(new JsonNodeFactory() {
-
                         @Override
                         public ObjectNode objectNode() {
                             return new ObjectNode(this, new TreeMap<String, JsonNode>());
                         }
 
                     })
-                            .build();
-
+                    .build();
         }
     }
 

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/JsonConverter.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/JsonConverter.java
@@ -28,6 +28,7 @@ import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.GenericRecord;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Convert an AVRO GenericRecord to a JsonNode.
@@ -192,12 +193,29 @@ public class JsonConverter {
 
     public static ArrayNode toJsonArray(JsonNode jsonNode, List<String> fields) {
         ArrayNode arrayNode = jsonNodeFactory.arrayNode();
-        Iterator<String>  it = jsonNode.fieldNames();
+        Iterator<String> it = jsonNode.fieldNames();
         while (it.hasNext()) {
             String fieldName = it.next();
-            if (fields.contains(fieldName)) {
+            if (fields == null || fields.contains(fieldName)) {
                 arrayNode.add(jsonNode.get(fieldName));
             }
+        }
+        return arrayNode;
+    }
+
+    public static ArrayNode toSortedJsonArray(JsonNode jsonNode, List<String> fields) {
+        ArrayNode arrayNode = jsonNodeFactory.arrayNode();
+        Iterator<String> it = jsonNode.fieldNames();
+        TreeMap<String, JsonNode> orderedNodes = new TreeMap<>();
+        while (it.hasNext()) {
+            String fieldName = it.next();
+            if (fields == null || fields.contains(fieldName)) {
+                final JsonNode currentJsonNode = jsonNode.get(fieldName);
+                orderedNodes.put(fieldName, currentJsonNode);
+            }
+        }
+        for (JsonNode orderedNode : orderedNodes.values()) {
+            arrayNode.add(orderedNode);
         }
         return arrayNode;
     }

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/JsonConverter.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/JsonConverter.java
@@ -23,12 +23,10 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericEnumSymbol;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.GenericRecord;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * Convert an AVRO GenericRecord to a JsonNode.
@@ -196,26 +194,9 @@ public class JsonConverter {
         Iterator<String> it = jsonNode.fieldNames();
         while (it.hasNext()) {
             String fieldName = it.next();
-            if (fields == null || fields.contains(fieldName)) {
+            if (fields.contains(fieldName)) {
                 arrayNode.add(jsonNode.get(fieldName));
             }
-        }
-        return arrayNode;
-    }
-
-    public static ArrayNode toSortedJsonArray(JsonNode jsonNode, List<String> fields) {
-        ArrayNode arrayNode = jsonNodeFactory.arrayNode();
-        Iterator<String> it = jsonNode.fieldNames();
-        TreeMap<String, JsonNode> orderedNodes = new TreeMap<>();
-        while (it.hasNext()) {
-            String fieldName = it.next();
-            if (fields == null || fields.contains(fieldName)) {
-                final JsonNode currentJsonNode = jsonNode.get(fieldName);
-                orderedNodes.put(fieldName, currentJsonNode);
-            }
-        }
-        for (JsonNode orderedNode : orderedNodes.values()) {
-            arrayNode.add(orderedNode);
         }
         return arrayNode;
     }

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchExtractTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchExtractTests.java
@@ -21,24 +21,11 @@ package org.apache.pulsar.io.elasticsearch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
-
-import java.nio.charset.StandardCharsets;
 import java.util.Optional;
-import java.util.TreeMap;
-
-import lombok.SneakyThrows;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.*;
-import org.apache.pulsar.client.impl.schema.generic.GenericAvroRecord;
 import org.apache.pulsar.client.impl.schema.generic.GenericSchemaImpl;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
@@ -299,19 +286,6 @@ public class ElasticSearchExtractTests {
         });
         assertEquals(pair.getLeft(), "[\"1\",1]");
         assertNull(pair.getRight());
-    }
-
-    @Test
-    public void testS() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
-        mapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
-
-        final JsonNode jsonNode = new ObjectMapper().readValue("{\"z\": true,\"a\": {\"c\": true, \"b\": false}}", JsonNode.class);
-        System.out.println("jsonNode" + jsonNode);
-        final String res = mapper.writeValueAsString(jsonNode);
-        System.out.println("res:" + res);
-
     }
 
     @Test(dataProvider = "schemaType")

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchExtractTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchExtractTests.java
@@ -20,11 +20,25 @@ package org.apache.pulsar.io.elasticsearch;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
+
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import java.util.TreeMap;
+
+import lombok.SneakyThrows;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.*;
+import org.apache.pulsar.client.impl.schema.generic.GenericAvroRecord;
 import org.apache.pulsar.client.impl.schema.generic.GenericSchemaImpl;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
@@ -285,5 +299,158 @@ public class ElasticSearchExtractTests {
         });
         assertEquals(pair.getLeft(), "[\"1\",1]");
         assertNull(pair.getRight());
+    }
+
+    @Test
+    public void testS() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+        mapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+
+        final JsonNode jsonNode = new ObjectMapper().readValue("{\"z\": true,\"a\": {\"c\": true, \"b\": false}}", JsonNode.class);
+        System.out.println("jsonNode" + jsonNode);
+        final String res = mapper.writeValueAsString(jsonNode);
+        System.out.println("res:" + res);
+
+    }
+
+    @Test(dataProvider = "schemaType")
+    public void testSortKeys(SchemaType schemaType) throws Exception {
+        {
+            RecordSchemaBuilder keySchemaBuilder = org.apache.pulsar.client.api.schema.SchemaBuilder.record("key");
+            keySchemaBuilder.field("a").type(SchemaType.STRING).optional().defaultValue(null);
+            keySchemaBuilder.field("b").type(SchemaType.STRING).optional().defaultValue(null);
+            keySchemaBuilder.field("c").type(SchemaType.STRING).optional().defaultValue(null);
+
+            RecordSchemaBuilder udtSchemaBuilder = SchemaBuilder.record("type1");
+            udtSchemaBuilder.field("b_inside_inner").type(SchemaType.STRING).optional().defaultValue(null);
+            udtSchemaBuilder.field("a_inside_inner").type(SchemaType.STRING).optional().defaultValue(null);
+            GenericSchema<GenericRecord> udtGenericSchema = GenericSchemaImpl.of(udtSchemaBuilder.build(schemaType));
+
+            keySchemaBuilder.field("inner", udtGenericSchema).type(schemaType).optional().defaultValue(null);
+            GenericSchema<GenericRecord> keySchema = GenericSchemaImpl.of(keySchemaBuilder.build(schemaType));
+
+            final GenericRecord innerRecord = udtGenericSchema.newRecordBuilder()
+                    .set("b_inside_inner", "0b_value_from_inner")
+                    .set("a_inside_inner", "a_value_from_inner")
+                    .build();
+
+            GenericRecord keyGenericRecord = keySchema.newRecordBuilder()
+                    .set("c", "c_key")
+                    .set("b", "0b_key")
+                    .set("a", "a_key")
+                    .set("inner", innerRecord)
+                    .build();
+
+            Record<GenericObject> genericObjectRecord = getKeyValueGenericObject(schemaType, keySchema, keyGenericRecord);
+
+
+            ElasticSearchSink elasticSearchSink = new ElasticSearchSink();
+            elasticSearchSink.open(ImmutableMap.of(
+                    "elasticSearchUrl", "http://localhost:9200",
+                    "compatibilityMode", "ELASTICSEARCH",
+                    "schemaEnable", "true",
+                    "canonicalKeyFields", "false",
+                    "keyIgnore", "false"), null);
+            Pair<String, String> pair = elasticSearchSink.extractIdAndDocument(genericObjectRecord);
+            assertEquals(pair.getKey(), "[\"a_key\",\"0b_key\",\"c_key\",{\"b_inside_inner\":\"0b_value_from_inner\",\"a_inside_inner\":\"a_value_from_inner\"}]");
+
+            elasticSearchSink = new ElasticSearchSink();
+            elasticSearchSink.open(ImmutableMap.of(
+                    "elasticSearchUrl", "http://localhost:9200",
+                    "compatibilityMode", "ELASTICSEARCH",
+                    "schemaEnable", "true",
+                    "canonicalKeyFields", "true",
+                    "keyIgnore", "false"), null);
+            pair = elasticSearchSink.extractIdAndDocument(genericObjectRecord);
+            assertEquals(pair.getKey(), "[\"a_key\",\"0b_key\",\"c_key\",{\"a_inside_inner\":\"a_value_from_inner\",\"b_inside_inner\":\"0b_value_from_inner\"}]");
+        }
+
+        {
+            RecordSchemaBuilder keySchemaBuilder = org.apache.pulsar.client.api.schema.SchemaBuilder.record("key");
+
+            RecordSchemaBuilder udtSchemaBuilder = SchemaBuilder.record("type1");
+            udtSchemaBuilder.field("b_inside_inner").type(SchemaType.STRING).optional().defaultValue(null);
+            udtSchemaBuilder.field("a_inside_inner").type(SchemaType.STRING).optional().defaultValue(null);
+            GenericSchema<GenericRecord> udtGenericSchema = GenericSchemaImpl.of(udtSchemaBuilder.build(schemaType));
+
+            keySchemaBuilder.field("singleKey", udtGenericSchema).type(schemaType).optional().defaultValue(null);
+            GenericSchema<GenericRecord> keySchema = GenericSchemaImpl.of(keySchemaBuilder.build(schemaType));
+
+            final GenericRecord innerRecord = udtGenericSchema.newRecordBuilder()
+                    .set("b_inside_inner", "0b_value_from_inner")
+                    .set("a_inside_inner", "a_value_from_inner")
+                    .build();
+
+            GenericRecord keyGenericRecord = keySchema.newRecordBuilder()
+                    .set("singleKey", innerRecord)
+                    .build();
+
+            Record<GenericObject> genericObjectRecord = getKeyValueGenericObject(schemaType, keySchema, keyGenericRecord);
+
+
+            ElasticSearchSink elasticSearchSink = new ElasticSearchSink();
+            elasticSearchSink.open(ImmutableMap.of(
+                    "elasticSearchUrl", "http://localhost:9200",
+                    "compatibilityMode", "ELASTICSEARCH",
+                    "schemaEnable", "true",
+                    "canonicalKeyFields", "false",
+                    "keyIgnore", "false"), null);
+            Pair<String, String> pair = elasticSearchSink.extractIdAndDocument(genericObjectRecord);
+            assertEquals(pair.getKey(), "{\"b_inside_inner\":\"0b_value_from_inner\",\"a_inside_inner\":\"a_value_from_inner\"}");
+
+            elasticSearchSink = new ElasticSearchSink();
+            elasticSearchSink.open(ImmutableMap.of(
+                    "elasticSearchUrl", "http://localhost:9200",
+                    "compatibilityMode", "ELASTICSEARCH",
+                    "schemaEnable", "true",
+                    "canonicalKeyFields", "true",
+                    "keyIgnore", "false"), null);
+            pair = elasticSearchSink.extractIdAndDocument(genericObjectRecord);
+            assertEquals(pair.getKey(), "{\"a_inside_inner\":\"a_value_from_inner\",\"b_inside_inner\":\"0b_value_from_inner\"}");
+
+        }
+    }
+
+    private Record<GenericObject> getKeyValueGenericObject(SchemaType schemaType, GenericSchema<GenericRecord> keySchema, GenericRecord keyGenericRecord) {
+        RecordSchemaBuilder valueSchemaBuilder = SchemaBuilder.record("value");
+        valueSchemaBuilder.field("value").type(SchemaType.STRING);
+        GenericSchema<GenericRecord> valueSchema = GenericSchemaImpl.of(valueSchemaBuilder.build(schemaType));
+
+        GenericRecord valueGenericRecord = valueSchema.newRecordBuilder()
+                .set("value", "value")
+                .build();
+
+        Schema<KeyValue<GenericRecord, GenericRecord>> keyValueSchema =
+                Schema.KeyValue(keySchema, valueSchema, KeyValueEncodingType.INLINE);
+        KeyValue<GenericRecord, GenericRecord> keyValue = new KeyValue<>(keyGenericRecord, valueGenericRecord);
+        GenericObject genericObject = new GenericObject() {
+            @Override
+            public SchemaType getSchemaType() {
+                return SchemaType.KEY_VALUE;
+            }
+
+            @Override
+            public Object getNativeObject() {
+                return keyValue;
+            }
+        };
+        Record<GenericObject> genericObjectRecord = new Record<GenericObject>() {
+            @Override
+            public Optional<String> getTopicName() {
+                return Optional.of("data-ks1.table1");
+            }
+
+            @Override
+            public Schema  getSchema() {
+                return keyValueSchema;
+            }
+
+            @Override
+            public GenericObject getValue() {
+                return genericObject;
+            }
+        };
+        return genericObjectRecord;
     }
 }


### PR DESCRIPTION
Basic implementation of canonical output for the key.
If the key schema is avro or json, we sort the fields alphabetically (and recursively).

Implementation notes:
- For JSON, we have to parse and rewrite the entire JSON
- For avro, in this pull, the implementation efficiency can be improved. At the moment: Avro record -> unordered JSON -> ordered JSON. We can remove the intermediate json
  