### PR TITLE
Pulsar shell: allow custom commands

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
@@ -193,7 +193,7 @@ public class PulsarAdminTool {
                 cause = e;
             }
             System.err.println(cause.getClass() + ": " + cause.getMessage());
-            System.exit(1);
+            exit(1);
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
@@ -249,7 +249,6 @@ public class PulsarAdminTool {
             jcommander.usage();
             return false;
         }
-
         if (isBlank(rootParams.serviceUrl)) {
             System.out.println("Can't find any admin url to use");
             jcommander.usage();

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
@@ -249,6 +249,7 @@ public class PulsarAdminTool {
             jcommander.usage();
             return false;
         }
+
         if (isBlank(rootParams.serviceUrl)) {
             System.out.println("Can't find any admin url to use");
             jcommander.usage();

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/AdminShell.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/AdminShell.java
@@ -51,7 +51,6 @@ public class AdminShell extends PulsarAdminTool implements ShellCommandsProvider
     @Override
     public void setupState(Properties properties) {
         getJCommander().setProgramName(getName());
-        setupCommands(b -> null);
     }
 
     @Override


### PR DESCRIPTION
Without this change if you add custom commands you get a NPE.
Because setupCommands is running twice