### PR TITLE
[managed-ledger] prevent sending duplicate reads to BK/offloaders

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
@@ -274,8 +274,8 @@ public class RangeEntryCacheImpl implements EntryCache {
 
     @AllArgsConstructor
     private static final class ReadEntriesCallbackWithContext {
-        ReadEntriesCallback callback;
-        Object ctx;
+        final ReadEntriesCallback callback;
+        final Object ctx;
     }
     private class CachedPendingRead {
         final PendingReadKey key;
@@ -397,8 +397,8 @@ public class RangeEntryCacheImpl implements EntryCache {
                     CompletableFuture<List<EntryImpl>> readResult = lh.readAsync(firstEntry, lastEntry)
                             .thenApply(
                                     ledgerEntries -> {
-                                        checkNotNull(ml.getName());
-                                        checkNotNull(ml.getExecutor());
+                                        requireNonNull(ml.getName());
+                                        requireNonNull(ml.getExecutor());
 
                                         try {
                                             // We got the entries, we need to transform them to a List<> type

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
@@ -20,6 +20,7 @@ package org.apache.bookkeeper.mledger.impl.cache;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 import static org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.createManagedLedgerException;
 import com.google.common.collect.Lists;
 import com.google.common.primitives.Longs;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
@@ -25,9 +25,15 @@ import com.google.common.collect.Lists;
 import com.google.common.primitives.Longs;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.AllArgsConstructor;
+import lombok.Value;
 import org.apache.bookkeeper.client.api.BKException;
 import org.apache.bookkeeper.client.api.LedgerEntry;
 import org.apache.bookkeeper.client.api.ReadHandle;
@@ -53,8 +59,17 @@ public class RangeEntryCacheImpl implements EntryCache {
     private ManagedLedgerInterceptor interceptor;
     private final RangeCache<PositionImpl, EntryImpl> entries;
     private final boolean copyEntries;
+    private final ConcurrentHashMap<PendingReadKey, CachedPendingRead> cachedPendingReads =
+            new ConcurrentHashMap<>();
 
     private static final double MB = 1024 * 1024;
+
+    @Value
+    private static class PendingReadKey {
+        private final long ledgerId;
+        private final long startEntry;
+        private final long endEntry;
+    }
 
     public RangeEntryCacheImpl(RangeEntryCacheManagerImpl manager, ManagedLedgerImpl ml, boolean copyEntries) {
         this.manager = manager;
@@ -257,6 +272,77 @@ public class RangeEntryCacheImpl implements EntryCache {
         }
     }
 
+    @AllArgsConstructor
+    private static final class ReadEntriesCallbackWithContext {
+        ReadEntriesCallback callback;
+        Object ctx;
+    }
+    private class CachedPendingRead {
+        final PendingReadKey key;
+        final List<ReadEntriesCallbackWithContext> callbacks = new ArrayList<>(1);
+        boolean completed = false;
+
+        public CachedPendingRead(PendingReadKey key) {
+            this.key = key;
+        }
+
+        public void attach(CompletableFuture<List<EntryImpl>> handle) {
+            // when the future is done remove this from the map
+            // new reads will go to a new instance
+            // this is required because we are going to do refcount management
+            // on the results of the callback
+            handle.whenComplete((___, error) -> {
+                synchronized (CachedPendingRead.this) {
+                    completed = true;
+                    cachedPendingReads.remove(key, this);
+                }
+            });
+
+            handle.thenAcceptAsync(entriesToReturn -> {
+                synchronized (CachedPendingRead.this) {
+                    if (callbacks.size() == 1) {
+                        callbacks.get(0)
+                                .callback.readEntriesComplete((List) entriesToReturn,
+                                        callbacks.get(0).ctx);
+                    } else {
+                        for (ReadEntriesCallbackWithContext callback : callbacks) {
+                            List<EntryImpl> copy = new ArrayList<>(entriesToReturn.size());
+                            for (EntryImpl entry : entriesToReturn) {
+                                EntryImpl entryCopy = EntryImpl.create(entry);
+                                copy.add(entryCopy);
+                            }
+                            callback.callback.readEntriesComplete((List) copy, callback.ctx);
+                        }
+                        for (EntryImpl entry : entriesToReturn) {
+                            entry.release();
+                        }
+                    }
+                }
+            }, ml.getExecutor().chooseThread(ml.getName())).exceptionally(exception -> {
+                synchronized (CachedPendingRead.this) {
+                    for (ReadEntriesCallbackWithContext callback : callbacks) {
+                        if (exception instanceof BKException
+                                && ((BKException) exception).getCode() == BKException.Code.TooManyRequestsException) {
+                            callback.callback.readEntriesFailed(createManagedLedgerException(exception), callback.ctx);
+                        } else {
+                            ManagedLedgerException mlException = createManagedLedgerException(exception);
+                            callback.callback.readEntriesFailed(mlException, callback.ctx);
+                        }
+                    }
+                }
+                return null;
+            });
+        }
+
+        synchronized boolean addListener(ReadEntriesCallback callback, Object ctx) {
+            if (completed) {
+                return false;
+            }
+            callbacks.add(new ReadEntriesCallbackWithContext(callback, ctx));
+            return true;
+        }
+    }
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     private void asyncReadEntry0(ReadHandle lh, long firstEntry, long lastEntry, boolean shouldCacheEntry,
             final ReadEntriesCallback callback, Object ctx) {
@@ -296,44 +382,61 @@ public class RangeEntryCacheImpl implements EntryCache {
             }
 
             // Read all the entries from bookkeeper
-            lh.readAsync(firstEntry, lastEntry).thenAcceptAsync(
-                    ledgerEntries -> {
-                        checkNotNull(ml.getName());
-                        checkNotNull(ml.getExecutor());
+            final PendingReadKey key = new PendingReadKey(lh.getId(), firstEntry, lastEntry);
 
-                        try {
-                            // We got the entries, we need to transform them to a List<> type
-                            long totalSize = 0;
-                            final List<EntryImpl> entriesToReturn = Lists.newArrayListWithExpectedSize(entriesToRead);
-                            for (LedgerEntry e : ledgerEntries) {
-                                EntryImpl entry = RangeEntryCacheManagerImpl.create(e, interceptor);
-                                entriesToReturn.add(entry);
-                                totalSize += entry.getLength();
-                                if (shouldCacheEntry) {
-                                    EntryImpl cacheEntry = EntryImpl.create(entry);
-                                    insert(cacheEntry);
-                                    cacheEntry.release();
-                                }
-                            }
+            boolean listenerAdded = false;
+            while (!listenerAdded) {
+                AtomicBoolean createdByThisThread = new AtomicBoolean();
+                CachedPendingRead cachedPendingRead = cachedPendingReads.computeIfAbsent(key, operationKey -> {
+                    createdByThisThread.set(true);
+                    return new CachedPendingRead(operationKey);
+                });
+                listenerAdded = cachedPendingRead.addListener(callback, ctx);
 
-                            manager.mlFactoryMBean.recordCacheMiss(entriesToReturn.size(), totalSize);
-                            ml.getMbean().addReadEntriesSample(entriesToReturn.size(), totalSize);
+                if (createdByThisThread.get()) {
+                    CompletableFuture<List<EntryImpl>> readResult = lh.readAsync(firstEntry, lastEntry)
+                            .thenApply(
+                                    ledgerEntries -> {
+                                        checkNotNull(ml.getName());
+                                        checkNotNull(ml.getExecutor());
 
-                            callback.readEntriesComplete((List) entriesToReturn, ctx);
-                        } finally {
-                            ledgerEntries.close();
-                        }
-                    }, ml.getExecutor().chooseThread(ml.getName())).exceptionally(exception -> {
+                                        try {
+                                            // We got the entries, we need to transform them to a List<> type
+                                            long totalSize = 0;
+                                            final List<EntryImpl> entriesToReturn =
+                                                    Lists.newArrayListWithExpectedSize(entriesToRead);
+                                            for (LedgerEntry e : ledgerEntries) {
+                                                EntryImpl entry = RangeEntryCacheManagerImpl.create(e, interceptor);
+                                                entriesToReturn.add(entry);
+                                                totalSize += entry.getLength();
+                                                if (shouldCacheEntry) {
+                                                    EntryImpl cacheEntry = EntryImpl.create(entry);
+                                                    insert(cacheEntry);
+                                                    cacheEntry.release();
+                                                }
+                                            }
+
+                                            manager.mlFactoryMBean.recordCacheMiss(entriesToReturn.size(), totalSize);
+                                            ml.getMbean().addReadEntriesSample(entriesToReturn.size(), totalSize);
+
+                                            return entriesToReturn;
+                                        } finally {
+                                            ledgerEntries.close();
+                                        }
+                                    });
+                    // handle LH invalidation
+                    readResult.exceptionally(exception -> {
                         if (exception instanceof BKException
                                 && ((BKException) exception).getCode() == BKException.Code.TooManyRequestsException) {
-                            callback.readEntriesFailed(createManagedLedgerException(exception), ctx);
                         } else {
                             ml.invalidateLedgerHandle(lh);
-                            ManagedLedgerException mlException = createManagedLedgerException(exception);
-                            callback.readEntriesFailed(mlException, ctx);
                         }
                         return null;
-            });
+                    });
+
+                    cachedPendingRead.attach(readResult);
+                }
+            }
         }
     }
 
@@ -341,6 +444,7 @@ public class RangeEntryCacheImpl implements EntryCache {
     public void clear() {
         long removedSize = entries.clear();
         manager.entriesRemoved(removedSize);
+        cachedPendingReads.clear();
     }
 
     @Override


### PR DESCRIPTION
Problem:
In fan out scenarios (when you have multiple subscriptions on the same topic) it is very likely that Pulsar sends the same read request to the bookie when the cursor are "catching up".
This in turn adds much pressure on the bookies.

Modifications:
This patch saves BK resources by not sending reads for the same "range" of entries for a given Ledger.

Running benchmarks we have observed that it is a condition that is very likely to happen.