### PR TITLE
Write to cache entries read but not served to Consumers

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
@@ -734,4 +734,8 @@ public interface ManagedCursor {
      * @return whether this cursor is closed.
      */
     boolean isClosed();
+
+    default void cacheEntry(Entry entry) {
+
+    }
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -935,6 +935,10 @@ public class ManagedCursorImpl implements ManagedCursor {
         return state == State.Closed || state == State.Closing;
     }
 
+    public void cacheEntry(Entry entry) {
+        ledger.entryCache.insert((EntryImpl) entry);
+    }
+
     @Override
     public boolean cancelPendingReadRequest() {
         if (log.isDebugEnabled()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -248,7 +248,6 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
                     log.debug("[{}] Schedule replay of {} messages for {} consumers", name, messagesToReplayNow.size(),
                             consumerList.size());
                 }
-
                 havePendingReplayRead = true;
                 minReplayedPosition = messagesToReplayNow.stream().min(PositionImpl::compareTo).orElse(null);
                 Set<? extends Position> deletedMessages = topic.isDelayedDeliveryEnabled()
@@ -629,6 +628,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
             }
             entries.subList(start, entries.size()).forEach(entry -> {
                 long stickyKeyHash = getStickyKeyHash(entry);
+                cursor.cacheEntry(entry);
                 addMessageToReplay(entry.getLedgerId(), entry.getEntryId(), stickyKeyHash);
                 entry.release();
             });

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/BackedInputStream.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/BackedInputStream.java
@@ -27,4 +27,5 @@ import java.io.InputStream;
 public abstract class BackedInputStream extends InputStream {
     public abstract void seek(long position);
     public abstract void seekForward(long position) throws IOException;
+    public abstract long getCurrentPosition();
 }

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedInputStreamImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedInputStreamImpl.java
@@ -85,7 +85,10 @@ public class BlobStoreBackedInputStreamImpl extends BackedInputStream {
             long startRange = cursor;
             long endRange = Math.min(cursor + bufferSize - 1,
                                      objectLen - 1);
-
+            if (log.isDebugEnabled()) {
+                log.info("refillBufferIfNeeded {} - {} ({} bytes to fill)",
+                        startRange, endRange, (endRange - startRange));
+            }
             try {
                 long startReadTime = System.nanoTime();
                 Blob blob = blobStore.getBlob(bucket, key, new GetOptions().range(startRange, endRange));
@@ -149,6 +152,7 @@ public class BlobStoreBackedInputStreamImpl extends BackedInputStream {
             long newIndex = position - bufferOffsetStart;
             buffer.readerIndex((int) newIndex);
         } else {
+            bufferOffsetStart = bufferOffsetEnd = -1;
             this.cursor = position;
             buffer.clear();
         }
@@ -162,6 +166,13 @@ public class BlobStoreBackedInputStreamImpl extends BackedInputStream {
             throw new IOException(String.format("Error seeking, new position %d < current position %d",
                                                 position, cursor));
         }
+    }
+
+    public long getCurrentPosition() {
+        if (bufferOffsetStart != -1) {
+            return bufferOffsetStart + buffer.readerIndex();
+        }
+        return cursor + buffer.readerIndex();
     }
 
     @Override

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -55,6 +57,8 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
     private final BackedInputStream inputStream;
     private final DataInputStream dataStream;
     private final ExecutorService executor;
+    // this Map is accessed only by one thread
+    private final Map<Long, Long> entryOffsets = new TreeMap<>();
 
     enum State {
         Opened,
@@ -90,6 +94,7 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
                 try {
                     index.close();
                     inputStream.close();
+                    entryOffsets.clear();
                     state = State.Closed;
                     promise.complete(null);
                 } catch (IOException t) {
@@ -101,7 +106,10 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
 
     @Override
     public CompletableFuture<LedgerEntries> readAsync(long firstEntry, long lastEntry) {
-        log.debug("Ledger {}: reading {} - {}", getId(), firstEntry, lastEntry);
+        if (log.isDebugEnabled()) {
+            log.debug("Ledger {}: reading {} - {} ({} entries}",
+                    getId(), firstEntry, lastEntry, (1 + lastEntry - firstEntry));
+        }
         CompletableFuture<LedgerEntries> promise = new CompletableFuture<>();
         executor.submit(() -> {
             List<LedgerEntry> entries = new ArrayList<LedgerEntry>();
@@ -130,6 +138,7 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
                                 ledgerId, firstEntry, lastEntry);
                         throw new BKException.BKUnexpectedConditionException();
                     }
+                    long currentPosition = inputStream.getCurrentPosition();
                     int length = dataStream.readInt();
                     if (length < 0) { // hit padding or new block
                         inputStream.seek(index.getIndexEntryForEntry(nextExpectedId).getDataOffset());
@@ -138,6 +147,7 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
                     long entryId = dataStream.readLong();
 
                     if (entryId == nextExpectedId) {
+                        entryOffsets.put(entryId, currentPosition);
                         ByteBuf buf = PulsarByteBufAllocator.DEFAULT.buffer(length, length);
                         entries.add(LedgerEntryImpl.create(ledgerId, entryId, length, buf));
                         int toWrite = length;
@@ -160,7 +170,14 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
                         // the read method, we should allow to seek to the right position and the entry id should
                         // never over to the last entry again.
                         if (!seeked) {
-                            inputStream.seek(index.getIndexEntryForEntry(nextExpectedId).getDataOffset());
+                            Long knownOffset = entryOffsets.get(nextExpectedId);
+                            if (knownOffset != null) {
+                                inputStream.seek(knownOffset);
+                            } else {
+                                long dataOffset = index.getIndexEntryForEntry(nextExpectedId).getDataOffset();
+                                inputStream.seek(dataOffset);
+                            }
+
                             seeked = true;
                             continue;
                         }


### PR DESCRIPTION
This is a POC PR to solve https://github.com/apache/pulsar/issues/16421 

the problem that it is trying to solve is that when you are using batching the consumer receives N entries, containing M messages (with M >> N), then it exhaust quickly its permits and at the next dispatcher round the dispatcher loads too many messages from storage (BK or TieredStorage).
there is a bunch of entries that are read but cannot be dispatched, so we are wasting precious reads.
my latest change adds back to the "cache" the entries that have not been dispatched, so that at the second round the entries are still in the cache and we save from reading from tiered storage (or even BK!) again the same data.
This will be a good improvement also for non offloaded shared subscription.
the change applies only to Shared Subscriptions