### PR TITLE
Pulsar shell: configs to manage multiple clusters/tenants

### DIFF
--- a/bin/pulsar-shell
+++ b/bin/pulsar-shell
@@ -34,17 +34,6 @@ BINDIR=$(dirname "$PRG")
 export PULSAR_HOME=`cd -P $BINDIR/..;pwd`
 . "$PULSAR_HOME/bin/pulsar-admin-common.sh"
 OPTS="-Dorg.jline.terminal.jansi=false $OPTS"
+DEFAULT_CONFIG="-Dpulsar.shell.config.default=$PULSAR_CLIENT_CONF"
 
-DEFAULT_SHELL_ARGS="--config $PULSAR_CLIENT_CONF"
-PASSED_SHELL_ARGS=""
-while [[ $# -gt 0 ]]
-do
-  key="$1"
-  if [[ "$key" == "-c" || "$key" == "--config" ]]; then
-    DEFAULT_SHELL_ARGS=""
-  fi
-  PASSED_SHELL_ARGS="$PASSED_SHELL_ARGS $key"
-  shift
-done
-
-exec $JAVA $OPTS org.apache.pulsar.shell.PulsarShell $DEFAULT_SHELL_ARGS $PASSED_SHELL_ARGS
+exec $JAVA $OPTS $DEFAULT_CONFIG org.apache.pulsar.shell.PulsarShell "$@"

--- a/bin/pulsar-shell
+++ b/bin/pulsar-shell
@@ -35,8 +35,6 @@ export PULSAR_HOME=`cd -P $BINDIR/..;pwd`
 . "$PULSAR_HOME/bin/pulsar-admin-common.sh"
 OPTS="-Dorg.jline.terminal.jansi=false $OPTS"
 
-#Change to PULSAR_HOME to support relative paths
-cd "$PULSAR_HOME"
 DEFAULT_SHELL_ARGS="--config $PULSAR_CLIENT_CONF"
 PASSED_SHELL_ARGS=""
 while [[ $# -gt 0 ]]

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/ConfigShell.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/ConfigShell.java
@@ -1,0 +1,272 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.shell;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+import com.beust.jcommander.Parameters;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import lombok.Getter;
+import lombok.SneakyThrows;
+import org.apache.commons.io.IOUtils;
+import org.apache.pulsar.shell.config.ConfigStore;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+@Parameters(commandDescription = "Manage Pulsar shell configurations.")
+public class ConfigShell implements ShellCommandsProvider {
+
+    @Getter
+    @Parameters
+    public static class Params {
+
+        @Parameter(names = {"-h", "--help",}, help = true, description = "Show this help.")
+        boolean help;
+    }
+
+    private interface RunnableWithResult {
+        boolean run() throws Exception;
+    }
+
+    private JCommander jcommander;
+    private Params params;
+    private final PulsarShell pulsarShell;
+    private final Map<String, RunnableWithResult> commands = new HashMap<>();
+    private final ConfigStore configStore;
+    private final ObjectMapper writer = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+    @Getter
+    private String currentConfig = ConfigStore.DEFAULT_CONFIG;
+
+    public ConfigShell(PulsarShell pulsarShell) {
+        this.configStore = pulsarShell.getConfigStore();
+        this.pulsarShell = pulsarShell;
+    }
+
+    @Override
+    public String getName() {
+        return "config";
+    }
+
+    @Override
+    public String getServiceUrl() {
+        return null;
+    }
+
+    @Override
+    public String getAdminUrl() {
+        return null;
+    }
+
+    @Override
+    public void setupState(Properties properties) {
+
+        this.params = new Params();
+        this.jcommander = new JCommander();
+        jcommander.addObject(params);
+
+        commands.put("list", new CmdConfigList());
+        commands.put("put", new CmdConfigPut());
+        commands.put("delete", new CmdConfigDelete());
+        commands.put("use", new CmdConfigUse());
+        commands.put("view", new CmdConfigView());
+        commands.forEach((k, v) -> jcommander.addCommand(k, v));
+    }
+
+    @Override
+    public void cleanupState(Properties properties) {
+        setupState(properties);
+    }
+
+    @Override
+    public JCommander getJCommander() {
+        return jcommander;
+    }
+
+    @Override
+    public boolean runCommand(String[] args) throws Exception {
+        try {
+            jcommander.parse(args);
+
+            if (params.help) {
+                jcommander.usage();
+                return true;
+            }
+
+            String chosenCommand = jcommander.getParsedCommand();
+            final RunnableWithResult command = commands.get(chosenCommand);
+            if (command == null) {
+                jcommander.usage();
+                return false;
+            }
+            return command.run();
+        } catch (Throwable e) {
+            jcommander.getConsole().println(e.getMessage());
+            String chosenCommand = jcommander.getParsedCommand();
+            if (e instanceof ParameterException) {
+                try {
+                    jcommander.getUsageFormatter().usage(chosenCommand);
+                } catch (ParameterException noCmd) {
+                    e.printStackTrace();
+                }
+            } else {
+                e.printStackTrace();
+            }
+            return false;
+        }
+    }
+
+    @Parameters(commandDescription = "List configurations")
+    private class CmdConfigList implements RunnableWithResult {
+
+        @Override
+        @SneakyThrows
+        public boolean run() {
+            print(configStore.listConfigs());
+            return true;
+        }
+    }
+
+    @Parameters(commandDescription = "Use the configuration for next commands")
+    private class CmdConfigUse implements RunnableWithResult {
+        @Parameter(description = "Name of the config", required = true)
+        @JCommanderCompleter.ParameterCompleter(completer = JCommanderCompleter.ParameterCompleter.Completers.CONFIGS )
+        private String name;
+
+        @Override
+        @SneakyThrows
+        public boolean run() {
+            final ConfigStore.ConfigEntry config = configStore.getConfig(name);
+            if (config == null) {
+                print("Config " + name + " not found");
+                return false;
+            }
+            final String value = config.getValue();
+            currentConfig = name;
+            final Properties properties = new Properties();
+            properties.load(new StringReader(value));
+            pulsarShell.reload(properties);
+            return true;
+        }
+    }
+
+    @Parameters(commandDescription = "Show configuration")
+    private class CmdConfigView implements RunnableWithResult {
+        @Parameter(description = "Name of the config", required = true)
+        @JCommanderCompleter.ParameterCompleter(completer = JCommanderCompleter.ParameterCompleter.Completers.CONFIGS )
+        private String name;
+
+        @Override
+        @SneakyThrows
+        public boolean run() {
+            final ConfigStore.ConfigEntry config = configStore.getConfig(this.name);
+            if (config == null) {
+                print("Config " + name + " not found");
+                return false;
+            }
+            print(config.getValue());
+            return true;
+        }
+    }
+
+    @Parameters(commandDescription = "Delete a configuration")
+    private class CmdConfigDelete implements RunnableWithResult {
+        @Parameter(description = "Name of the config", required = true)
+        @JCommanderCompleter.ParameterCompleter(completer = JCommanderCompleter.ParameterCompleter.Completers.CONFIGS )
+        private String name;
+
+        @Override
+        @SneakyThrows
+        public boolean run() {
+            if (currentConfig != null && currentConfig.equals(name)) {
+                print("'" + name + "' is currenty used and it can't be deleted");
+                return false;
+            }
+            configStore.deleteConfig(name);
+            return true;
+        }
+    }
+
+    @Parameters(commandDescription = "Put a new configuration or override an existing one.")
+    private class CmdConfigPut implements RunnableWithResult {
+
+        @Parameter(description = "Configuration name", required = true)
+        private String name;
+
+        @Parameter(names = {"--url"}, description = "URL of the config")
+        private String url;
+
+        @Parameter(names = {"--file"}, description = "File path of the config")
+        @JCommanderCompleter.ParameterCompleter(completer = JCommanderCompleter.ParameterCompleter.Completers.FILES )
+        private String file;
+
+        @Override
+        @SneakyThrows
+        public boolean run() {
+            byte[] bytes;
+
+            if (file != null) {
+                bytes = Files.readAllBytes(new File(file).toPath());
+            } else if (url != null) {
+                final ByteArrayOutputStream bout = new ByteArrayOutputStream();
+
+                try (InputStream in = URI.create(url).toURL().openStream()) {
+                    IOUtils.copy(in, bout);
+                }
+                bytes = bout.toByteArray();
+            } else {
+                print("--file or --url are required.");
+                return false;
+            }
+
+            configStore.putConfig(new ConfigStore.ConfigEntry(name, new String(bytes, StandardCharsets.UTF_8)));
+            return true;
+        }
+    }
+
+
+    <T> void print(List<T> items) {
+        for (T item : items) {
+            print(item);
+        }
+    }
+
+    <T> void print(T item) {
+        try {
+            if (item instanceof String) {
+                jcommander.getConsole().println((String) item);
+            } else {
+                System.out.println(writer.writeValueAsString(item));
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/ConfigShell.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/ConfigShell.java
@@ -18,22 +18,18 @@
  */
 package org.apache.pulsar.shell;
 
+import static org.apache.pulsar.shell.config.ConfigStore.DEFAULT_CONFIG;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import lombok.Getter;
-import lombok.SneakyThrows;
-import org.apache.commons.io.IOUtils;
-import org.apache.pulsar.shell.config.ConfigStore;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -42,9 +38,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.SneakyThrows;
+import org.apache.commons.io.IOUtils;
+import org.apache.pulsar.shell.config.ConfigStore;
 
-import static org.apache.pulsar.shell.config.ConfigStore.DEFAULT_CONFIG;
-
+/**
+ * Shell commands to manage shell configurations.
+ */
 @Parameters(commandDescription = "Manage Pulsar shell configurations.")
 public class ConfigShell implements ShellCommandsProvider {
 
@@ -53,7 +54,7 @@ public class ConfigShell implements ShellCommandsProvider {
     @Parameters
     public static class Params {
 
-        @Parameter(names = {"-h", "--help",}, help = true, description = "Show this help.")
+        @Parameter(names = {"-h", "--help"}, help = true, description = "Show this help.")
         boolean help;
     }
 
@@ -176,7 +177,7 @@ public class ConfigShell implements ShellCommandsProvider {
     @Parameters(commandDescription = "Use the configuration for next commands")
     private class CmdConfigUse implements RunnableWithResult {
         @Parameter(description = "Name of the config", required = true)
-        @JCommanderCompleter.ParameterCompleter(type = JCommanderCompleter.ParameterCompleter.Type.CONFIGS )
+        @JCommanderCompleter.ParameterCompleter(type = JCommanderCompleter.ParameterCompleter.Type.CONFIGS)
         private String name;
 
         @Override
@@ -199,7 +200,7 @@ public class ConfigShell implements ShellCommandsProvider {
     @Parameters(commandDescription = "View configuration")
     private class CmdConfigView implements RunnableWithResult {
         @Parameter(description = "Name of the config", required = true)
-        @JCommanderCompleter.ParameterCompleter(type = JCommanderCompleter.ParameterCompleter.Type.CONFIGS )
+        @JCommanderCompleter.ParameterCompleter(type = JCommanderCompleter.ParameterCompleter.Type.CONFIGS)
         private String name;
 
         @Override
@@ -218,7 +219,7 @@ public class ConfigShell implements ShellCommandsProvider {
     @Parameters(commandDescription = "Delete a configuration")
     private class CmdConfigDelete implements RunnableWithResult {
         @Parameter(description = "Name of the config", required = true)
-        @JCommanderCompleter.ParameterCompleter(type = JCommanderCompleter.ParameterCompleter.Type.CONFIGS )
+        @JCommanderCompleter.ParameterCompleter(type = JCommanderCompleter.ParameterCompleter.Type.CONFIGS)
         private String name;
 
         @Override
@@ -270,14 +271,14 @@ public class ConfigShell implements ShellCommandsProvider {
     private abstract class CmdConfigPut implements RunnableWithResult {
 
         @Parameter(description = "Configuration name", required = true)
-        @JCommanderCompleter.ParameterCompleter(type = JCommanderCompleter.ParameterCompleter.Type.CONFIGS )
+        @JCommanderCompleter.ParameterCompleter(type = JCommanderCompleter.ParameterCompleter.Type.CONFIGS)
         protected String name;
 
         @Parameter(names = {"--url"}, description = "URL of the config")
         protected String url;
 
         @Parameter(names = {"--file"}, description = "File path of the config")
-        @JCommanderCompleter.ParameterCompleter(type = JCommanderCompleter.ParameterCompleter.Type.FILES )
+        @JCommanderCompleter.ParameterCompleter(type = JCommanderCompleter.ParameterCompleter.Type.FILES)
         protected String file;
 
         @Override

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/JCommanderCompleter.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/JCommanderCompleter.java
@@ -23,7 +23,6 @@ import com.beust.jcommander.ParameterDescription;
 import com.beust.jcommander.WrappedParameter;
 
 import java.io.File;
-import java.io.IOException;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.lang.reflect.Field;
@@ -36,12 +35,10 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import org.apache.pulsar.admin.cli.CmdBase;
 import org.apache.pulsar.shell.config.ConfigStore;
-import org.checkerframework.checker.units.qual.C;
 import org.jline.builtins.Completers;
 import org.jline.reader.Candidate;
 import org.jline.reader.Completer;
@@ -49,10 +46,8 @@ import org.jline.reader.LineReader;
 import org.jline.reader.ParsedLine;
 import org.jline.reader.impl.completer.NullCompleter;
 import org.jline.reader.impl.completer.StringsCompleter;
-import org.jline.utils.AttributedString;
 
 import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
 
 /**
  * Convert JCommander instance to JLine3 completers.
@@ -178,10 +173,10 @@ public class JCommanderCompleter {
         final Field field = (Field) reflField.get(param.getParameterized());
         final ParameterCompleter parameterCompleter = field.getAnnotation(ParameterCompleter.class);
         if (parameterCompleter != null) {
-            final ParameterCompleter.Completers completer = parameterCompleter.completer();
-            if (completer == ParameterCompleter.Completers.FILES) {
-                valueCompleter = new Completers.FilesCompleter(new File("."));
-            } else if (completer == ParameterCompleter.Completers.CONFIGS) {
+            final ParameterCompleter.Type completer = parameterCompleter.type();
+            if (completer == ParameterCompleter.Type.FILES) {
+                valueCompleter = new Completers.FilesCompleter(new File(System.getProperty("user.dir")));
+            } else if (completer == ParameterCompleter.Type.CONFIGS) {
                 valueCompleter = new Completer() {
                     @Override
                     @SneakyThrows
@@ -197,15 +192,15 @@ public class JCommanderCompleter {
     }
 
     @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
-    @Target({ FIELD, METHOD })
+    @Target({ FIELD })
     public @interface ParameterCompleter {
 
-        enum Completers {
+        enum Type {
             FILES,
             CONFIGS;
         }
 
-        Completers completer();
+        Type type();
 
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/JCommanderCompleter.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/JCommanderCompleter.java
@@ -18,10 +18,10 @@
  */
 package org.apache.pulsar.shell;
 
+import static java.lang.annotation.ElementType.FIELD;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterDescription;
 import com.beust.jcommander.WrappedParameter;
-
 import java.io.File;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -33,7 +33,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.SneakyThrows;
@@ -46,8 +45,6 @@ import org.jline.reader.LineReader;
 import org.jline.reader.ParsedLine;
 import org.jline.reader.impl.completer.NullCompleter;
 import org.jline.reader.impl.completer.StringsCompleter;
-
-import static java.lang.annotation.ElementType.FIELD;
 
 /**
  * Convert JCommander instance to JLine3 completers.

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/PulsarShell.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/PulsarShell.java
@@ -150,6 +150,7 @@ public class PulsarShell {
 
         pulsarShellDir = computePulsarShellFile();
         Files.createDirectories(pulsarShellDir.toPath());
+        System.out.println(String.format("Using directory: %s", pulsarShellDir.getAbsolutePath()));
 
         ConfigStore.ConfigEntry defaultConfig = null;
         if (mainOptions.configFile != null) {
@@ -226,12 +227,16 @@ public class PulsarShell {
             LineReader reader = readerBuilder.build();
 
             final String welcomeMessage =
-                    String.format("Welcome to Pulsar shell!\n  %s: %s\n  %s: %s\n\n "
-                                    + "Type 'help' to get started or try the autocompletion (TAB button).\n",
+                    String.format("Welcome to Pulsar shell!\n  %s: %s\n  %s: %s\n\n"
+                                    + "Type %s to get started or try the autocompletion (TAB button).\n" +
+                                    "Type %s or %s to end the shell session.\n",
                             new AttributedStringBuilder().style(AttributedStyle.BOLD).append("Service URL").toAnsi(),
                             serviceUrl,
                             new AttributedStringBuilder().style(AttributedStyle.BOLD).append("Admin URL").toAnsi(),
-                            adminUrl);
+                            adminUrl,
+                            new AttributedStringBuilder().style(AttributedStyle.BOLD).append("help").toAnsi(),
+                            new AttributedStringBuilder().style(AttributedStyle.BOLD).append("exit").toAnsi(),
+                            new AttributedStringBuilder().style(AttributedStyle.BOLD).append("quit").toAnsi());
             output(welcomeMessage, terminal);
             String promptMessage;
             if (configShell != null && configShell.getCurrentConfig() != null) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/PulsarShell.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/PulsarShell.java
@@ -29,7 +29,6 @@ import java.io.StringReader;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -228,8 +227,8 @@ public class PulsarShell {
 
             final String welcomeMessage =
                     String.format("Welcome to Pulsar shell!\n  %s: %s\n  %s: %s\n\n"
-                                    + "Type %s to get started or try the autocompletion (TAB button).\n" +
-                                    "Type %s or %s to end the shell session.\n",
+                                    + "Type %s to get started or try the autocompletion (TAB button).\n"
+                                    + "Type %s or %s to end the shell session.\n",
                             new AttributedStringBuilder().style(AttributedStyle.BOLD).append("Service URL").toAnsi(),
                             serviceUrl,
                             new AttributedStringBuilder().style(AttributedStyle.BOLD).append("Admin URL").toAnsi(),

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/PulsarShell.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/PulsarShell.java
@@ -22,7 +22,6 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringReader;
@@ -453,7 +452,8 @@ public class PulsarShell {
         }
 
         if (!commandOk) {
-            throw new IllegalArgumentException("Cannot use stdin, -e/--execute-command and -f/--filename option at the same time");
+            throw new IllegalArgumentException("Cannot use stdin, -e/--execute-command "
+                    + "and -f/--filename option at the same time");
         }
         return mainOptions.filename != null || mainOptions.readFromStdin || mainOptions.inlineCommand != null;
     }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/PulsarShell.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/PulsarShell.java
@@ -46,7 +46,8 @@ import org.apache.pulsar.shell.config.FileConfigStore;
 import org.jline.reader.Completer;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
-    import org.jline.reader.impl.completer.AggregateCompleter;
+import org.jline.reader.impl.DefaultParser;
+import org.jline.reader.impl.completer.AggregateCompleter;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
 import org.jline.utils.AttributedStringBuilder;
@@ -218,6 +219,7 @@ public class PulsarShell {
 
             LineReaderBuilder readerBuilder = LineReaderBuilder.builder()
                     .terminal(terminal)
+                    .parser(new DefaultParser().eofOnUnclosedQuote(true))
                     .completer(completer)
                     .variable(LineReader.INDENTATION, 2)
                     .option(LineReader.Option.INSERT_BRACKET, true);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/ConfigStore.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/ConfigStore.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.shell.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.IOException;
+import java.util.List;
+
+public interface ConfigStore {
+
+    String DEFAULT_CONFIG = "default";
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    class ConfigEntry {
+        String name;
+        String value;
+    }
+
+
+    void putConfig(ConfigEntry entry) throws IOException;
+
+    ConfigEntry getConfig(String name) throws IOException;
+
+    void deleteConfig(String name) throws IOException;
+
+    List<ConfigEntry> listConfigs() throws IOException;
+}

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/ConfigStore.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/ConfigStore.java
@@ -20,8 +20,6 @@ package org.apache.pulsar.shell.config;
 
 import java.io.IOException;
 import java.util.List;
-
-import io.swagger.jackson.mixin.IgnoreOriginalRefMixin;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/ConfigStore.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/ConfigStore.java
@@ -20,6 +20,8 @@ package org.apache.pulsar.shell.config;
 
 import java.io.IOException;
 import java.util.List;
+
+import io.swagger.jackson.mixin.IgnoreOriginalRefMixin;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -46,4 +48,8 @@ public interface ConfigStore {
     void deleteConfig(String name) throws IOException;
 
     List<ConfigEntry> listConfigs() throws IOException;
+
+    void setLastUsed(String name) throws IOException;
+
+    ConfigEntry getLastUsed() throws IOException;
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/FileConfigStore.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/FileConfigStore.java
@@ -59,8 +59,12 @@ public class FileConfigStore implements ConfigStore {
         } else {
             fileConfig = new FileConfig();
         }
-        this.defaultConfig = new ConfigEntry(defaultConfig.getName(), defaultConfig.getValue());
-        cleanupValue(this.defaultConfig);
+        if (defaultConfig != null) {
+            this.defaultConfig = new ConfigEntry(defaultConfig.getName(), defaultConfig.getValue());
+            cleanupValue(this.defaultConfig);
+        } else {
+            this.defaultConfig = null;
+        }
     }
 
     private void read() throws IOException {
@@ -126,7 +130,9 @@ public class FileConfigStore implements ConfigStore {
     @Override
     public List<ConfigEntry> listConfigs() {
         List<ConfigEntry> all = new ArrayList<>(fileConfig.configs.values());
-        all.add(0, defaultConfig);
+        if (defaultConfig != null) {
+            all.add(0, defaultConfig);
+        }
         return all;
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/FileConfigStore.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/FileConfigStore.java
@@ -77,7 +77,7 @@ public class FileConfigStore implements ConfigStore {
     @Override
     public void putConfig(ConfigEntry entry) throws IOException {
         if (DEFAULT_CONFIG.equals(entry.getName())) {
-            throw new IllegalArgumentException("\"" + DEFAULT_CONFIG + "\" can't be modified.");
+            throw new IllegalArgumentException("'" + DEFAULT_CONFIG + "' can't be modified.");
         }
         cleanupValue(entry);
         fileConfig.configs.put(entry.getName(), entry);
@@ -110,7 +110,7 @@ public class FileConfigStore implements ConfigStore {
     @Override
     public void deleteConfig(String name) throws IOException{
         if (DEFAULT_CONFIG.equals(name)) {
-            throw new IllegalArgumentException("\"" + DEFAULT_CONFIG + "\" can't be modified.");
+            throw new IllegalArgumentException("'" + DEFAULT_CONFIG + "' can't be deleted.");
         }
         final ConfigEntry old = fileConfig.configs.remove(name);
         if (old != null) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/FileConfigStore.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/FileConfigStore.java
@@ -44,6 +44,7 @@ public class FileConfigStore implements ConfigStore {
     @NoArgsConstructor
     public static class FileConfig {
         private LinkedHashMap<String, ConfigEntry> configs = new LinkedHashMap<>();
+        private String last;
     }
 
     private final ObjectMapper mapper = new ObjectMapper();
@@ -127,5 +128,19 @@ public class FileConfigStore implements ConfigStore {
         List<ConfigEntry> all = new ArrayList<>(fileConfig.configs.values());
         all.add(0, defaultConfig);
         return all;
+    }
+
+    @Override
+    public void setLastUsed(String name) throws IOException {
+        fileConfig.last = name;
+        write();
+    }
+
+    @Override
+    public ConfigEntry getLastUsed() throws IOException {
+        if (fileConfig.last != null) {
+            return getConfig(fileConfig.last);
+        }
+        return null;
     }
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/FileConfigStore.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/FileConfigStore.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.shell.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Scanner;
+
+public class FileConfigStore implements ConfigStore {
+
+    @Data
+    @NoArgsConstructor
+    public static class FileConfig {
+        private LinkedHashMap<String, ConfigEntry> configs = new LinkedHashMap<>();
+    }
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final File file;
+    private final ConfigEntry defaultConfig;
+    private FileConfig fileConfig;
+
+    public FileConfigStore(File file, ConfigEntry defaultConfig) throws IOException {
+        this.file = file;
+        if (file.exists()) {
+            read();
+        } else {
+            fileConfig = new FileConfig();
+        }
+        this.defaultConfig = new ConfigEntry(defaultConfig.getName(), defaultConfig.getValue());
+        cleanupValue(this.defaultConfig);
+    }
+
+    private void read() throws IOException {
+        try (final BufferedInputStream buffered = new BufferedInputStream(new FileInputStream(file));) {
+            try {
+                fileConfig = mapper.readValue(buffered, FileConfig.class);
+            } catch (MismatchedInputException mismatchedInputException) {
+                fileConfig = new FileConfig();
+            }
+        }
+    }
+
+    private void write() throws IOException {
+        try (final BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(new FileOutputStream(file));) {
+            mapper.writeValue(bufferedOutputStream, fileConfig);
+        }
+    }
+
+    @Override
+    public void putConfig(ConfigEntry entry) throws IOException {
+        if (DEFAULT_CONFIG.equals(entry.getName())) {
+            throw new IllegalArgumentException("\"" + DEFAULT_CONFIG + "\" can't be modified.");
+        }
+        cleanupValue(entry);
+        fileConfig.configs.put(entry.getName(), entry);
+        write();
+    }
+
+    private static void cleanupValue(ConfigEntry entry) {
+        StringBuilder builder = new StringBuilder();
+        try (Scanner scanner = new Scanner(entry.getValue());) {
+            while (scanner.hasNextLine()) {
+                String line = scanner.nextLine().trim();
+                if (line.startsWith("#")) {
+                    continue;
+                }
+                builder.append(line);
+                builder.append(System.lineSeparator());
+            }
+        }
+        entry.setValue(builder.toString());
+    }
+
+    @Override
+    public ConfigEntry getConfig(String name) {
+        if (DEFAULT_CONFIG.equals(name)) {
+            return defaultConfig;
+        }
+        return fileConfig.configs.get(name);
+    }
+
+    @Override
+    public void deleteConfig(String name) throws IOException{
+        if (DEFAULT_CONFIG.equals(name)) {
+            throw new IllegalArgumentException("\"" + DEFAULT_CONFIG + "\" can't be modified.");
+        }
+        final ConfigEntry old = fileConfig.configs.remove(name);
+        if (old != null) {
+            write();
+        }
+    }
+
+    @Override
+    public List<ConfigEntry> listConfigs() {
+        List<ConfigEntry> all = new ArrayList<>(fileConfig.configs.values());
+        all.add(0, defaultConfig);
+        return all;
+    }
+}

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/FileConfigStore.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/FileConfigStore.java
@@ -20,9 +20,6 @@ package org.apache.pulsar.shell.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -33,7 +30,14 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Scanner;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+/**
+ * File based configurations store.
+ *
+ * All the configurations are stored in a single file in JSON format.
+ */
 public class FileConfigStore implements ConfigStore {
 
     @Data

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/package-info.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/config/package-info.java
@@ -17,33 +17,3 @@
  * under the License.
  */
 package org.apache.pulsar.shell.config;
-
-import java.io.IOException;
-import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-/**
- * Shell configurations store layer.
- */
-public interface ConfigStore {
-
-    String DEFAULT_CONFIG = "default";
-    @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
-    class ConfigEntry {
-        String name;
-        String value;
-    }
-
-
-    void putConfig(ConfigEntry entry) throws IOException;
-
-    ConfigEntry getConfig(String name) throws IOException;
-
-    void deleteConfig(String name) throws IOException;
-
-    List<ConfigEntry> listConfigs() throws IOException;
-}

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/ConfigShellTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/ConfigShellTest.java
@@ -27,11 +27,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import com.beust.jcommander.internal.Console;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -98,7 +100,7 @@ public class ConfigShellTest {
 
         assertFalse(configShell.runCommand(new String[]{"update", "default",
                 "--file", newClientConf.toFile().getAbsolutePath()}));
-        assertEquals(output, Arrays.asList("'default' can't be modified."));
+        assertEquals(output, Arrays.asList("'default' can't be updated."));
         output.clear();
 
         assertFalse(configShell.runCommand(new String[]{"delete", "default"}));
@@ -117,9 +119,13 @@ public class ConfigShellTest {
         assertTrue(output.isEmpty());
         output.clear();
 
+        assertNull(pulsarShell.getConfigStore().getLastUsed());
+
         assertTrue(configShell.runCommand(new String[]{"use", "myclient"}));
         assertTrue(output.isEmpty());
         output.clear();
+        assertEquals(pulsarShell.getConfigStore().getLastUsed(), pulsarShell.getConfigStore()
+                .getConfig("myclient"));
 
         verify(pulsarShell).reload(any());
 

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/ConfigShellTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/ConfigShellTest.java
@@ -1,0 +1,139 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.shell;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import com.beust.jcommander.internal.Console;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import org.apache.pulsar.shell.config.ConfigStore;
+import org.apache.pulsar.shell.config.FileConfigStore;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class ConfigShellTest {
+
+    private PulsarShell pulsarShell;
+    private ConfigShell configShell;
+    private final List<String> output = new ArrayList<>();
+
+    @BeforeMethod(alwaysRun = true)
+    public void before() throws Exception {
+
+        pulsarShell = spy(mock(PulsarShell.class));
+        doNothing().when(pulsarShell).reload(any());
+        final Path tempJson = Files.createTempFile("pulsar-shell", ".json");
+
+        when(pulsarShell.getConfigStore()).thenReturn(
+                new FileConfigStore(tempJson.toFile(),
+                        new ConfigStore.ConfigEntry(ConfigStore.DEFAULT_CONFIG, "#comment\ndefault-config=true")));
+        configShell = new ConfigShell(pulsarShell);
+        configShell.setupState(new Properties());
+
+        configShell.getJCommander().setConsole(new Console() {
+            @Override
+            public void print(String msg) {
+                System.out.print("got: " + msg);
+                output.add(msg);
+            }
+
+            @Override
+            public void println(String msg) {
+                System.out.println("got: " + msg);
+                output.add(msg);
+            }
+
+            @Override
+            public char[] readPassword(boolean echoInput) {
+                return new char[0];
+            }
+        });
+
+    }
+
+    @Test
+    public void testDefault() throws Exception {
+        assertTrue(configShell.runCommand(new String[]{"list"}));
+        assertEquals(output, Arrays.asList("default (*)"));
+        output.clear();
+        assertTrue(configShell.runCommand(new String[]{"view", "default"}));
+        assertEquals(output.get(0), "default-config=true\n");
+        output.clear();
+
+        final Path newClientConf = Files.createTempFile("client", ".conf");
+        assertFalse(configShell.runCommand(new String[]{"create", "default",
+                "--file", newClientConf.toFile().getAbsolutePath()}));
+        assertEquals(output, Arrays.asList("Config 'default' already exists."));
+        output.clear();
+
+        assertFalse(configShell.runCommand(new String[]{"update", "default",
+                "--file", newClientConf.toFile().getAbsolutePath()}));
+        assertEquals(output, Arrays.asList("'default' can't be modified."));
+        output.clear();
+
+        assertFalse(configShell.runCommand(new String[]{"delete", "default"}));
+        assertEquals(output, Arrays.asList("'default' can't be deleted."));
+    }
+
+    @Test
+    public void test() throws Exception {
+        final Path newClientConf = Files.createTempFile("client", ".conf");
+
+        final byte[] content = ("webServiceUrl=http://localhost:8081/\n" +
+                "brokerServiceUrl=pulsar://localhost:6651/\n").getBytes(StandardCharsets.UTF_8);
+        Files.write(newClientConf, content);
+        assertTrue(configShell.runCommand(new String[]{"create", "myclient",
+                "--file", newClientConf.toFile().getAbsolutePath()}));
+        assertTrue(output.isEmpty());
+        output.clear();
+
+        assertTrue(configShell.runCommand(new String[]{"use", "myclient"}));
+        assertTrue(output.isEmpty());
+        output.clear();
+
+        verify(pulsarShell).reload(any());
+
+        assertTrue(configShell.runCommand(new String[]{"list"}));
+        assertEquals(output, Arrays.asList("default", "myclient (*)"));
+        output.clear();
+
+        assertFalse(configShell.runCommand(new String[]{"delete", "myclient"}));
+        assertEquals(output, Arrays.asList("'myclient' is currently used and it can't be deleted."));
+        output.clear();
+
+        assertTrue(configShell.runCommand(new String[]{"update", "myclient",
+                "--file", newClientConf.toFile().getAbsolutePath()}));
+        assertTrue(output.isEmpty());
+        verify(pulsarShell, times(2)).reload(any());
+    }
+}

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/ConfigShellTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/ConfigShellTest.java
@@ -33,7 +33,6 @@ import com.beust.jcommander.internal.Console;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/JCommanderCompleterTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/JCommanderCompleterTest.java
@@ -33,7 +33,7 @@ public class JCommanderCompleterTest {
         final AdminShell shell = new AdminShell(new Properties());
         shell.setupState(new Properties());
         final List<Completer> completers = JCommanderCompleter.createCompletersForCommand("admin",
-                shell.getJCommander());
+                shell.getJCommander(), null);
         assertFalse(completers.isEmpty());
         for (Completer completer : completers) {
             assertTrue(completer instanceof OptionStrictArgumentCompleter);

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/PulsarShellTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/PulsarShellTest.java
@@ -188,7 +188,7 @@ public class PulsarShellTest {
         final String shellFile = Thread.currentThread()
                 .getContextClassLoader().getResource("test-shell-file-error").getFile();
 
-        final TestPulsarShell testPulsarShell = new TestPulsarShell(new String[]{"-f", shellFile, "-e"},
+        final TestPulsarShell testPulsarShell = new TestPulsarShell(new String[]{"-f", shellFile, "--fail-on-error"},
                 props, pulsarAdminBuilder);
         try {
             testPulsarShell.run((a) -> linereader, (a) -> terminal);


### PR DESCRIPTION
New concept of `configs`

A config is a key-value object where key is a logical name and the value is a client.conf content.
You can now create many configs in the shell and they will be saved in your home directory ($HOME/.pulsar-shell/configs.json)

there's a `default` config which is the config you're passing to pulsar-shell (with `-c`).
New root command: `config`
- config list: list all configs
- config view <configname>: show config value
- config create (--file|--url|--value) <file/url/base64:xx> <configname>: create a config
- config update (--file|--url|--value) <file/url/base64:xx> <configname>: update a config
- config delete <configname>: delete a config
- config use <configname>: set current config to that config 

The last used config will be used as first config for the new shell session. The info is stored in the json.

Plus:
- Moved `pulsar-shell -e` to run command (before was 'exit-on-error', now moved to '--fail-on-error', so in order to setup your shell you can run

```
pulsar-shell -e "config create --value 'base64:xxxxx' mycluster-mytenant
config use mycluster-mytenant
"
```
Then when you open the shell the next time the `mycluster-mytenant` will be used.
