### PR TITLE
[feat][elasticsearch-sink] Option to strip out non printable characters

### DIFF
--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
@@ -299,6 +299,12 @@ public class ElasticSearchConfig implements Serializable {
     )
     private IdHashingAlgorithm idHashingAlgorithm = IdHashingAlgorithm.NONE;
 
+    @FieldDoc(
+            defaultValue = "true",
+            help = "If stripNonPrintableCharacters is true, all non-printable characters will be removed from the document."
+    )
+    private boolean stripNonPrintableCharacters = true;
+
     public enum MalformedDocAction {
         IGNORE,
         WARN,

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
@@ -53,6 +53,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.regex.Pattern;
 
 @Connector(
         name = "elastic_search",
@@ -69,6 +70,7 @@ public class ElasticSearchSink implements Sink<GenericObject> {
     private ObjectMapper sortedObjectMapper;
     private List<String> primaryFields = null;
     private final Base64.Encoder base64Encoder = Base64.getEncoder().withoutPadding();
+    private final Pattern nonPrintableCharactersPattern = Pattern.compile("[\\p{C}]");
 
     @Override
     public void open(Map<String, Object> config, SinkContext sinkContext) throws Exception {
@@ -257,13 +259,25 @@ public class ElasticSearchSink implements Sink<GenericObject> {
                         id,
                         doc);
             }
+            doc = sanitizeValue(doc);
             return Pair.of(id, doc);
     } else {
-        return Pair.of(null, new String(
-                record.getMessage()
-                        .orElseThrow(() -> new IllegalArgumentException("Record does not carry message information"))
-                        .getData(), StandardCharsets.UTF_8));
+            final byte[] data = record
+                    .getMessage()
+                    .orElseThrow(() -> new IllegalArgumentException("Record does not carry message information"))
+                    .getData();
+            String doc = new String(data, StandardCharsets.UTF_8);
+            doc = sanitizeValue(doc);
+            return Pair.of(null, doc);
         }
+    }
+
+    private String sanitizeValue(String value) {
+        if (value == null || !elasticSearchConfig.isStripNonPrintableCharacters()) {
+            return value;
+        }
+        return nonPrintableCharactersPattern.matcher(value).replaceAll("");
+
     }
 
     public String stringifyKey(Schema<?> schema, Object val) throws JsonProcessingException {

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkRawDataTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkRawDataTests.java
@@ -18,9 +18,12 @@
  */
 package org.apache.pulsar.io.elasticsearch;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.core.SinkContext;
 import org.mockito.Mock;
@@ -31,6 +34,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -44,6 +48,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.fail;
 
 public abstract class ElasticSearchSinkRawDataTests extends ElasticSearchTestBase {
 
@@ -136,6 +141,47 @@ public abstract class ElasticSearchSinkRawDataTests extends ElasticSearchTestBas
     protected final void send(int numRecords) throws Exception {
         for (int idx = 0; idx < numRecords; idx++) {
             sink.write(mockRecord);
+        }
+    }
+
+    @Data
+    @AllArgsConstructor
+    private static class StripNonPrintableCharactersTestConfig {
+        private boolean stripNonPrintableCharacters;
+        private boolean bulkEnabled;
+
+    }
+    @DataProvider(name = "stripNonPrintableCharacters")
+    public Object[] stripNonPrintableCharacters() {
+        return new Object[]{
+                new StripNonPrintableCharactersTestConfig(true, true),
+                new StripNonPrintableCharactersTestConfig(true, false),
+                new StripNonPrintableCharactersTestConfig(false, true),
+                new StripNonPrintableCharactersTestConfig(false, false),
+        };
+    }
+
+
+    @Test(dataProvider = "stripNonPrintableCharacters")
+    public final void testStripNonPrintableCharacters(StripNonPrintableCharactersTestConfig conf) throws Exception {
+        map.put("indexName", "test-index");
+        map.put("bulkEnabled", conf.isBulkEnabled());
+        map.put("bulkActions", 1);
+        map.put("stripNonPrintableCharacters", conf.isStripNonPrintableCharacters());
+        sink.open(map, mockSinkContext);
+
+        final String data = "\t" + ((char)0) + "{\"a\":\"b" + ((char)31) + "\"}";
+        when(mockMessage.getData()).thenReturn(data.getBytes(StandardCharsets.UTF_8));
+        try {
+            send(1);
+            if (!conf.isStripNonPrintableCharacters()) {
+                fail("with stripNonPrintableCharacters=false it should have raised an exception");
+            }
+            verify(mockRecord, times(1)).ack();
+        } catch (Throwable t) {
+            if (conf.isStripNonPrintableCharacters()) {
+                throw t;
+            }
         }
     }
 


### PR DESCRIPTION
### Issue

If the message value contains non-printable characters you will get 

```
2022-04-22T22:37:29.673384094Z 22:37:29.668 [osct-dev-westus-tnt-10/astracdc/alerts-sk-es-01-0] ERROR org.apache.pulsar.io.elasticsearch.ElasticSearchSink - Malformed document messageId=73895:0:1
2022-04-22T22:37:29.673415795Z com.fasterxml.jackson.core.JsonParseException: Illegal character ((CTRL-CHAR, code 0)): only regular white space (\r, \n, \t) is allowed between tokens
2022-04-22T22:37:29.673424695Z  at [Source: (String)"\u0000\u0000\u0002�\u000C\u0002\u001Epick_start_time\u0000\u0002\u00081211\u0002\u000ESafeway\u0002�����_\u0000\u0000\u0002\u00021\u0002\u0018445184429011"; line: 1, column: 2]
```

Even if you set malformedDocAction to IGNORE, the message will be re-delivered. In case of KEY_SHARED subscriptions this will lead to stuck subscriptions scenario.

The issue is that [JSON format doesn't accept this kind of characters](https://datatracker.ietf.org/doc/html/rfc8259#section-7). 

>All Unicode characters may be placed within the
   quotation marks, except for the characters that MUST be escaped:
   quotation mark, reverse solidus, and the control characters (U+0000
   through U+001F).

Since usually these characters are useless, it is better to drop them all instead of encoding (which is not simple because it depends how much the json is malformed. For example, inside a key or a value you can encode them but you cannot between tokens)


- New option `stripNonPrintableCharacters` default=true (which will trigger a different behaviour by default) which removes the non printable characters from the output json (only for the document, not the _id because the no matters if the _is a json or not). The stripping is done via RegEx because, unfortunately, Jackson Mapper doesn't support this out of the box.
