### PR TITLE
[fix][elasticsearch-sink] Handle Avro collections native types (GenericData.Array and Utf8 map keys)

### DIFF
--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/JsonConverterTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/JsonConverterTests.java
@@ -43,6 +43,8 @@ public class JsonConverterTests {
 
     @Test
     public void testAvroToJson() throws IOException {
+        Schema avroArraySchema = SchemaBuilder.array().items(SchemaBuilder.builder().stringType());
+        Schema mapUtf8Schema = SchemaBuilder.map().values(SchemaBuilder.builder().intType());
         Schema schema = SchemaBuilder.record("record").fields()
                 .name("n").type().longType().longDefault(10)
                 .name("l").type().longType().longDefault(10)
@@ -55,7 +57,9 @@ public class JsonConverterTests {
                 .name("fi").type().fixed("fi").size(3).fixedDefault(new byte[]{1,2,3})
                 .name("en").type().enumeration("en").symbols("a","b","c").enumDefault("b")
                 .name("array").type().optional().array().items(SchemaBuilder.builder().stringType())
+                .name("arrayavro").type().optional().array().items(SchemaBuilder.builder().stringType())
                 .name("map").type().optional().map().values(SchemaBuilder.builder().intType())
+                .name("maputf8").type().optional().map().values(SchemaBuilder.builder().intType())
                 .endRecord();
         GenericRecord genericRecord = new GenericData.Record(schema);
         genericRecord.put("n", null);
@@ -69,7 +73,9 @@ public class JsonConverterTests {
         genericRecord.put("fi", GenericData.get().createFixed(null, new byte[]{'a','b','c'}, schema.getField("fi").schema()));
         genericRecord.put("en", GenericData.get().createEnum("b", schema.getField("en").schema()));
         genericRecord.put("array", new String[] {"toto"});
+        genericRecord.put("arrayavro", new GenericData.Array<>(avroArraySchema, Arrays.asList("toto")));
         genericRecord.put("map", ImmutableMap.of("a",10));
+        genericRecord.put("maputf8", ImmutableMap.of(new org.apache.avro.util.Utf8("a"),10));
         JsonNode jsonNode = JsonConverter.toJson(ElasticSearchConfig.load(ImmutableMap.of()), genericRecord);
         assertEquals(jsonNode.get("n"), NullNode.getInstance());
         assertEquals(jsonNode.get("l").asLong(), 1L);
@@ -83,9 +89,14 @@ public class JsonConverterTests {
         assertEquals(jsonNode.get("s").asText(), "toto");
         assertTrue(jsonNode.get("array").isArray());
         assertEquals(jsonNode.get("array").iterator().next().asText(), "toto");
+        assertTrue(jsonNode.get("arrayavro").isArray());
+        assertEquals(jsonNode.get("arrayavro").iterator().next().asText(), "toto");
         assertTrue(jsonNode.get("map").isObject());
         assertEquals(jsonNode.get("map").elements().next().asText(), "10");
         assertEquals(jsonNode.get("map").get("a").numberValue(), 10);
+        assertTrue(jsonNode.get("maputf8").isObject());
+        assertEquals(jsonNode.get("maputf8").elements().next().asText(), "10");
+        assertEquals(jsonNode.get("maputf8").get("a").numberValue(), 10);
     }
 
     @Test

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/ElasticSearchSinkTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/ElasticSearchSinkTester.java
@@ -21,9 +21,13 @@ package org.apache.pulsar.tests.integration.io.sinks;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
@@ -31,6 +35,7 @@ import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.transport.ElasticsearchTransport;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
+import com.google.common.collect.ImmutableMap;
 import io.vertx.core.http.RequestOptions;
 import lombok.AllArgsConstructor;
 import lombok.Cleanup;
@@ -61,6 +66,9 @@ public abstract class ElasticSearchSinkTester extends SinkTester<ElasticsearchCo
     public static final class SimplePojo {
         private String field1;
         private String field2;
+        private List<Integer> list1;
+        private Set<Long> set1;
+        private Map<String, String> map1;
     }
 
     /**
@@ -129,9 +137,20 @@ public abstract class ElasticSearchSinkTester extends SinkTester<ElasticsearchCo
             for (int i = 0; i < numMessages; i++) {
                 String key = "key-" + i;
                 kvs.put(key, key);
+                final SimplePojo keyPojo = new SimplePojo(
+                        "f1_" + i,
+                        "f2_" + i,
+                        Arrays.asList(i, i +1),
+                        new HashSet<>(Arrays.asList((long) i)),
+                        ImmutableMap.of("map1_k_" + i, "map1_kv_" + i));
+                final SimplePojo valuePojo = new SimplePojo(
+                        "f1_" + i,
+                        "f2_" + i,
+                        Arrays.asList(i, i +1),
+                        new HashSet<>(Arrays.asList((long) i)),
+                        ImmutableMap.of("map1_v_" + i, "map1_vv_" + i));
                 producer.newMessage()
-                        .value(new KeyValue<>(new SimplePojo("f1_" + i, "f2_" + i),
-                                new SimplePojo("v1_" + i, "v2_" + i)))
+                        .value(new KeyValue<>(keyPojo, valuePojo))
                         .send();
             }
 


### PR DESCRIPTION
```
// Map<String, Object> 

ERROR org.apache.pulsar.io.elasticsearch.ElasticSearchSink - write error:
2022-04-26T12:03:34.776219894Z java.lang.IllegalArgumentException: Error while converting a value of type class java.util.HashMap to a MAP: java.lang.ClassCastException: class org.apache.avro.util.Utf8 cannot be cast to class java.lang.String (org.apache.avro.util.Utf8 is in unnamed module of loader 'app'; java.lang.String is in module java.base of loader 'bootstrap')


// List/Set
022-04-26T11:56:51.477776276Z Caused by: java.lang.ClassCastException: class org.apache.avro.generic.GenericData$Array cannot be cast to class [Ljava.lang.Object; (org.apache.avro.generic.GenericData$Array is in unnamed module of loader 'app'; [Ljava.lang.Object; is in module java.base of loader 'bootstrap')
2022-04-26T11:56:51.477782027Z 	at org.apache.pulsar.io.elasticsearch.JsonConverter.toJson(JsonConverter.java:90) ~[?:?
```