### PR TITLE
[enh][managed-ledger] Add experimental prometheus metrics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -38,6 +38,7 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.concurrent.Promise;
 import io.prometheus.client.Gauge;
+import io.prometheus.client.Summary;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Collections;
@@ -208,6 +209,8 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     private final long maxPendingBytesPerThread;
     private final long resumeThresholdPendingBytesPerThread;
 
+    private Summary.Timer unwritabilitySummaryTimer;
+
     // Number of bytes pending to be published from a single specific IO thread.
     private static final FastThreadLocal<MutableLong> pendingBytesPerThread = new FastThreadLocal<MutableLong>() {
         @Override
@@ -338,6 +341,15 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
         if (log.isDebugEnabled()) {
             log.debug("Channel writability has changed to: {}", ctx.channel().isWritable());
+        }
+        // This logic assumes that the state always goes writable to unwritable or unwritable to writable
+        if (ctx.channel().isWritable()) {
+            if (unwritabilitySummaryTimer != null) {
+                unwritabilitySummaryTimer.observeDuration();
+                unwritabilitySummaryTimer = null;
+            }
+        } else {
+            unwritabilitySummaryTimer = unwritabilityDuration.startTimer();
         }
     }
 
@@ -2592,6 +2604,13 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     private static final Gauge throttledConnections = Gauge.build()
             .name("pulsar_broker_throttled_connections")
             .help("Counter of connections throttled because of per-connection limit")
+            .register();
+
+    private static final Summary unwritabilityDuration = Summary.build()
+            .name("pulsar_broker_cnx_unwritability_duration")
+            .help("Counter changes")
+            .quantile(0.5, 0.01)
+            .quantile(0.99, 0.01)
             .register();
 
     private static final Gauge throttledConnectionsGlobal = Gauge.build()

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -22,6 +22,7 @@ import static org.apache.bookkeeper.mledger.util.SafeRun.safeRun;
 import static org.apache.pulsar.broker.service.persistent.PersistentTopic.MESSAGE_RATE_BACKOFF_MS;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
+import io.prometheus.client.Counter;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -75,6 +76,11 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
     protected final PersistentTopic topic;
     protected final ManagedCursor cursor;
     protected volatile Range<PositionImpl> lastIndividualDeletedRangeFromCursorRecovery;
+
+    private static final Counter unwritableWhileReadingMessages = Counter.build()
+            .name("pulsar_broker_unwritable_read_bookie_total")
+            .help("Number of times the dispatcher decreased reads due to channel not writable")
+            .register();
 
     private CompletableFuture<Void> closeFuture = null;
     protected final MessageRedeliveryController redeliveryMessages;
@@ -348,6 +354,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
             // message. The intent here is to keep use the request as a notification mechanism while avoiding to
             // read and dispatch a big batch of messages which will need to wait before getting written to the
             // socket.
+            unwritableWhileReadingMessages.inc();
             messagesToRead = 1;
         }
 


### PR DESCRIPTION
### Motivation

Add a summary to track the time in the cache. I chose a summary instead of a histogram because we don't have any idea of the expected time in the cache. It's not clear to me how expensive it is to track this data via a Prometheus Summary, so we should verify that before pushing it into any production environment.

Add several other metrics related to the consumer's read path.

This PR does not follow the observable guidelines in the Pulsar project to avoid using the prometheus client directly. At the very least, it will be helpful for testing.

### Modifications

* Add Summary named `pulsar_ml_cache_entry_duration_millis` to the `RangeCache`
* As a minor optimization, I only call `System.nanoTime()` once for all of the duration calculations done in each loop
* Add Summary named `pulsar_ml_cache_entry_range_size` to the `RangeEntryCacheImpl`
* Add Summary named `pulsar_broker_cnx_unwritability_duration` to the `ServerCnx`
* Add Counter named `pulsar_broker_unwritable_read_bookie_total` to `PersistentDispatcherMultipleConsumers` (this should probably have been in more dispatchers)