### PR TITLE
[fix][elasticsearch-sink] enable bulk flushing interval by default

### DIFF
--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
@@ -180,10 +180,10 @@ public class ElasticSearchConfig implements Serializable {
 
     @FieldDoc(
             required = false,
-            defaultValue = "-1",
-            help = "The bulk flush interval flushing any bulk request pending if the interval passes. Default is -1 meaning not set."
+            defaultValue = "10000",
+            help = "The bulk flush interval flushing any bulk request pending if the interval passes. -1 or zero means the interval flushing is disabled."
     )
-    private long bulkFlushIntervalInMs = -1;
+    private long bulkFlushIntervalInMs = 10000L;
 
     // connection settings, see https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/java-rest-low-config.html
     @FieldDoc(


### PR DESCRIPTION
Better default value for `bulkFlushIntervalInMs` (from disabled to 10 seconds). This option is highly recommended when bulk is enabled in order to avoid the sink to look stuck in case of low-traffic (actions or message size thresholds not hit for long time) 