### PR TITLE
Offloader metrics (#13833)

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -896,7 +896,10 @@ managedLedgerDefaultAckQuorum=2
 
 # How frequently to flush the cursor positions that were accumulated due to rate limiting. (seconds).
 # Default is 60 seconds
-managedLedgerCursorPositionFlushSeconds = 60
+managedLedgerCursorPositionFlushSeconds=60
+
+# How frequently to refresh the stats. (seconds). Default is 60 seconds
+managedLedgerStatsPeriodSeconds=60
 
 # Default type of checksum to use when writing to BookKeeper. Default is "CRC32C"
 # Other possible options are "CRC32", "MAC" or "DUMMY" (no checksum).

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloaderFactory.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloaderFactory.java
@@ -52,7 +52,8 @@ public interface LedgerOffloaderFactory<T extends LedgerOffloader> {
      */
     T create(OffloadPoliciesImpl offloadPolicies,
              Map<String, String> userMetadata,
-             OrderedScheduler scheduler)
+             OrderedScheduler scheduler,
+             LedgerOffloaderStats offloaderStats)
         throws IOException;
 
     /**
@@ -68,8 +69,9 @@ public interface LedgerOffloaderFactory<T extends LedgerOffloader> {
     default T create(OffloadPoliciesImpl offloadPolicies,
                      Map<String, String> userMetadata,
                      SchemaStorage schemaStorage,
-                     OrderedScheduler scheduler)
+                     OrderedScheduler scheduler,
+                     LedgerOffloaderStats offloaderStats)
             throws IOException {
-        return create(offloadPolicies, userMetadata, scheduler);
+        return create(offloadPolicies, userMetadata, scheduler, offloaderStats);
     }
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloaderStats.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloaderStats.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.apache.bookkeeper.common.annotation.InterfaceAudience;
+import org.apache.bookkeeper.common.annotation.InterfaceStability;
+import org.apache.bookkeeper.mledger.impl.LedgerOffloaderStatsImpl;
+
+
+/**
+ * Management Bean for a {@link LedgerOffloader}.
+ */
+@InterfaceAudience.LimitedPrivate
+@InterfaceStability.Stable
+public interface LedgerOffloaderStats extends AutoCloseable {
+
+    void recordOffloadError(String topic);
+
+    void recordOffloadBytes(String topic, long size);
+
+    void recordReadLedgerLatency(String topic, long latency, TimeUnit unit);
+
+    void recordWriteToStorageError(String topic);
+
+    void recordReadOffloadError(String topic);
+
+    void recordReadOffloadBytes(String topic, long size);
+
+    void recordReadOffloadIndexLatency(String topic, long latency, TimeUnit unit);
+
+    void recordReadOffloadDataLatency(String topic, long latency, TimeUnit unit);
+
+    void recordDeleteOffloadOps(String topic, boolean succeed);
+
+
+    static LedgerOffloaderStats create(boolean exposeManagedLedgerStats, boolean exposeTopicLevelMetrics,
+                                       ScheduledExecutorService scheduler, int interval) {
+        if (!exposeManagedLedgerStats) {
+            return LedgerOffloaderStatsDisable.INSTANCE;
+        }
+
+        return LedgerOffloaderStatsImpl.getInstance(exposeTopicLevelMetrics, scheduler, interval);
+    }
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloaderStatsDisable.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloaderStatsDisable.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger;
+
+import java.util.concurrent.TimeUnit;
+
+class LedgerOffloaderStatsDisable implements LedgerOffloaderStats {
+
+    static final LedgerOffloaderStats INSTANCE = new LedgerOffloaderStatsDisable();
+
+    private LedgerOffloaderStatsDisable() {
+
+    }
+
+    @Override
+    public void recordOffloadError(String topic) {
+
+    }
+
+    @Override
+    public void recordOffloadBytes(String topic, long size) {
+
+    }
+
+    @Override
+    public void recordReadLedgerLatency(String topic, long latency, TimeUnit unit) {
+
+    }
+
+    @Override
+    public void recordWriteToStorageError(String topic) {
+
+    }
+
+    @Override
+    public void recordReadOffloadError(String topic) {
+
+    }
+
+    @Override
+    public void recordReadOffloadBytes(String topic, long size) {
+
+    }
+
+    @Override
+    public void recordReadOffloadIndexLatency(String topic, long latency, TimeUnit unit) {
+
+    }
+
+    @Override
+    public void recordReadOffloadDataLatency(String topic, long latency, TimeUnit unit) {
+
+    }
+
+    @Override
+    public void recordDeleteOffloadOps(String topic, boolean succeed) {
+
+    }
+
+    @Override
+    public void close() throws Exception {
+
+    }
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactoryConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactoryConfig.java
@@ -48,22 +48,22 @@ public class ManagedLedgerFactoryConfig {
     private double cacheEvictionFrequency = 100;
 
     /**
-     * All entries that have stayed in cache for more than the configured time, will be evicted
+     * All entries that have stayed in cache for more than the configured time, will be evicted.
      */
     private long cacheEvictionTimeThresholdMillis = 1000;
 
     /**
-     * Whether we should make a copy of the entry payloads when inserting in cache
+     * Whether we should make a copy of the entry payloads when inserting in cache.
      */
     private boolean copyEntriesInCache = false;
 
     /**
-     * Whether trace managed ledger task execution time
+     * Whether trace managed ledger task execution time.
      */
     private boolean traceTaskExecution = true;
 
     /**
-     * Managed ledger prometheus stats Latency Rollover Seconds
+     * Managed ledger prometheus stats Latency Rollover Seconds.
      */
     private int prometheusStatsLatencyRolloverSeconds = 60;
 
@@ -73,7 +73,12 @@ public class ManagedLedgerFactoryConfig {
     private int cursorPositionFlushSeconds = 60;
 
     /**
-     * cluster name for prometheus stats
+     * How frequently to refresh the stats.
+     */
+    private int statsPeriodSeconds = 60;
+
+    /**
+     * cluster name for prometheus stats.
      */
     private String clusterName;
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/LedgerOffloaderStatsImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/LedgerOffloaderStatsImpl.java
@@ -1,0 +1,352 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.Summary;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.stream.Collectors;
+import org.apache.bookkeeper.mledger.LedgerOffloaderStats;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pulsar.common.naming.TopicName;
+
+public final class LedgerOffloaderStatsImpl implements LedgerOffloaderStats, Runnable {
+    private static final String TOPIC_LABEL = "topic";
+    private static final String NAMESPACE_LABEL = "namespace";
+    private static final String UNKNOWN = "unknown";
+    private static final String STATUS = "status";
+    private static final String SUCCEED = "succeed";
+    private static final String FAILED = "failed";
+
+    private final boolean exposeTopicLevelMetrics;
+    private final int interval;
+
+    private final Counter offloadError;
+    private final Gauge offloadRate;
+    private final Counter deleteOffloadOps;
+    private final Summary readLedgerLatency;
+    private final Counter writeStorageError;
+    private final Counter readOffloadError;
+    private final Gauge readOffloadRate;
+    private final Summary readOffloadIndexLatency;
+    private final Summary readOffloadDataLatency;
+
+    private final Map<String, Long> topicAccess;
+    private final Map<String, String> topic2Namespace;
+    private final Map<String, Pair<LongAdder, LongAdder>> offloadAndReadOffloadBytesMap;
+
+    final AtomicBoolean closed = new AtomicBoolean(false);
+
+     private LedgerOffloaderStatsImpl(boolean exposeTopicLevelMetrics,
+                                     ScheduledExecutorService scheduler, int interval) {
+        this.interval = interval;
+        this.exposeTopicLevelMetrics = exposeTopicLevelMetrics;
+        if (null != scheduler) {
+            scheduler.scheduleAtFixedRate(this, interval, interval, TimeUnit.SECONDS);
+        }
+
+        this.topicAccess = new ConcurrentHashMap<>();
+        this.topic2Namespace = new ConcurrentHashMap<>();
+        this.offloadAndReadOffloadBytesMap = new ConcurrentHashMap<>();
+
+        String[] labels = exposeTopicLevelMetrics
+                ? new String[]{NAMESPACE_LABEL, TOPIC_LABEL} : new String[]{NAMESPACE_LABEL};
+
+        this.offloadError = Counter.build("brk_ledgeroffloader_offload_error", "-")
+                .labelNames(labels).create().register();
+        this.offloadRate = Gauge.build("brk_ledgeroffloader_offload_rate", "-")
+                .labelNames(labels).create().register();
+
+        this.readOffloadError = Counter.build("brk_ledgeroffloader_read_offload_error", "-")
+                .labelNames(labels).create().register();
+        this.readOffloadRate = Gauge.build("brk_ledgeroffloader_read_offload_rate", "-")
+                .labelNames(labels).create().register();
+        this.writeStorageError = Counter.build("brk_ledgeroffloader_write_storage_error", "-")
+                .labelNames(labels).create().register();
+
+        this.readOffloadIndexLatency = Summary.build("brk_ledgeroffloader_read_offload_index_latency", "-")
+                .labelNames(labels).create().register();
+        this.readOffloadDataLatency = Summary.build("brk_ledgeroffloader_read_offload_data_latency", "-")
+                .labelNames(labels).create().register();
+        this.readLedgerLatency = Summary.build("brk_ledgeroffloader_read_ledger_latency", "-")
+                .labelNames(labels).create().register();
+
+        String[] deleteOpsLabels = exposeTopicLevelMetrics
+                ? new String[]{NAMESPACE_LABEL, TOPIC_LABEL, STATUS} : new String[]{NAMESPACE_LABEL, STATUS};
+        this.deleteOffloadOps = Counter.build("brk_ledgeroffloader_delete_offload_ops", "-")
+                .labelNames(deleteOpsLabels).create().register();
+    }
+
+
+    private static LedgerOffloaderStats instance;
+    public static synchronized LedgerOffloaderStats getInstance(boolean exposeTopicLevelMetrics,
+                                                                ScheduledExecutorService scheduler, int interval) {
+        if (null == instance) {
+            instance = new LedgerOffloaderStatsImpl(exposeTopicLevelMetrics, scheduler, interval);
+        }
+
+        return instance;
+    }
+
+    @Override
+    public void recordOffloadError(String topic) {
+        String[] labelValues = this.labelValues(topic);
+        this.offloadError.labels(labelValues).inc();
+        this.addOrUpdateTopicAccess(topic);
+    }
+
+    @Override
+    public void recordOffloadBytes(String topic, long size) {
+        topic = StringUtils.isBlank(topic) ? UNKNOWN : topic;
+        Pair<LongAdder, LongAdder> pair = this.offloadAndReadOffloadBytesMap
+                .computeIfAbsent(topic, __ -> new ImmutablePair<>(new LongAdder(), new LongAdder()));
+        pair.getLeft().add(size);
+        this.addOrUpdateTopicAccess(topic);
+    }
+
+    @Override
+    public void recordReadLedgerLatency(String topic, long latency, TimeUnit unit) {
+        String[] labelValues = this.labelValues(topic);
+        this.readLedgerLatency.labels(labelValues).observe(unit.toMicros(latency));
+        this.addOrUpdateTopicAccess(topic);
+    }
+
+    @Override
+    public void recordWriteToStorageError(String topic) {
+        String[] labelValues = this.labelValues(topic);
+        this.writeStorageError.labels(labelValues).inc();
+        this.addOrUpdateTopicAccess(topic);
+    }
+
+    @Override
+    public void recordReadOffloadError(String topic) {
+        String[] labelValues = this.labelValues(topic);
+        this.readOffloadError.labels(labelValues).inc();
+        this.addOrUpdateTopicAccess(topic);
+    }
+
+    @Override
+    public void recordReadOffloadBytes(String topic, long size) {
+        topic = StringUtils.isBlank(topic) ? UNKNOWN : topic;
+        Pair<LongAdder, LongAdder> pair = this.offloadAndReadOffloadBytesMap
+                .computeIfAbsent(topic, __ -> new ImmutablePair<>(new LongAdder(), new LongAdder()));
+        pair.getRight().add(size);
+        this.addOrUpdateTopicAccess(topic);
+    }
+
+    @Override
+    public void recordReadOffloadIndexLatency(String topic, long latency, TimeUnit unit) {
+        String[] labelValues = this.labelValues(topic);
+        this.readOffloadIndexLatency.labels(labelValues).observe(unit.toMicros(latency));
+        this.addOrUpdateTopicAccess(topic);
+    }
+
+    @Override
+    public void recordReadOffloadDataLatency(String topic, long latency, TimeUnit unit) {
+        String[] labelValues = this.labelValues(topic);
+        this.readOffloadDataLatency.labels(labelValues).observe(unit.toMicros(latency));
+        this.addOrUpdateTopicAccess(topic);
+    }
+
+    @Override
+    public void recordDeleteOffloadOps(String topic, boolean succeed) {
+        String status = succeed ? SUCCEED : FAILED;
+        String[] labelValues = this.labelValues(topic, status);
+        this.deleteOffloadOps.labels(labelValues).inc();
+        this.addOrUpdateTopicAccess(topic);
+    }
+
+    private void addOrUpdateTopicAccess(String topic) {
+        topic = StringUtils.isBlank(topic) ? UNKNOWN : topic;
+        this.topicAccess.put(topic, System.currentTimeMillis());
+    }
+
+    private String[] labelValues(String topic, String status) {
+        if (StringUtils.isBlank(topic)) {
+            return exposeTopicLevelMetrics ? new String[]{UNKNOWN, UNKNOWN, status} : new String[]{UNKNOWN, status};
+        }
+        String namespace = this.getNamespace(topic);
+        return this.exposeTopicLevelMetrics ? new String[]{namespace, topic, status} : new String[]{namespace, status};
+    }
+
+    private String[] labelValues(String topic) {
+        if (StringUtils.isBlank(topic)) {
+            return this.exposeTopicLevelMetrics ? new String[]{UNKNOWN, UNKNOWN} : new String[]{UNKNOWN};
+        }
+        String namespace = this.getNamespace(topic);
+        return this.exposeTopicLevelMetrics ? new String[]{namespace, topic} : new String[]{namespace};
+    }
+
+    private String getNamespace(String topic) {
+        return this.topic2Namespace.computeIfAbsent(topic, t -> {
+            try {
+                return TopicName.get(t).getNamespace();
+            } catch (IllegalArgumentException ex) {
+                return UNKNOWN;
+            }
+        });
+    }
+
+    private void cleanExpiredTopicMetrics() {
+        long now = System.currentTimeMillis();
+        long timeout = TimeUnit.MINUTES.toMillis(2);
+
+        topicAccess.entrySet().removeIf(entry -> {
+            String topic = entry.getKey();
+            long access = entry.getValue();
+
+            if (now - access >= timeout) {
+                this.topic2Namespace.remove(topic);
+                this.offloadAndReadOffloadBytesMap.remove(topic);
+                String[] labelValues = this.labelValues(topic);
+                this.offloadError.remove(labelValues);
+                this.offloadRate.remove(labelValues);
+                this.readLedgerLatency.remove(labelValues);
+                this.writeStorageError.remove(labelValues);
+                this.readOffloadError.remove(labelValues);
+                this.readOffloadRate.remove(labelValues);
+                this.readOffloadIndexLatency.remove(labelValues);
+                this.readOffloadDataLatency.remove(labelValues);
+
+                labelValues = this.labelValues(topic, SUCCEED);
+                this.deleteOffloadOps.remove(labelValues);
+                labelValues = this.labelValues(topic, FAILED);
+                this.deleteOffloadOps.remove(labelValues);
+
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @Override
+    public void run() {
+        this.cleanExpiredTopicMetrics();
+
+        this.offloadAndReadOffloadBytesMap.forEach((topic, pair) -> {
+            String[] labelValues = this.labelValues(topic);
+
+            double interval = this.interval;
+            long offloadBytes = pair.getLeft().sumThenReset();
+            long readOffloadBytes = pair.getRight().sumThenReset();
+
+            this.offloadRate.labels(labelValues).set(offloadBytes / interval);
+            this.readOffloadRate.labels(labelValues).set(readOffloadBytes / interval);
+        });
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (instance == this && this.closed.compareAndSet(false, true)) {
+            CollectorRegistry.defaultRegistry.unregister(this.offloadError);
+            CollectorRegistry.defaultRegistry.unregister(this.offloadRate);
+            CollectorRegistry.defaultRegistry.unregister(this.readLedgerLatency);
+            CollectorRegistry.defaultRegistry.unregister(this.writeStorageError);
+            CollectorRegistry.defaultRegistry.unregister(this.readOffloadError);
+            CollectorRegistry.defaultRegistry.unregister(this.readOffloadRate);
+            CollectorRegistry.defaultRegistry.unregister(this.readOffloadIndexLatency);
+            CollectorRegistry.defaultRegistry.unregister(this.readOffloadDataLatency);
+            this.topic2Namespace.clear();
+            this.offloadAndReadOffloadBytesMap.clear();
+        }
+    }
+
+    @VisibleForTesting
+    public long getOffloadBytes(String topic) {
+        if (this.exposeTopicLevelMetrics) {
+            Pair<LongAdder, LongAdder> pair = this.offloadAndReadOffloadBytesMap.get(topic);
+            return pair.getLeft().sum();
+        }
+
+        String namespace = this.topic2Namespace.get(topic);
+        List<String> topics = this.offloadAndReadOffloadBytesMap.keySet().stream()
+                .filter(topicName -> topicName.contains(namespace)).collect(Collectors.toList());
+
+        long totalBytes = 0;
+        for (String key : topics) {
+            totalBytes += this.offloadAndReadOffloadBytesMap.get(key).getLeft().sum();
+        }
+        return totalBytes;
+    }
+
+    @VisibleForTesting
+    public long getOffloadError(String topic) {
+        String[] labels = this.labelValues(topic);
+        return (long) this.offloadError.labels(labels).get();
+    }
+
+    @VisibleForTesting
+    public long getWriteStorageError(String topic) {
+        String[] labels = this.labelValues(topic);
+        return (long) this.writeStorageError.labels(labels).get();
+    }
+
+    @VisibleForTesting
+    public long getReadOffloadError(String topic) {
+        String[] labels = this.labelValues(topic);
+        return (long) this.readOffloadError.labels(labels).get();
+    }
+
+    @VisibleForTesting
+    public long getReadOffloadBytes(String topic) {
+        if (this.exposeTopicLevelMetrics) {
+            Pair<LongAdder, LongAdder> pair = this.offloadAndReadOffloadBytesMap.get(topic);
+            return pair.getRight().sum();
+        }
+
+        String namespace = this.topic2Namespace.get(topic);
+        List<String> topics = this.offloadAndReadOffloadBytesMap.keySet().stream()
+                .filter(topicName -> topicName.contains(namespace)).collect(Collectors.toList());
+
+        long totalBytes = 0;
+        for (String key : topics) {
+            totalBytes += this.offloadAndReadOffloadBytesMap.get(key).getRight().sum();
+        }
+        return totalBytes;
+    }
+
+    @VisibleForTesting
+    public Summary.Child.Value getReadLedgerLatency(String topic) {
+        String[] labels = this.labelValues(topic);
+        return this.readLedgerLatency.labels(labels).get();
+    }
+
+    @VisibleForTesting
+    public Summary.Child.Value getReadOffloadIndexLatency(String topic) {
+        String[] labels = this.labelValues(topic);
+        return this.readOffloadIndexLatency.labels(labels).get();
+    }
+
+    @VisibleForTesting
+    public Summary.Child.Value getReadOffloadDataLatency(String topic) {
+        String[] labels = this.labelValues(topic);
+        return this.readOffloadDataLatency.labels(labels).get();
+    }
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -104,8 +104,6 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
     private final long cacheEvictionTimeThresholdNanos;
     private final MetadataStore metadataStore;
 
-    public static final int StatsPeriodSeconds = 60;
-
     private static class PendingInitializeManagedLedger {
 
         private final ManagedLedgerImpl ledger;
@@ -179,7 +177,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
         this.mbean = new ManagedLedgerFactoryMBeanImpl(this);
         this.entryCacheManager = new EntryCacheManager(this);
         this.statsTask = scheduledExecutor.scheduleWithFixedDelay(catchingAndLoggingThrowables(this::refreshStats),
-                0, StatsPeriodSeconds, TimeUnit.SECONDS);
+                0, config.getStatsPeriodSeconds(), TimeUnit.SECONDS);
         this.flushCursorsTask = scheduledExecutor.scheduleAtFixedRate(catchingAndLoggingThrowables(this::flushCursors),
                 config.getCursorPositionFlushSeconds(), config.getCursorPositionFlushSeconds(), TimeUnit.SECONDS);
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1449,6 +1449,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
             doc = "How frequently to flush the cursor positions that were accumulated due to rate limiting. (seconds). Default is 60 seconds")
     private int managedLedgerCursorPositionFlushSeconds = 60;
 
+    @FieldContext(minValue = 1,
+            category = CATEGORY_STORAGE_ML,
+            doc = "How frequently to refresh the stats. (seconds). Default is 60 seconds")
+    private int managedLedgerStatsPeriodSeconds = 60;
+
     //
     //
     @FieldContext(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
@@ -70,6 +70,7 @@ public class ManagedLedgerClientFactory implements ManagedLedgerStorage {
         managedLedgerFactoryConfig.setTraceTaskExecution(conf.isManagedLedgerTraceTaskExecution());
         managedLedgerFactoryConfig.setCursorPositionFlushSeconds(conf.getManagedLedgerCursorPositionFlushSeconds());
         managedLedgerFactoryConfig.setManagedLedgerInfoCompressionType(conf.getManagedLedgerInfoCompressionType());
+        managedLedgerFactoryConfig.setStatsPeriodSeconds(conf.getManagedLedgerStatsPeriodSeconds());
 
         Configuration configuration = new ClientConfiguration();
         if (conf.isBookkeeperClientExposeStatsToPrometheus()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedLedgerMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedLedgerMetrics.java
@@ -46,11 +46,15 @@ public class ManagedLedgerMetrics extends AbstractMetrics {
     private static final Buckets
             BRK_ML_ENTRYSIZEBUCKETS = new Buckets("brk_ml_EntrySizeBuckets", ENTRY_SIZE_BUCKETS_BYTES);
 
+    private int statsPeriodSeconds;
+
     public ManagedLedgerMetrics(PulsarService pulsar) {
         super(pulsar);
         this.metricsCollection = Lists.newArrayList();
         this.ledgersByDimensionMap = Maps.newHashMap();
         this.tempAggregatedMetricsMap = Maps.newHashMap();
+        this.statsPeriodSeconds = ((ManagedLedgerFactoryImpl) pulsar.getManagedLedgerFactory())
+                .getConfig().getStatsPeriodSeconds();
     }
 
     @Override
@@ -112,16 +116,16 @@ public class ManagedLedgerMetrics extends AbstractMetrics {
                 // handle bucket entries initialization here
                 BRK_ML_ADDENTRYLATENCYBUCKETS.populateBucketEntries(tempAggregatedMetricsMap,
                         lStats.getAddEntryLatencyBuckets(),
-                        ManagedLedgerFactoryImpl.StatsPeriodSeconds);
+                        statsPeriodSeconds);
                 BRK_ML_LEDGERADDENTRYLATENCYBUCKETS.populateBucketEntries(tempAggregatedMetricsMap,
                         lStats.getLedgerAddEntryLatencyBuckets(),
-                        ManagedLedgerFactoryImpl.StatsPeriodSeconds);
+                        statsPeriodSeconds);
                 BRK_ML_LEDGERSWITCHLATENCYBUCKETS.populateBucketEntries(tempAggregatedMetricsMap,
                         lStats.getLedgerSwitchLatencyBuckets(),
-                        ManagedLedgerFactoryImpl.StatsPeriodSeconds);
+                        statsPeriodSeconds);
                 BRK_ML_ENTRYSIZEBUCKETS.populateBucketEntries(tempAggregatedMetricsMap,
                         lStats.getEntrySizeBuckets(),
-                        ManagedLedgerFactoryImpl.StatsPeriodSeconds);
+                        statsPeriodSeconds);
                 populateAggregationMapWithSum(tempAggregatedMetricsMap, "brk_ml_MarkDeleteRate",
                         lStats.getMarkDeleteRate());
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -38,6 +38,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.stats.NullStatsProvider;
 import org.apache.bookkeeper.stats.StatsProvider;
 import org.apache.pulsar.PulsarVersion;
@@ -53,6 +54,7 @@ import org.apache.pulsar.common.util.SimpleTextOutputStream;
  * in a text format suitable to be consumed by Prometheus.
  * Format specification can be found at {@link https://prometheus.io/docs/instrumenting/exposition_formats/}
  */
+@Slf4j
 public class PrometheusMetricsGenerator {
 
     static {
@@ -199,13 +201,16 @@ public class PrometheusMetricsGenerator {
                             .write("{cluster=\"").write(cluster).write('"');
                 }
 
+                //to avoid quantile label duplicated
+                boolean appendedQuantile = false;
                 for (Map.Entry<String, String> metric : metrics1.getDimensions().entrySet()) {
                     if (metric.getKey().isEmpty() || "cluster".equals(metric.getKey())) {
                         continue;
                     }
                     stream.write(", ").write(metric.getKey()).write("=\"").write(metric.getValue()).write('"');
-                    if (value != null && !value.isEmpty()) {
+                    if (value != null && !value.isEmpty() && !appendedQuantile) {
                         stream.write(", ").write("quantile=\"").write(value).write('"');
+                        appendedQuantile = true;
                     }
                 }
                 stream.write("} ").write(String.valueOf(entry.getValue()))

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/LedgerOffloaderMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/LedgerOffloaderMetricsTest.java
@@ -1,0 +1,187 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.stats;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.List;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.apache.bookkeeper.mledger.LedgerOffloader;
+import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.mledger.impl.LedgerOffloaderStatsImpl;
+import org.apache.pulsar.broker.service.BrokerService;
+import org.apache.pulsar.broker.service.BrokerTestBase;
+import org.apache.pulsar.broker.service.Topic;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.junit.Assert;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+public class LedgerOffloaderMetricsTest  extends BrokerTestBase {
+
+    @Override
+    protected void setup() throws Exception {
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testTopicLevelMetrics() throws Exception {
+        conf.setExposeTopicLevelMetricsInPrometheus(true);
+        super.baseSetup();
+
+        String ns1 = "prop/ns-abc1";
+        admin.namespaces().createNamespace(ns1);
+        String []topics = new String[3];
+
+        LedgerOffloaderStatsImpl offloaderStats = (LedgerOffloaderStatsImpl) pulsar.getOffloaderStats();
+
+        LedgerOffloader offloader = Mockito.mock(LedgerOffloader.class);
+        Topic topic = Mockito.mock(PersistentTopic.class);
+        CompletableFuture<Optional<Topic>> topicFuture = new CompletableFuture<>();
+        Optional<Topic> topicOptional = Optional.of(topic);
+        topicFuture.complete(topicOptional);
+        BrokerService brokerService = spy(pulsar.getBrokerService());
+        doReturn(brokerService).when(pulsar).getBrokerService();
+
+
+        for (int i = 0; i < 3; i++) {
+            String topicName = "persistent://prop/ns-abc1/testMetrics" + UUID.randomUUID();
+            topics[i] = topicName;
+            admin.topics().createNonPartitionedTopic(topicName);
+
+            doReturn(topicFuture).when(brokerService).getTopicIfExists(topicName);
+            Assert.assertTrue(topic instanceof PersistentTopic);
+
+            ManagedLedger ledgerM = Mockito.mock(ManagedLedger.class);
+            doReturn(ledgerM).when(((PersistentTopic) topic)).getManagedLedger();
+            ManagedLedgerConfig config = Mockito.mock(ManagedLedgerConfig.class);
+            doReturn(config).when(ledgerM).getConfig();
+            doReturn(offloader).when(config).getLedgerOffloader();
+
+            offloaderStats.recordOffloadError(topicName);
+            offloaderStats.recordOffloadError(topicName);
+            offloaderStats.recordOffloadBytes(topicName, 100);
+            offloaderStats.recordReadLedgerLatency(topicName, 1000, TimeUnit.NANOSECONDS);
+            offloaderStats.recordReadOffloadError(topicName);
+            offloaderStats.recordReadOffloadError(topicName);
+            offloaderStats.recordReadOffloadIndexLatency(topicName, 1000000L, TimeUnit.NANOSECONDS);
+            offloaderStats.recordReadOffloadBytes(topicName, 100000);
+            offloaderStats.recordWriteToStorageError(topicName);
+            offloaderStats.recordWriteToStorageError(topicName);
+        }
+
+        for (String topicName : topics) {
+            Assert.assertEquals(offloaderStats.getOffloadError(topicName), 2);
+            Assert.assertEquals(offloaderStats.getOffloadBytes(topicName) , 100);
+            Assert.assertEquals((long) offloaderStats.getReadLedgerLatency(topicName).sum, 1);
+            Assert.assertEquals(offloaderStats.getReadOffloadError(topicName), 2);
+            Assert.assertEquals((long) offloaderStats.getReadOffloadIndexLatency(topicName).sum ,1000);
+            Assert.assertEquals(offloaderStats.getReadOffloadBytes(topicName), 100000);
+            Assert.assertEquals(offloaderStats.getWriteStorageError(topicName), 2);
+        }
+    }
+
+    @Test
+    public void testNamespaceLevelMetrics() throws Exception {
+        conf.setExposeTopicLevelMetricsInPrometheus(false);
+        super.baseSetup();
+
+        String ns1 = "prop/ns-abc1";
+        String ns2 = "prop/ns-abc2";
+
+        LedgerOffloaderStatsImpl offloaderStats = (LedgerOffloaderStatsImpl) pulsar.getOffloaderStats();
+
+        LedgerOffloader offloader = Mockito.mock(LedgerOffloader.class);
+        Topic topic = Mockito.mock(PersistentTopic.class);
+        CompletableFuture<Optional<Topic>> topicFuture = new CompletableFuture<>();
+        Optional<Topic> topicOptional = Optional.of(topic);
+        topicFuture.complete(topicOptional);
+        BrokerService brokerService = spy(pulsar.getBrokerService());
+        doReturn(brokerService).when(pulsar).getBrokerService();
+        Queue<String> queue = new LinkedList<>();
+        Map<String, List<String>> namespace2Topics = new HashMap<>();
+        for (int s = 0; s < 2; s++) {
+            String nameSpace = ns1;
+            if (s == 1) {
+                nameSpace = ns2;
+            }
+            namespace2Topics.put(nameSpace, new ArrayList<>());
+
+            admin.namespaces().createNamespace(nameSpace);
+            String baseTopic1 = "persistent://" + nameSpace + "/testMetrics";
+            for (int i = 0; i < 6; i++) {
+                String topicName = baseTopic1 + UUID.randomUUID();
+                List<String> topicList = namespace2Topics.get(nameSpace);
+                topicList.add(topicName);
+
+                queue.add(topicName);
+                admin.topics().createNonPartitionedTopic(topicName);
+                doReturn(topicFuture).when(brokerService).getTopicIfExists(topicName);
+                Assert.assertTrue(topic instanceof PersistentTopic);
+
+
+                ManagedLedger ledgerM = Mockito.mock(ManagedLedger.class);
+                doReturn(ledgerM).when(((PersistentTopic) topic)).getManagedLedger();
+                ManagedLedgerConfig config = Mockito.mock(ManagedLedgerConfig.class);
+                doReturn(config).when(ledgerM).getConfig();
+                doReturn(offloader).when(config).getLedgerOffloader();
+                Mockito.when(ledgerM.getName()).thenAnswer((Answer<String>) invocation -> queue.poll());
+
+                offloaderStats.recordOffloadError(topicName);
+                offloaderStats.recordOffloadBytes(topicName, 100);
+                offloaderStats.recordReadLedgerLatency(topicName, 1000, TimeUnit.NANOSECONDS);
+                offloaderStats.recordReadOffloadError(topicName);
+                offloaderStats.recordReadOffloadIndexLatency(topicName, 1000000L, TimeUnit.NANOSECONDS);
+                offloaderStats.recordReadOffloadBytes(topicName, 100000);
+                offloaderStats.recordWriteToStorageError(topicName);
+            }
+        }
+
+        for (Map.Entry<String, List<String>> entry : namespace2Topics.entrySet()) {
+            String namespace = entry.getKey();
+            List<String> topics = entry.getValue();
+            String topicName = topics.get(0);
+
+            Assert.assertTrue(offloaderStats.getOffloadError(topicName) >= 1);
+            Assert.assertTrue(offloaderStats.getOffloadBytes(topicName) >= 100);
+            Assert.assertTrue((long) offloaderStats.getReadLedgerLatency(topicName).sum >= 1);
+            Assert.assertTrue(offloaderStats.getReadOffloadError(topicName) >= 1);
+            Assert.assertTrue((long) offloaderStats.getReadOffloadIndexLatency(topicName).sum >= 1000);
+            Assert.assertTrue(offloaderStats.getReadOffloadBytes(topicName) >= 100000);
+            Assert.assertTrue(offloaderStats.getWriteStorageError(topicName) >= 1);
+        }
+    }
+
+}

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorCache.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorCache.java
@@ -30,6 +30,7 @@ import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
 import org.apache.bookkeeper.mledger.LedgerOffloaderFactory;
+import org.apache.bookkeeper.mledger.LedgerOffloaderStats;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactoryConfig;
@@ -62,6 +63,7 @@ public class PulsarConnectorCache {
 
     private final StatsProvider statsProvider;
     private OrderedScheduler offloaderScheduler;
+    private final LedgerOffloaderStats offloaderStats;
     private OffloadersCache offloadersCache = new OffloadersCache();
     private LedgerOffloader defaultOffloader;
     private Map<NamespaceName, LedgerOffloader> offloaderMap = new ConcurrentHashMap<>();
@@ -84,6 +86,14 @@ public class PulsarConnectorCache {
         pulsarConnectorConfig.getStatsProviderConfigs().forEach(clientConfiguration::setProperty);
 
         this.statsProvider.start(clientConfiguration);
+
+        this.initOffloaderScheduler(pulsarConnectorConfig.getOffloadPolices());
+
+        int period = pulsarConnectorConfig.getManagedLedgerStatsPeriodSeconds();
+        boolean exposeTopicLevelMetrics = pulsarConnectorConfig.isExposeTopicLevelMetricsInPrometheus();
+        this.offloaderStats =
+                LedgerOffloaderStats.create(pulsarConnectorConfig.isExposeManagedLedgerMetricsInPrometheus(),
+                        exposeTopicLevelMetrics, offloaderScheduler, period);
 
         this.defaultOffloader = initManagedLedgerOffloader(
                 pulsarConnectorConfig.getOffloadPolices(), pulsarConnectorConfig);
@@ -143,13 +153,10 @@ public class PulsarConnectorCache {
         return managedLedgerConfig;
     }
 
-    private synchronized OrderedScheduler getOffloaderScheduler(OffloadPoliciesImpl offloadPolicies) {
-        if (this.offloaderScheduler == null) {
+    private void initOffloaderScheduler(OffloadPoliciesImpl offloadPolicies) {
             this.offloaderScheduler = OrderedScheduler.newSchedulerBuilder()
                     .numThreads(offloadPolicies.getManagedLedgerOffloadMaxThreads())
                     .name("pulsar-offloader").build();
-        }
-        return this.offloaderScheduler;
     }
 
     private LedgerOffloader initManagedLedgerOffloader(OffloadPoliciesImpl offloadPolicies,
@@ -172,7 +179,7 @@ public class PulsarConnectorCache {
                             LedgerOffloader.METADATA_SOFTWARE_VERSION_KEY.toLowerCase(), PulsarVersion.getVersion(),
                             LedgerOffloader.METADATA_SOFTWARE_GITSHA_KEY.toLowerCase(), PulsarVersion.getGitSha()
                         ),
-                        getOffloaderScheduler(offloadPolicies));
+                        this.offloaderScheduler, this.offloaderStats);
                 } catch (IOException ioe) {
                     log.error("Failed to create offloader: ", ioe);
                     throw new RuntimeException(ioe.getMessage(), ioe.getCause());

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorConfig.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorConfig.java
@@ -69,6 +69,11 @@ public class PulsarConnectorConfig implements AutoCloseable {
     private String offloadersDirectory = "./offloaders";
     private Map<String, String> offloaderProperties = new HashMap<>();
 
+    //--- Ledger metrics ---
+    private boolean exposeTopicLevelMetricsInPrometheus = false;
+    private boolean exposeManagedLedgerMetricsInPrometheus = false;
+    private int managedLedgerStatsPeriodSeconds = 60;
+
     private PulsarAdmin pulsarAdmin;
 
     // --- Bookkeeper
@@ -276,6 +281,37 @@ public class PulsarConnectorConfig implements AutoCloseable {
     public PulsarConnectorConfig setOffloaderProperties(String offloaderProperties) throws IOException {
         this.offloaderProperties = new ObjectMapper().readValue(offloaderProperties, Map.class);
         return this;
+    }
+
+    @Config("pulsar.expose-topic-level-metrics-in-prometheus")
+    public PulsarConnectorConfig setExposeTopicLevelMetricsInPrometheus(boolean exposeTopicLevelMetricsInPrometheus) {
+        this.exposeTopicLevelMetricsInPrometheus = exposeTopicLevelMetricsInPrometheus;
+        return this;
+    }
+
+    public boolean isExposeTopicLevelMetricsInPrometheus() {
+        return exposeTopicLevelMetricsInPrometheus;
+    }
+
+    @Config("pulsar.expose-managed-ledger-metrics-in-prometheus")
+    public PulsarConnectorConfig setExposeManagedLedgerMetricsInPrometheus(
+            boolean exposeManagedLedgerMetricsInPrometheus) {
+        this.exposeManagedLedgerMetricsInPrometheus = exposeManagedLedgerMetricsInPrometheus;
+        return this;
+    }
+
+    public boolean isExposeManagedLedgerMetricsInPrometheus() {
+        return exposeManagedLedgerMetricsInPrometheus;
+    }
+
+    @Config("pulsar.managed-ledger-stats-period-seconds")
+    public PulsarConnectorConfig setManagedLedgerStatsPeriodSeconds(int managedLedgerStatsPeriodSeconds) {
+        this.managedLedgerStatsPeriodSeconds = managedLedgerStatsPeriodSeconds;
+        return this;
+    }
+
+    public int getManagedLedgerStatsPeriodSeconds() {
+        return managedLedgerStatsPeriodSeconds;
     }
 
     // --- Authentication ---

--- a/tiered-storage/file-system/src/main/java/org/apache/bookkeeper/mledger/offload/filesystem/FileSystemLedgerOffloaderFactory.java
+++ b/tiered-storage/file-system/src/main/java/org/apache/bookkeeper/mledger/offload/filesystem/FileSystemLedgerOffloaderFactory.java
@@ -20,6 +20,7 @@ package org.apache.bookkeeper.mledger.offload.filesystem;
 
 import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.mledger.LedgerOffloaderFactory;
+import org.apache.bookkeeper.mledger.LedgerOffloaderStats;
 import org.apache.bookkeeper.mledger.offload.filesystem.impl.FileSystemManagedLedgerOffloader;
 import org.apache.pulsar.common.policies.data.OffloadPoliciesImpl;
 
@@ -34,7 +35,9 @@ public class FileSystemLedgerOffloaderFactory implements LedgerOffloaderFactory<
 
     @Override
     public FileSystemManagedLedgerOffloader create(OffloadPoliciesImpl offloadPolicies,
-                                                   Map<String, String> userMetadata, OrderedScheduler scheduler) throws IOException {
-        return FileSystemManagedLedgerOffloader.create(offloadPolicies, scheduler);
+                                                   Map<String, String> userMetadata,
+                                                   OrderedScheduler scheduler,
+                                                   LedgerOffloaderStats offloaderStats) throws IOException {
+        return FileSystemManagedLedgerOffloader.create(offloadPolicies, scheduler, offloaderStats);
     }
 }

--- a/tiered-storage/file-system/src/main/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileStoreBackedReadHandleImpl.java
+++ b/tiered-storage/file-system/src/main/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileStoreBackedReadHandleImpl.java
@@ -20,6 +20,7 @@ package org.apache.bookkeeper.mledger.offload.filesystem.impl;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
+import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.api.LastConfirmedAndEntry;
 import org.apache.bookkeeper.client.api.LedgerEntries;
@@ -28,7 +29,7 @@ import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.client.impl.LedgerEntriesImpl;
 import org.apache.bookkeeper.client.impl.LedgerEntryImpl;
-
+import org.apache.bookkeeper.mledger.LedgerOffloaderStats;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.MapFile;
@@ -50,16 +51,25 @@ public class FileStoreBackedReadHandleImpl implements ReadHandle {
     private final MapFile.Reader reader;
     private final long ledgerId;
     private final LedgerMetadata ledgerMetadata;
+    private final LedgerOffloaderStats offloaderStats;
+    private final String managedLedgerName;
 
-    private FileStoreBackedReadHandleImpl(ExecutorService executor, MapFile.Reader reader, long ledgerId) throws IOException {
+    private FileStoreBackedReadHandleImpl(ExecutorService executor, MapFile.Reader reader, long ledgerId,
+                                          LedgerOffloaderStats offloaderStats,
+                                          String managedLedgerName) throws IOException {
         this.ledgerId = ledgerId;
         this.executor = executor;
         this.reader = reader;
+        this.offloaderStats = offloaderStats;
+        this.managedLedgerName = managedLedgerName;
         LongWritable key = new LongWritable();
         BytesWritable value = new BytesWritable();
         try {
             key.set(FileSystemManagedLedgerOffloader.METADATA_KEY_INDEX);
+            long startReadIndexTime = System.nanoTime();
             reader.get(key, value);
+            offloaderStats.recordReadOffloadIndexLatency(managedLedgerName,
+                    System.nanoTime() - startReadIndexTime, TimeUnit.NANOSECONDS);
             this.ledgerMetadata = parseLedgerMetadata(ledgerId, value.copyBytes());
         } catch (IOException e) {
             log.error("Fail to read LedgerMetadata for ledgerId {}",
@@ -114,7 +124,10 @@ public class FileStoreBackedReadHandleImpl implements ReadHandle {
                 key.set(nextExpectedId - 1);
                 reader.seek(key);
                 while (entriesToRead > 0) {
+                    long startReadTime = System.nanoTime();
                     reader.next(key, value);
+                    this.offloaderStats.recordReadOffloadDataLatency(managedLedgerName,
+                            System.nanoTime() - startReadTime, TimeUnit.NANOSECONDS);
                     int length = value.getLength();
                     long entryId = key.get();
                     if (entryId == nextExpectedId) {
@@ -123,6 +136,7 @@ public class FileStoreBackedReadHandleImpl implements ReadHandle {
                         buf.writeBytes(value.copyBytes());
                         entriesToRead--;
                         nextExpectedId++;
+                        this.offloaderStats.recordReadOffloadBytes(managedLedgerName, length);
                     } else if (entryId > lastEntry) {
                         log.info("Expected to read {}, but read {}, which is greater than last entry {}",
                                 nextExpectedId, entryId, lastEntry);
@@ -131,6 +145,7 @@ public class FileStoreBackedReadHandleImpl implements ReadHandle {
             }
                 promise.complete(LedgerEntriesImpl.create(entries));
             } catch (Throwable t) {
+                this.offloaderStats.recordReadOffloadError(managedLedgerName);
                 promise.completeExceptionally(t);
                 entries.forEach(LedgerEntry::close);
             }
@@ -177,7 +192,8 @@ public class FileStoreBackedReadHandleImpl implements ReadHandle {
         return promise;
     }
 
-    public static ReadHandle open(ScheduledExecutorService executor, MapFile.Reader reader, long ledgerId) throws IOException {
-            return new FileStoreBackedReadHandleImpl(executor, reader, ledgerId);
+    public static ReadHandle open(ScheduledExecutorService executor, MapFile.Reader reader, long ledgerId,
+                                  LedgerOffloaderStats offloaderStats, String managedLedgerName) throws IOException {
+        return new FileStoreBackedReadHandleImpl(executor, reader, ledgerId, offloaderStats, managedLedgerName);
     }
 }

--- a/tiered-storage/file-system/src/main/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileSystemManagedLedgerOffloader.java
+++ b/tiered-storage/file-system/src/main/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileSystemManagedLedgerOffloader.java
@@ -21,11 +21,13 @@ package org.apache.bookkeeper.mledger.offload.filesystem.impl;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import io.netty.util.Recycler;
+import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.client.api.LedgerEntry;
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
+import org.apache.bookkeeper.mledger.LedgerOffloaderStats;
 import org.apache.bookkeeper.mledger.offload.filesystem.FileSystemLedgerOffloaderFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -66,6 +68,7 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
     private static final long ENTRIES_PER_READ = 100;
     private OrderedScheduler assignmentScheduler;
     private OffloadPoliciesImpl offloadPolicies;
+    private final LedgerOffloaderStats offloaderStats;
 
     public static boolean driverSupported(String driver) {
         return DRIVER_NAMES.equals(driver);
@@ -76,11 +79,14 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
         return driverName;
     }
 
-    public static FileSystemManagedLedgerOffloader create(OffloadPoliciesImpl conf, OrderedScheduler scheduler) throws IOException {
-        return new FileSystemManagedLedgerOffloader(conf, scheduler);
+    public static FileSystemManagedLedgerOffloader create(OffloadPoliciesImpl conf,
+                                                          OrderedScheduler scheduler,
+                                                          LedgerOffloaderStats offloaderStats) throws IOException {
+        return new FileSystemManagedLedgerOffloader(conf, scheduler, offloaderStats);
     }
 
-    private FileSystemManagedLedgerOffloader(OffloadPoliciesImpl conf, OrderedScheduler scheduler) throws IOException {
+    private FileSystemManagedLedgerOffloader(OffloadPoliciesImpl conf, OrderedScheduler scheduler,
+                                             LedgerOffloaderStats offloaderStats) throws IOException {
         this.offloadPolicies = conf;
         this.configuration = new Configuration();
         if (conf.getFileSystemProfilePath() != null) {
@@ -108,10 +114,15 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
         this.assignmentScheduler = OrderedScheduler.newSchedulerBuilder()
                 .numThreads(conf.getManagedLedgerOffloadMaxThreads())
                 .name("offload-assignment").build();
+        this.offloaderStats = offloaderStats;
     }
 
     @VisibleForTesting
-    public FileSystemManagedLedgerOffloader(OffloadPoliciesImpl conf, OrderedScheduler scheduler, String testHDFSPath, String baseDir) throws IOException {
+    public FileSystemManagedLedgerOffloader(OffloadPoliciesImpl conf,
+                                            OrderedScheduler scheduler,
+                                            String testHDFSPath,
+                                            String baseDir,
+                                            LedgerOffloaderStats offloaderStats) throws IOException {
         this.offloadPolicies = conf;
         this.configuration = new Configuration();
         this.configuration.set("fs.hdfs.impl", "org.apache.hadoop.hdfs.DistributedFileSystem");
@@ -125,6 +136,7 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
         this.assignmentScheduler = OrderedScheduler.newSchedulerBuilder()
                 .numThreads(conf.getManagedLedgerOffloadMaxThreads())
                 .name("offload-assignment").build();
+        this.offloaderStats = offloaderStats;
     }
 
     @Override
@@ -141,7 +153,10 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
     @Override
     public CompletableFuture<Void> offload(ReadHandle readHandle, UUID uuid, Map<String, String> extraMetadata) {
         CompletableFuture<Void> promise = new CompletableFuture<>();
-        scheduler.chooseThread(readHandle.getId()).submit(new LedgerReader(readHandle, uuid, extraMetadata, promise, storageBasePath, configuration, assignmentScheduler, offloadPolicies.getManagedLedgerOffloadPrefetchRounds()));
+        scheduler.chooseThread(readHandle.getId()).submit(
+                new LedgerReader(readHandle, uuid, extraMetadata, promise, storageBasePath, configuration,
+                        assignmentScheduler, offloadPolicies.getManagedLedgerOffloadPrefetchRounds(),
+                        this.offloaderStats));
         return promise;
     }
 
@@ -156,9 +171,17 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
         volatile Exception fileSystemWriteException = null;
         private OrderedScheduler assignmentScheduler;
         private int managedLedgerOffloadPrefetchRounds = 1;
+        private final LedgerOffloaderStats offloaderStats;
 
-        private LedgerReader(ReadHandle readHandle, UUID uuid, Map<String, String> extraMetadata, CompletableFuture<Void> promise,
-                             String storageBasePath, Configuration configuration, OrderedScheduler assignmentScheduler, int managedLedgerOffloadPrefetchRounds) {
+        private LedgerReader(ReadHandle readHandle,
+                             UUID uuid,
+                             Map<String, String> extraMetadata,
+                             CompletableFuture<Void> promise,
+                             String storageBasePath,
+                             Configuration configuration,
+                             OrderedScheduler assignmentScheduler,
+                             int managedLedgerOffloadPrefetchRounds,
+                             LedgerOffloaderStats offloaderStats) {
             this.readHandle = readHandle;
             this.uuid = uuid;
             this.extraMetadata = extraMetadata;
@@ -167,6 +190,7 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
             this.configuration = configuration;
             this.assignmentScheduler = assignmentScheduler;
             this.managedLedgerOffloadPrefetchRounds = managedLedgerOffloadPrefetchRounds;
+            this.offloaderStats = offloaderStats;
         }
 
         @Override
@@ -177,7 +201,8 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
                 return;
             }
             long ledgerId = readHandle.getId();
-            String storagePath = getStoragePath(storageBasePath, extraMetadata.get(MANAGED_LEDGER_NAME));
+            final String topicName = extraMetadata.get(MANAGED_LEDGER_NAME);
+            String storagePath = getStoragePath(storageBasePath, topicName);
             String dataFilePath = getDataFilePath(storagePath, ledgerId, uuid);
             LongWritable key = new LongWritable();
             BytesWritable value = new BytesWritable();
@@ -199,7 +224,10 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
                 do {
                     long end = Math.min(needToOffloadFirstEntryNumber + ENTRIES_PER_READ - 1, readHandle.getLastAddConfirmed());
                     log.debug("read ledger entries. start: {}, end: {}", needToOffloadFirstEntryNumber, end);
+                    long startReadTime = System.nanoTime();
                     LedgerEntries ledgerEntriesOnce = readHandle.readAsync(needToOffloadFirstEntryNumber, end).get();
+                    long cost = System.nanoTime() - startReadTime;
+                    this.offloaderStats.recordReadLedgerLatency(topicName, cost, TimeUnit.NANOSECONDS);
                     semaphore.acquire();
                     countDownLatch = new CountDownLatch(1);
                     assignmentScheduler.chooseThread(ledgerId).submit(FileSystemWriter.create(ledgerEntriesOnce, dataWriter, semaphore,
@@ -213,11 +241,12 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
                 IOUtils.closeStream(dataWriter);
                 promise.complete(null);
             } catch (Exception e) {
-                log.error("Exception when get CompletableFuture<LedgerEntries> : ManagerLedgerName: {}, " +
-                        "LedgerId: {}, UUID: {} ", extraMetadata.get(MANAGED_LEDGER_NAME), ledgerId, uuid, e);
+                log.error("Exception when get CompletableFuture<LedgerEntries> : ManagerLedgerName: {}, "
+                        + "LedgerId: {}, UUID: {} ", topicName, ledgerId, uuid, e);
                 if (e instanceof InterruptedException) {
                     Thread.currentThread().interrupt();
                 }
+                this.offloaderStats.recordOffloadError(topicName);
                 promise.completeExceptionally(e);
             }
         }
@@ -273,6 +302,7 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
 
         @Override
         public void run() {
+            String managedLedgerName = ledgerReader.extraMetadata.get(MANAGED_LEDGER_NAME);
             if (ledgerReader.fileSystemWriteException == null) {
                 Iterator<LedgerEntry> iterator = ledgerEntriesOnce.iterator();
                 while (iterator.hasNext()) {
@@ -284,9 +314,11 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
                         dataWriter.append(key, value);
                     } catch (IOException e) {
                         ledgerReader.fileSystemWriteException = e;
+                        ledgerReader.offloaderStats.recordWriteToStorageError(managedLedgerName);
                         break;
                     }
                     haveOffloadEntryNumber.incrementAndGet();
+                    ledgerReader.offloaderStats.recordOffloadBytes(managedLedgerName, entry.getLength());
                 }
             }
             countDownLatch.countDown();
@@ -299,17 +331,19 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
     @Override
     public CompletableFuture<ReadHandle> readOffloaded(long ledgerId, UUID uuid, Map<String, String> offloadDriverMetadata) {
 
+        final String ledgerName = offloadDriverMetadata.get(MANAGED_LEDGER_NAME);
         CompletableFuture<ReadHandle> promise = new CompletableFuture<>();
-        String storagePath = getStoragePath(storageBasePath, offloadDriverMetadata.get(MANAGED_LEDGER_NAME));
+        String storagePath = getStoragePath(storageBasePath, ledgerName);
         String dataFilePath = getDataFilePath(storagePath, ledgerId, uuid);
         scheduler.chooseThread(ledgerId).submit(() -> {
             try {
                 MapFile.Reader reader = new MapFile.Reader(new Path(dataFilePath),
                         configuration);
-                promise.complete(FileStoreBackedReadHandleImpl.open(scheduler.chooseThread(ledgerId), reader, ledgerId));
+                promise.complete(FileStoreBackedReadHandleImpl.open(
+                        scheduler.chooseThread(ledgerId), reader, ledgerId, this.offloaderStats, ledgerName));
             } catch (Throwable t) {
-                log.error("Failed to open FileStoreBackedReadHandleImpl: ManagerLedgerName: {}, " +
-                        "LegerId: {}, UUID: {}", offloadDriverMetadata.get(MANAGED_LEDGER_NAME), ledgerId, uuid, t);
+                log.error("Failed to open FileStoreBackedReadHandleImpl: ManagerLedgerName: {}, "
+                        + "LegerId: {}, UUID: {}", ledgerName, ledgerId, uuid, t);
                 promise.completeExceptionally(t);
             }
         });
@@ -326,7 +360,8 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
 
     @Override
     public CompletableFuture<Void> deleteOffloaded(long ledgerId, UUID uid, Map<String, String> offloadDriverMetadata) {
-        String storagePath = getStoragePath(storageBasePath, offloadDriverMetadata.get(MANAGED_LEDGER_NAME));
+        String ledgerName = offloadDriverMetadata.get(MANAGED_LEDGER_NAME);
+        String storagePath = getStoragePath(storageBasePath, ledgerName);
         String dataFilePath = getDataFilePath(storagePath, ledgerId, uid);
         CompletableFuture<Void> promise = new CompletableFuture<>();
         try {
@@ -336,7 +371,8 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
             log.error("Failed to delete Offloaded: ", e);
             promise.completeExceptionally(e);
         }
-        return promise;
+        return promise.whenComplete((__, t) ->
+                this.offloaderStats.recordDeleteOffloadOps(ledgerName, t == null));
     }
 
     @Override

--- a/tiered-storage/file-system/src/test/java/org/apache/bookkeeper/mledger/offload/filesystem/FileStoreTestBase.java
+++ b/tiered-storage/file-system/src/test/java/org/apache/bookkeeper/mledger/offload/filesystem/FileStoreTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.bookkeeper.mledger.offload.filesystem;
 
 import org.apache.bookkeeper.common.util.OrderedScheduler;
+import org.apache.bookkeeper.mledger.LedgerOffloaderStats;
 import org.apache.bookkeeper.mledger.offload.filesystem.impl.FileSystemManagedLedgerOffloader;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
@@ -30,6 +31,7 @@ import org.testng.annotations.BeforeMethod;
 import java.io.File;
 import java.nio.file.Files;
 import java.util.Properties;
+import java.util.concurrent.Executors;
 
 public abstract class FileStoreTestBase {
     protected FileSystemManagedLedgerOffloader fileSystemManagedLedgerOffloader;
@@ -37,6 +39,7 @@ public abstract class FileStoreTestBase {
     protected final String basePath = "pulsar";
     private MiniDFSCluster hdfsCluster;
     private String hdfsURI;
+    protected LedgerOffloaderStats offloaderStats;
 
     @BeforeMethod(alwaysRun = true)
     public void start() throws Exception {
@@ -48,9 +51,10 @@ public abstract class FileStoreTestBase {
 
         hdfsURI = "hdfs://localhost:"+ hdfsCluster.getNameNodePort() + "/";
         Properties properties = new Properties();
+        this.offloaderStats = LedgerOffloaderStats.create(true, true, Executors.newScheduledThreadPool(1), 60);
         fileSystemManagedLedgerOffloader = new FileSystemManagedLedgerOffloader(
                 OffloadPoliciesImpl.create(properties),
-                scheduler, hdfsURI, basePath);
+                scheduler, hdfsURI, basePath, offloaderStats);
     }
 
     @AfterMethod(alwaysRun = true)

--- a/tiered-storage/file-system/src/test/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileSystemManagedLedgerOffloaderTest.java
+++ b/tiered-storage/file-system/src/test/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileSystemManagedLedgerOffloaderTest.java
@@ -28,16 +28,17 @@ import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.client.api.LedgerEntry;
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
+import org.apache.bookkeeper.mledger.impl.LedgerOffloaderStatsImpl;
 import org.apache.bookkeeper.mledger.offload.filesystem.FileStoreTestBase;
 import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.testng.annotations.BeforeMethod;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.MockZooKeeper;
 import org.apache.zookeeper.data.ACL;
 import org.testng.annotations.Test;
-
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -53,7 +54,7 @@ import static org.testng.Assert.assertTrue;
 
 public class FileSystemManagedLedgerOffloaderTest extends FileStoreTestBase {
     private final PulsarMockBookKeeper bk;
-    private String topic = "public/default/persistent/testOffload";
+    private String topic = "public/default/testOffload";
     private String storagePath = createStoragePath(topic);
     private LedgerHandle lh;
     private ReadHandle toWrite;
@@ -82,6 +83,12 @@ public class FileSystemManagedLedgerOffloaderTest extends FileStoreTestBase {
 
         return bk.newOpenLedgerOp().withLedgerId(lh.getId())
                 .withPassword("foobar".getBytes()).withDigestType(DigestType.CRC32).execute().get();
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    @Override
+    public void start() throws Exception {
+        super.start();
     }
 
     @Test
@@ -117,6 +124,31 @@ public class FileSystemManagedLedgerOffloaderTest extends FileStoreTestBase {
             assertEquals(toWriteEntry.getLength(), toTestEntry.getLength());
             assertEquals(toWriteEntry.getEntryBuffer(), toTestEntry.getEntryBuffer());
         }
+    }
+
+    @Test
+    public void testOffloadAndReadMetrics() throws Exception {
+        LedgerOffloader offloader = fileSystemManagedLedgerOffloader;
+        UUID uuid = UUID.randomUUID();
+        offloader.offload(toWrite, uuid, map).get();
+
+        LedgerOffloaderStatsImpl offloaderStats = (LedgerOffloaderStatsImpl) this.offloaderStats;
+        assertTrue(offloaderStats.getOffloadError(topic) == 0);
+        assertTrue(offloaderStats.getOffloadBytes(topic) > 0);
+        assertTrue(offloaderStats.getReadLedgerLatency(topic).count > 0);
+        assertTrue(offloaderStats.getWriteStorageError(topic) == 0);
+
+        ReadHandle toTest = offloader.readOffloaded(toWrite.getId(), uuid, map).get();
+        LedgerEntries toTestEntries = toTest.read(0, numberOfEntries - 1);
+        Iterator<LedgerEntry> toTestIter = toTestEntries.iterator();
+        while (toTestIter.hasNext()) {
+            LedgerEntry toTestEntry = toTestIter.next();
+        }
+
+        assertTrue(offloaderStats.getReadOffloadError(topic) == 0);
+        assertTrue(offloaderStats.getReadOffloadBytes(topic) > 0);
+        assertTrue(offloaderStats.getReadOffloadDataLatency(topic).count > 0);
+        assertTrue(offloaderStats.getReadOffloadIndexLatency(topic).count > 0);
     }
 
     @Test

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/JCloudLedgerOffloaderFactory.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/JCloudLedgerOffloaderFactory.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.Map;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.mledger.LedgerOffloaderFactory;
+import org.apache.bookkeeper.mledger.LedgerOffloaderStats;
 import org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreManagedLedgerOffloader;
 import org.apache.bookkeeper.mledger.offload.jcloud.provider.JCloudBlobStoreProvider;
 import org.apache.bookkeeper.mledger.offload.jcloud.provider.TieredStorageConfiguration;
@@ -45,10 +46,11 @@ public class JCloudLedgerOffloaderFactory implements LedgerOffloaderFactory<Blob
 
     @Override
     public BlobStoreManagedLedgerOffloader create(OffloadPoliciesImpl offloadPolicies, Map<String, String> userMetadata,
-                                                  OrderedScheduler scheduler) throws IOException {
+                                                  OrderedScheduler scheduler,
+                                                  LedgerOffloaderStats offloaderStats) throws IOException {
         
         TieredStorageConfiguration config =
                 TieredStorageConfiguration.create(offloadPolicies.toProperties());
-        return BlobStoreManagedLedgerOffloader.create(config, userMetadata, scheduler);
+        return BlobStoreManagedLedgerOffloader.create(config, userMetadata, scheduler, offloaderStats);
     }
 }

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
-
+import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.api.LastConfirmedAndEntry;
 import org.apache.bookkeeper.client.api.LedgerEntries;
@@ -36,6 +36,7 @@ import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.client.impl.LedgerEntriesImpl;
 import org.apache.bookkeeper.client.impl.LedgerEntryImpl;
+import org.apache.bookkeeper.mledger.LedgerOffloaderStats;
 import org.apache.bookkeeper.mledger.offload.jcloud.BackedInputStream;
 import org.apache.bookkeeper.mledger.offload.jcloud.OffloadIndexBlock;
 import org.apache.bookkeeper.mledger.offload.jcloud.OffloadIndexBlockBuilder;
@@ -63,8 +64,7 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
     private State state = null;
 
     private BlobStoreBackedReadHandleImpl(long ledgerId, OffloadIndexBlock index,
-                                          BackedInputStream inputStream,
-                                          ExecutorService executor) {
+                                          BackedInputStream inputStream, ExecutorService executor) {
         this.ledgerId = ledgerId;
         this.index = index;
         this.inputStream = inputStream;
@@ -222,7 +222,8 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
     public static ReadHandle open(ScheduledExecutorService executor,
                                   BlobStore blobStore, String bucket, String key, String indexKey,
                                   VersionCheck versionCheck,
-                                  long ledgerId, int readBufferSize)
+                                  long ledgerId, int readBufferSize,
+                                  LedgerOffloaderStats offloaderStats, String managedLedgerName)
             throws IOException {
         int retryCount = 3;
         OffloadIndexBlock index = null;
@@ -233,7 +234,10 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
         // If we use a backoff to control the retry, it will introduce a concurrent operation.
         // We don't want to make it complicated, because in the most of case it shouldn't in the retry loop.
         while (retryCount-- > 0) {
+            long readIndexStartTime = System.nanoTime();
             Blob blob = blobStore.getBlob(bucket, indexKey);
+            offloaderStats.recordReadOffloadIndexLatency(managedLedgerName,
+                    System.nanoTime() - readIndexStartTime, TimeUnit.NANOSECONDS);
             versionCheck.check(indexKey, blob);
             OffloadIndexBlockBuilder indexBuilder = OffloadIndexBlockBuilder.create();
             try (InputStream payLoadStream = blob.getPayload().openStream()) {
@@ -253,9 +257,7 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
         }
 
         BackedInputStream inputStream = new BlobStoreBackedInputStreamImpl(blobStore, bucket, key,
-                versionCheck,
-                index.getDataObjectLength(),
-                readBufferSize);
+                versionCheck, index.getDataObjectLength(), readBufferSize, offloaderStats, managedLedgerName);
 
         return new BlobStoreBackedReadHandleImpl(ledgerId, index, inputStream, executor);
     }

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloader.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloader.java
@@ -45,6 +45,7 @@ import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
 import org.apache.bookkeeper.mledger.LedgerOffloader.OffloadHandle.OfferEntryResult;
+import org.apache.bookkeeper.mledger.LedgerOffloaderStats;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.OffloadedLedgerMetadata;
@@ -91,6 +92,8 @@ import org.jclouds.io.payloads.InputStreamPayload;
 @Slf4j
 public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
 
+    private static final String MANAGED_LEDGER_NAME = "ManagedLedgerName";
+
     private final OrderedScheduler scheduler;
     private final TieredStorageConfiguration config;
     private final Location writeLocation;
@@ -113,16 +116,18 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
     private final int streamingBlockSize;
     private volatile ManagedLedger ml;
     private OffloadIndexBlockV2Builder streamingIndexBuilder;
+    private final LedgerOffloaderStats offloaderStats;
 
     public static BlobStoreManagedLedgerOffloader create(TieredStorageConfiguration config,
                                                          Map<String, String> userMetadata,
-                                                         OrderedScheduler scheduler) throws IOException {
+                                                         OrderedScheduler scheduler,
+                                                         LedgerOffloaderStats offloaderStats) throws IOException {
 
-        return new BlobStoreManagedLedgerOffloader(config, scheduler, userMetadata);
+        return new BlobStoreManagedLedgerOffloader(config, scheduler, userMetadata, offloaderStats);
     }
 
     BlobStoreManagedLedgerOffloader(TieredStorageConfiguration config, OrderedScheduler scheduler,
-                                    Map<String, String> userMetadata) {
+                                    Map<String, String> userMetadata, LedgerOffloaderStats offloaderStats) {
 
         this.scheduler = scheduler;
         this.userMetadata = userMetadata;
@@ -149,6 +154,7 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
                 config.getBucket(), config.getRegion());
 
         blobStores.putIfAbsent(config.getBlobStoreLocation(), config.getBlobStore());
+        this.offloaderStats = offloaderStats;
         log.info("The ledger offloader was created.");
     }
 
@@ -170,6 +176,7 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
     public CompletableFuture<Void> offload(ReadHandle readHandle,
                                            UUID uuid,
                                            Map<String, String> extraMetadata) {
+        final String topicName = extraMetadata.get(MANAGED_LEDGER_NAME);
         final BlobStore writeBlobStore = blobStores.get(config.getBlobStoreLocation());
         log.info("offload {} uuid {} extraMetadata {} to {} {}", readHandle.getId(), uuid, extraMetadata,
                 config.getBlobStoreLocation(), writeBlobStore);
@@ -212,13 +219,14 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
             try {
                 long startEntry = 0;
                 int partId = 1;
+                long start = System.nanoTime();
                 long entryBytesWritten = 0;
                 while (startEntry <= readHandle.getLastAddConfirmed()) {
                     int blockSize = BlockAwareSegmentInputStreamImpl
                         .calculateBlockSize(config.getMaxBlockSizeInBytes(), readHandle, startEntry, entryBytesWritten);
 
                     try (BlockAwareSegmentInputStream blockStream = new BlockAwareSegmentInputStreamImpl(
-                        readHandle, startEntry, blockSize)) {
+                            readHandle, startEntry, blockSize, this.offloaderStats, topicName)) {
 
                         Payload partPayload = Payloads.newInputStreamPayload(blockStream);
                         partPayload.getContentMetadata().setContentLength((long) blockSize);
@@ -237,6 +245,7 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
                         }
                         entryBytesWritten += blockStream.getBlockEntryBytesCount();
                         partId++;
+                        this.offloaderStats.recordOffloadBytes(topicName, blockStream.getBlockEntryBytesCount());
                     }
 
                     dataObjectLength += blockSize;
@@ -254,6 +263,8 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
                     log.error("Failed abortMultipartUpload in bucket - {} with key - {}, uploadId - {}.",
                             config.getBucket(), dataBlockKey, mpu.id(), throwable);
                 }
+                this.offloaderStats.recordWriteToStorageError(topicName);
+                this.offloaderStats.recordOffloadError(topicName);
                 promise.completeExceptionally(t);
                 return;
             }
@@ -277,7 +288,6 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
                         .payload(indexPayload)
                         .contentLength((long) indexStream.getStreamSize())
                     .build();
-
                 writeBlobStore.putBlob(config.getBucket(), blob);
                 promise.complete(null);
             } catch (Throwable t) {
@@ -287,6 +297,9 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
                     log.error("Failed deleteObject in bucket - {} with key - {}.",
                             config.getBucket(), dataBlockKey, throwable);
                 }
+
+                this.offloaderStats.recordWriteToStorageError(topicName);
+                this.offloaderStats.recordOffloadError(topicName);
                 promise.completeExceptionally(t);
                 return;
             }
@@ -532,7 +545,8 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
                         readBlobstore,
                         readBucket, key, indexKey,
                         DataBlockUtils.VERSION_CHECK,
-                        ledgerId, config.getReadBufferSizeInBytes()));
+                        ledgerId, config.getReadBufferSizeInBytes(),
+                        this.offloaderStats, offloadDriverMetadata.get(MANAGED_LEDGER_NAME)));
             } catch (Throwable t) {
                 log.error("Failed readOffloaded: ", t);
                 promise.completeExceptionally(t);
@@ -565,7 +579,8 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
                         readBlobstore,
                         readBucket, keys, indexKeys,
                         DataBlockUtils.VERSION_CHECK,
-                        ledgerId, config.getReadBufferSizeInBytes()));
+                        ledgerId, config.getReadBufferSizeInBytes(),
+                        this.offloaderStats, offloadDriverMetadata.get(MANAGED_LEDGER_NAME)));
             } catch (Throwable t) {
                 log.error("Failed readOffloaded: ", t);
                 promise.completeExceptionally(t);
@@ -599,7 +614,11 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
             }
         });
 
-        return promise;
+        return promise.whenComplete((__, t) -> {
+            if (null != this.ml) {
+                this.offloaderStats.recordDeleteOffloadOps(this.ml.getName(), t == null);
+            }
+        });
     }
 
     @Override
@@ -621,7 +640,8 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
             }
         });
 
-        return promise;
+        return promise.whenComplete((__, t) ->
+                this.offloaderStats.recordDeleteOffloadOps(this.ml.getName(), t == null));
     }
 
     @Override

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderStreamingTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderStreamingTest.java
@@ -34,6 +34,7 @@ import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
 import org.apache.bookkeeper.mledger.LedgerOffloader.OffloadHandle;
+import org.apache.bookkeeper.mledger.LedgerOffloaderStats;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.impl.EntryImpl;
 import org.apache.bookkeeper.mledger.offload.jcloud.provider.JCloudBlobStoreProvider;
@@ -52,6 +53,7 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
     private static final Logger log = LoggerFactory.getLogger(BlobStoreManagedLedgerOffloaderStreamingTest.class);
     private TieredStorageConfiguration mockedConfig;
     private static final Random random = new Random();
+    private final LedgerOffloaderStats offloaderStats;
 
     BlobStoreManagedLedgerOffloaderStreamingTest() throws Exception {
         super();
@@ -60,6 +62,7 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
         assertNotNull(provider);
         provider.validate(config);
         blobStore = provider.getBlobStore(config);
+        this.offloaderStats = LedgerOffloaderStats.create(false, false, null, 0);
     }
 
     private BlobStoreManagedLedgerOffloader getOffloader(Map<String, String> additionalConfig) throws IOException {
@@ -76,7 +79,7 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
         mockedConfig = mock(TieredStorageConfiguration.class, delegatesTo(getConfiguration(bucket, additionalConfig)));
         Mockito.doReturn(blobStore).when(mockedConfig).getBlobStore(); // Use the REAL blobStore
         BlobStoreManagedLedgerOffloader offloader = BlobStoreManagedLedgerOffloader
-                .create(mockedConfig, new HashMap<String, String>(), scheduler);
+                .create(mockedConfig, new HashMap<String, String>(), scheduler, this.offloaderStats);
         return offloader;
     }
 
@@ -85,7 +88,7 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
         mockedConfig = mock(TieredStorageConfiguration.class, delegatesTo(getConfiguration(bucket, additionalConfig)));
         Mockito.doReturn(mockedBlobStore).when(mockedConfig).getBlobStore();
         BlobStoreManagedLedgerOffloader offloader = BlobStoreManagedLedgerOffloader
-                .create(mockedConfig, new HashMap<String, String>(), scheduler);
+                .create(mockedConfig, new HashMap<String, String>(), scheduler, this.offloaderStats);
         return offloader;
     }
 


### PR DESCRIPTION
### Motivation
Currently, there is no offload metrics for tiered storage, so it is very hard for us to debug the performance issues. For example , we can not find why offload is slow or why read offload is slow. For above reasons. we need to add some offload metrics for monitoring.

### Modifications
Add metrics during offload procedure and read offload data procedure. Including offloadTime, offloadError, offloadRate, readLedgerLatency, writeStoreLatency, writeStoreError, readOffloadIndexLatency, readOffloadDataLatency, readOffloadRate, readOffloadError.

(cherry picked from commit 732049fc6ca1beb046deb43057be2b130736fbca)

As pre-req:

    [ManagedLedger] Make 'StatsPeroidSeconds' configurable (#11584)

    Make `StatsPeroidSeconds` configurable.

    - Move ‘StatsPeriodSeconds’ from ManagedLedgerFactoryImpl to ManagedLedgerFactoryConfig.
    - Add config `managedLedgerStatsPeriodSeconds`.

    (cherry picked from commit ddeae659be1f80f428fdb8c82c7a9a0c931c81fe)