### PR TITLE
Fix: checkstyle error in KinesisSinkTester. 

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KinesisSinkTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KinesisSinkTester.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.tests.integration.io.sinks;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.google.common.collect.ImmutableMap;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashMap;


### PR DESCRIPTION
### Motivation

Checkstyle error while running ` mvn clean install -DskipTests` locally

### Modifications

Removed unused import.