### PR TITLE
[fix][connector] KCA: use reflection to get pulsar-client impl classes

### DIFF
--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
@@ -326,7 +326,7 @@ public class KafkaConnectSink implements Sink<GenericObject> {
             // for the messages from the same batch.
             // Special case for FunctionCommon.getSequenceId()
             if (maxBatchBitsForOffset > 0) {
-                MessageSequenceRef messageSequenceRef = getMessageBatchIndexWithReflection(messageId);
+                BatchMessageSequenceRef messageSequenceRef = getMessageSequenceRefForBatchMessage(messageId);
                 if (messageSequenceRef != null) {
                     long ledgerId = messageSequenceRef.getLedgerId();
                     long entryId = messageSequenceRef.getEntryId();
@@ -362,13 +362,14 @@ public class KafkaConnectSink implements Sink<GenericObject> {
 
     @Getter
     @AllArgsConstructor
-    private static class MessageSequenceRef {
+    static class BatchMessageSequenceRef {
         long ledgerId;
         long entryId;
         int batchIdx;
     }
 
-    private static MessageSequenceRef getMessageBatchIndexWithReflection(MessageId messageId) {
+    @VisibleForTesting
+    static BatchMessageSequenceRef getMessageSequenceRefForBatchMessage(MessageId messageId) {
         long ledgerId;
         long entryId;
         int batchIdx;
@@ -397,7 +398,7 @@ public class KafkaConnectSink implements Sink<GenericObject> {
             throw new RuntimeException(ex);
         }
 
-        return new MessageSequenceRef(ledgerId, entryId, batchIdx);
+        return new BatchMessageSequenceRef(ledgerId, entryId, batchIdx);
     }
 
     @SuppressWarnings("rawtypes")

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
@@ -368,7 +368,7 @@ public class KafkaConnectSink implements Sink<GenericObject> {
         int batchIdx;
     }
 
-    private MessageSequenceRef getMessageBatchIndexWithReflection(MessageId messageId) {
+    private static MessageSequenceRef getMessageBatchIndexWithReflection(MessageId messageId) {
         long ledgerId;
         long entryId;
         int batchIdx;

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
@@ -26,6 +26,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,6 +40,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
@@ -52,9 +55,6 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.schema.GenericObject;
 import org.apache.pulsar.client.api.schema.KeyValueSchema;
-import org.apache.pulsar.client.impl.BatchMessageIdImpl;
-import org.apache.pulsar.client.impl.MessageIdImpl;
-import org.apache.pulsar.client.impl.TopicMessageIdImpl;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
@@ -322,45 +322,82 @@ public class KafkaConnectSink implements Sink<GenericObject> {
             }
 
             MessageId messageId = sourceRecord.getMessage().get().getMessageId();
-            MessageIdImpl msgId = (MessageIdImpl) ((messageId instanceof TopicMessageIdImpl)
-                    ? ((TopicMessageIdImpl) messageId).getInnerMessageId()
-                    : messageId);
-
             // sourceRecord.getRecordSequence() is not unique
             // for the messages from the same batch.
             // Special case for FunctionCommon.getSequenceId()
-            if (maxBatchBitsForOffset > 0 && msgId instanceof BatchMessageIdImpl) {
-                BatchMessageIdImpl batchMsgId = (BatchMessageIdImpl) msgId;
-                long ledgerId = batchMsgId.getLedgerId();
-                long entryId = batchMsgId.getEntryId();
+            if (maxBatchBitsForOffset > 0) {
+                MessageSequenceRef messageSequenceRef = getMessageBatchIndexWithReflection(messageId);
+                if (messageSequenceRef != null) {
+                    long ledgerId = messageSequenceRef.getLedgerId();
+                    long entryId = messageSequenceRef.getEntryId();
 
-                if (entryId > (1 << (28 - maxBatchBitsForOffset))) {
-                    log.error("EntryId of the message {} over max, chance of duplicate offsets", entryId);
+                    if (entryId > (1 << (28 - maxBatchBitsForOffset))) {
+                        log.error("EntryId of the message {} over max, chance of duplicate offsets", entryId);
+                    }
+                    int batchIdx = messageSequenceRef.getBatchIdx();
+
+                    if (batchIdx < 0) {
+                        // Should not happen unless data corruption
+                        log.error("BatchIdx {} of the message is negative, chance of duplicate offsets", batchIdx);
+                        batchIdx = 0;
+                    }
+                    if (batchIdx > (1 << maxBatchBitsForOffset)) {
+                        log.error("BatchIdx of the message {} over max, chance of duplicate offsets", batchIdx);
+                    }
+                    // Combine entry id and batchIdx
+                    entryId = (entryId << maxBatchBitsForOffset) | batchIdx;
+
+                    // The same as FunctionCommon.getSequenceId():
+                    // Combine ledger id and entry id to form offset
+                    // Use less than 32 bits to represent entry id since it will get
+                    // rolled over way before overflowing the max int range
+                    long offset = (ledgerId << 28) | entryId;
+                    return offset;
                 }
-
-                int batchIdx = batchMsgId.getBatchIndex();
-
-                if (batchIdx < 0) {
-                    // Should not happen unless data corruption
-                    log.error("BatchIdx {} of the message is negative, chance of duplicate offsets", batchIdx);
-                    batchIdx = 0;
-                }
-                if (batchIdx > (1 << maxBatchBitsForOffset)) {
-                    log.error("BatchIdx of the message {} over max, chance of duplicate offsets", batchIdx);
-                }
-                // Combine entry id and batchIdx
-                entryId = (entryId << maxBatchBitsForOffset) | batchIdx;
-
-                // The same as FunctionCommon.getSequenceId():
-                // Combine ledger id and entry id to form offset
-                // Use less than 32 bits to represent entry id since it will get
-                // rolled over way before overflowing the max int range
-                long offset = (ledgerId << 28) | entryId;
-                return offset;
             }
         }
         return sourceRecord.getRecordSequence()
                 .orElse(-1L);
+    }
+
+    @Getter
+    @AllArgsConstructor
+    private static class MessageSequenceRef {
+        long ledgerId;
+        long entryId;
+        int batchIdx;
+    }
+
+    private MessageSequenceRef getMessageBatchIndexWithReflection(MessageId messageId) {
+        long ledgerId;
+        long entryId;
+        int batchIdx;
+        try {
+            try {
+                messageId = (MessageId) messageId.getClass().getDeclaredMethod("getInnerMessageId").invoke(messageId);
+            } catch (NoSuchMethodException noSuchMethodException) {
+                // not a TopicMessageIdImpl
+            }
+
+            try {
+                batchIdx = (int) messageId.getClass().getDeclaredMethod("getBatchIndex").invoke(messageId);
+            } catch (NoSuchMethodException noSuchMethodException) {
+                // not a BatchMessageIdImpl, returning null to use the standard sequenceId
+                return null;
+            }
+
+            // if getBatchIndex exists it means messageId is a 'BatchMessageIdImpl' instance.
+            final Class<?> messageIdImplClass = messageId.getClass().getSuperclass();
+
+            ledgerId = (long) messageIdImplClass.getDeclaredMethod("getLedgerId").invoke(messageId);
+            entryId = (long) messageIdImplClass.getDeclaredMethod("getEntryId").invoke(messageId);
+        } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException ex) {
+            log.error("Unexpected error while retrieving sequenceId, messageId class: {}, error: {}",
+                    messageId.getClass().getName(), ex.getMessage(), ex);
+            throw new RuntimeException(ex);
+        }
+
+        return new MessageSequenceRef(ledgerId, entryId, batchIdx);
     }
 
     @SuppressWarnings("rawtypes")

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
@@ -50,6 +50,7 @@ import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.MessageImpl;
+import org.apache.pulsar.client.impl.TopicMessageIdImpl;
 import org.apache.pulsar.client.impl.schema.AvroSchema;
 import org.apache.pulsar.client.impl.schema.JSONSchema;
 import org.apache.pulsar.client.impl.schema.generic.GenericAvroRecord;
@@ -99,6 +100,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -1323,5 +1325,36 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
         rec.put("structMap", map);
 
         return rec;
+    }
+
+    @Test
+    public void testGetMessageSequenceRefForBatchMessage() throws Exception {
+        long ledgerId = 123L;
+        long entryId = Long.MAX_VALUE;
+        int batchIdx = 16;
+
+        KafkaConnectSink.BatchMessageSequenceRef ref = KafkaConnectSink
+                .getMessageSequenceRefForBatchMessage(new MessageIdImpl(ledgerId, entryId, 0));
+        assertNull(ref);
+
+        ref = KafkaConnectSink.getMessageSequenceRefForBatchMessage(
+                        new TopicMessageIdImpl("topic-0", "topic", new MessageIdImpl(ledgerId, entryId, 0))
+        );
+        assertNull(ref);
+
+        ref = KafkaConnectSink.getMessageSequenceRefForBatchMessage(
+                new BatchMessageIdImpl(ledgerId, entryId, 0, batchIdx));
+
+        assertEquals(ref.getLedgerId(), ledgerId);
+        assertEquals(ref.getEntryId(), entryId);
+        assertEquals(ref.getBatchIdx(), batchIdx);
+
+        ref = KafkaConnectSink.getMessageSequenceRefForBatchMessage(
+                new TopicMessageIdImpl("topic-0", "topic", new BatchMessageIdImpl(ledgerId, entryId, 0, batchIdx))
+        );
+
+        assertEquals(ref.getLedgerId(), ledgerId);
+        assertEquals(ref.getEntryId(), entryId);
+        assertEquals(ref.getBatchIdx(), batchIdx);
     }
 }


### PR DESCRIPTION
### Motivation
With the [latest changes to KCA](https://github.com/datastax/pulsar/commit/625da657cf509e547d934cf3b825786866f0386d) now you get this error if the message is batched:

```
java.lang.ClassCastException: class org.apache.pulsar.client.impl.BatchMessageIdImpl cannot be cast to class org.apache.pulsar.client.impl.MessageIdImpl (org.apache.pulsar.client.impl.BatchMessageIdImpl is in unnamed module of loader java.net.URLClassLoader @2ff4acd0; org.apache.pulsar.client.impl.MessageIdImpl is in unnamed module of loader org.apache.pulsar.common.nar.NarClassLoader @6ff415ad)
	at org.apache.pulsar.io.kafka.connect.KafkaConnectSink.getMessageOffset(KafkaConnectSink.java:327) ~[pulsar-io-kafka-connect-adaptor-2.8.3.1.0.13.jar:2.8.3.1.0.13]
	at org.apache.pulsar.io.kafka.connect.KafkaConnectSink.toSinkRecord(KafkaConnectSink.java:408) ~[pulsar-io-kafka-connect-adaptor-2.8.3.1.0.13.jar:2.8.3.1.0.13]
	at org.apache.pulsar.io.kafka.connect.KafkaConnectSink.write(KafkaConnectSink.java:121) [pulsar-io-kafka-connect-adaptor-2.8.3.1.0.13.jar:2.8.3.1.0.13]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.sendOutputMessage(JavaInstanceRunnable.java:368) [com.datastax.oss-pulsar-functions-instance-2.8.3.1.0.13-SNAPSHOT.jar:2.8.3.1.0.13-SNAPSHOT]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.handleResult(JavaInstanceRunnable.java:351) [com.datastax.oss-pulsar-functions-instance-2.8.3.1.0.13-SNAPSHOT.jar:2.8.3.1.0.13-SNAPSHOT]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.run(JavaInstanceRunnable.java:300) [com.datastax.oss-pulsar-functions-instance-2.8.3.1.0.13-SNAPSHOT.jar:2.8.3.1.0.13-SNAPSHOT]
```

The root problem is that connectors should not bundle the Pulsar client impl because it's provided at runtime by the Java Functions framework.

### Modifications

* Use reflection to get the custom sequenceId 
