### PR TITLE
Add debug for Proxy tests

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfigurationUtils.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfigurationUtils.java
@@ -43,7 +43,9 @@ public class ServiceConfigurationUtils {
     public static String unsafeLocalhostResolve() {
         try {
             // Get the fully qualified hostname
-            return InetAddress.getLocalHost().getCanonicalHostName();
+            String result =  InetAddress.getLocalHost().getCanonicalHostName();
+            LOG.info("unsafeLocalhostResolve -> {}", result);
+            return result;
         } catch (UnknownHostException ex) {
             LOG.error(ex.getMessage(), ex);
             throw new IllegalStateException("Failed to resolve localhost name.", ex);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -225,6 +225,7 @@ public class ClientCnx extends PulsarHandler {
         super.channelActive(ctx);
         this.localAddress = ctx.channel().localAddress();
         this.remoteAddress = ctx.channel().remoteAddress();
+        log.info("{} localAddress {} remoteAddress {}", ctx.channel(), localAddress, remoteAddress);
 
         this.timeoutTask = this.eventLoopGroup
                 .scheduleAtFixedRate(catchingAndLoggingThrowables(this::checkRequestTimeout), operationTimeoutMs,
@@ -234,6 +235,7 @@ public class ClientCnx extends PulsarHandler {
             if (log.isDebugEnabled()) {
                 log.debug("{} Connected to broker", ctx.channel());
             }
+            log.info("{} Connected to broker", ctx.channel());
         } else {
             log.info("{} Connected through proxy to target broker at {}", ctx.channel(), proxyToTargetBrokerAddress);
         }

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
@@ -526,7 +526,6 @@ public class ProxyConnection extends PulsarHandler {
         ProxyConfiguration proxyConfig = service.getConfiguration();
         initialConf.setServiceUrl(
                 proxyConfig.isTlsEnabledWithBroker() ? service.getServiceUrlTls() : service.getServiceUrl());
-
         // Apply all arbitrary configuration. This must be called before setting any fields annotated as
         // @Secret on the ClientConfigurationData object because of the way they are serialized.
         // See https://github.com/apache/pulsar/issues/8509 for more information.
@@ -534,7 +533,6 @@ public class ProxyConnection extends PulsarHandler {
                 .filterAndMapProperties(proxyConfig.getProperties(), "brokerClient_");
         ClientConfigurationData clientConf = ConfigurationDataUtils
                 .loadData(overrides, initialConf, ClientConfigurationData.class);
-
         clientConf.setAuthentication(this.getClientAuthentication());
         if (proxyConfig.isTlsEnabledWithBroker()) {
             clientConf.setUseTls(true);
@@ -549,6 +547,8 @@ public class ProxyConnection extends PulsarHandler {
                 clientConf.setTlsAllowInsecureConnection(proxyConfig.isTlsAllowInsecureConnection());
             }
         }
+        LOG.info("Created client conf tlsVer {} serviceUrl {} , tls {}, dump {}",
+                clientConf.isTlsHostnameVerificationEnable(), clientConf.getServiceUrl(), clientConf.isUseTls(), clientConf);
         return clientConf;
     }
 


### PR DESCRIPTION
Add debug to understand the cause of this issue on CI

ava.lang.AssertionError: Connection should be failed due to hostnameVerification enabled
	at org.testng.Assert.fail(Assert.java:99)
	at org.apache.pulsar.proxy.server.ProxyWithAuthorizationTest.testTlsHostVerificationProxyToBroker(ProxyWithAuthorizationTest.java:372)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132)
	at org.testng.internal.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:45)
	at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:73)
	at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:11)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
