### PR TITLE
Offloader: improve reading Shared subscriptions using a temporary in memory index

### DIFF
--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/BackedInputStream.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/BackedInputStream.java
@@ -27,4 +27,5 @@ import java.io.InputStream;
 public abstract class BackedInputStream extends InputStream {
     public abstract void seek(long position);
     public abstract void seekForward(long position) throws IOException;
+    public abstract long getCurrentPosition();
 }

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedInputStreamImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedInputStreamImpl.java
@@ -85,7 +85,10 @@ public class BlobStoreBackedInputStreamImpl extends BackedInputStream {
             long startRange = cursor;
             long endRange = Math.min(cursor + bufferSize - 1,
                                      objectLen - 1);
-
+            if (log.isDebugEnabled()) {
+                log.info("refillBufferIfNeeded {} - {} ({} bytes to fill)",
+                        startRange, endRange, (endRange - startRange));
+            }
             try {
                 long startReadTime = System.nanoTime();
                 Blob blob = blobStore.getBlob(bucket, key, new GetOptions().range(startRange, endRange));
@@ -149,6 +152,7 @@ public class BlobStoreBackedInputStreamImpl extends BackedInputStream {
             long newIndex = position - bufferOffsetStart;
             buffer.readerIndex((int) newIndex);
         } else {
+            bufferOffsetStart = bufferOffsetEnd = -1;
             this.cursor = position;
             buffer.clear();
         }
@@ -162,6 +166,13 @@ public class BlobStoreBackedInputStreamImpl extends BackedInputStream {
             throw new IOException(String.format("Error seeking, new position %d < current position %d",
                                                 position, cursor));
         }
+    }
+
+    public long getCurrentPosition() {
+        if (bufferOffsetStart != -1) {
+            return bufferOffsetStart + buffer.readerIndex();
+        }
+        return cursor + buffer.readerIndex();
     }
 
     @Override

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -55,6 +57,8 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
     private final BackedInputStream inputStream;
     private final DataInputStream dataStream;
     private final ExecutorService executor;
+    // this Map is accessed only by one thread
+    private final Map<Long, Long> entryOffsets = new TreeMap<>();
 
     enum State {
         Opened,
@@ -90,6 +94,7 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
                 try {
                     index.close();
                     inputStream.close();
+                    entryOffsets.clear();
                     state = State.Closed;
                     promise.complete(null);
                 } catch (IOException t) {
@@ -101,7 +106,10 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
 
     @Override
     public CompletableFuture<LedgerEntries> readAsync(long firstEntry, long lastEntry) {
-        log.debug("Ledger {}: reading {} - {}", getId(), firstEntry, lastEntry);
+        if (log.isDebugEnabled()) {
+            log.debug("Ledger {}: reading {} - {} ({} entries}",
+                    getId(), firstEntry, lastEntry, (1 + lastEntry - firstEntry));
+        }
         CompletableFuture<LedgerEntries> promise = new CompletableFuture<>();
         executor.submit(() -> {
             List<LedgerEntry> entries = new ArrayList<LedgerEntry>();
@@ -130,6 +138,7 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
                                 ledgerId, firstEntry, lastEntry);
                         throw new BKException.BKUnexpectedConditionException();
                     }
+                    long currentPosition = inputStream.getCurrentPosition();
                     int length = dataStream.readInt();
                     if (length < 0) { // hit padding or new block
                         inputStream.seek(index.getIndexEntryForEntry(nextExpectedId).getDataOffset());
@@ -138,6 +147,7 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
                     long entryId = dataStream.readLong();
 
                     if (entryId == nextExpectedId) {
+                        entryOffsets.put(entryId, currentPosition);
                         ByteBuf buf = PulsarByteBufAllocator.DEFAULT.buffer(length, length);
                         entries.add(LedgerEntryImpl.create(ledgerId, entryId, length, buf));
                         int toWrite = length;
@@ -160,7 +170,14 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
                         // the read method, we should allow to seek to the right position and the entry id should
                         // never over to the last entry again.
                         if (!seeked) {
-                            inputStream.seek(index.getIndexEntryForEntry(nextExpectedId).getDataOffset());
+                            Long knownOffset = entryOffsets.get(nextExpectedId);
+                            if (knownOffset != null) {
+                                inputStream.seek(knownOffset);
+                            } else {
+                                long dataOffset = index.getIndexEntryForEntry(nextExpectedId).getDataOffset();
+                                inputStream.seek(dataOffset);
+                            }
+
                             seeked = true;
                             continue;
                         }


### PR DESCRIPTION
This is a proof-of-concept.

This patch limits the size of backward seeks inside the temporary buffer held by the BlobStoreBackedInputStreamImpl.
For every backward seek we have to read (parse) all the entries from the beginning of the block up to the position.
With this patch we try to seek exactly to the position, and save lots of CPU cycles.

With this patch I am able to gain x5 in a Shared subscription. 
The Failover subscription is still x2 faster then the Shared subscription (at least on my laptop, but my laptop is limited in bandwidth to connect to GCP).

This is only a POC because the in-memory index may become huge, we will have to do something smarter