### PR TITLE
Feature: allow dynamic subscription name for multi-topic consumers

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 import org.apache.pulsar.common.classification.InterfaceAudience;
 import org.apache.pulsar.common.classification.InterfaceStability;
@@ -166,6 +167,15 @@ public interface ConsumerBuilder<T> extends Cloneable {
      * @return the consumer builder instance
      */
     ConsumerBuilder<T> subscriptionName(String subscriptionName);
+
+    /**
+     * Specify a function to compute the subscription name depending on the topic for this consumer.
+     *
+     * @param subscriptionNameByTopic a function called to compute the subscription name given a topic.
+     *
+     * @return the consumer builder instance
+     */
+    ConsumerBuilder<T> subscriptionNameByTopic(Function<String, String> subscriptionNameByTopic);
 
     /**
      * Specify the subscription properties for this subscription.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.AccessLevel;
@@ -216,6 +217,12 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
     public ConsumerBuilder<T> subscriptionName(String subscriptionName) {
         checkArgument(StringUtils.isNotBlank(subscriptionName), "subscriptionName cannot be blank");
         conf.setSubscriptionName(subscriptionName);
+        return this;
+    }
+
+    @Override
+    public ConsumerBuilder<T> subscriptionNameByTopic(Function<String, String> subscriptionNameByTopic) {
+        conf.setSubscriptionNameByTopic(subscriptionNameByTopic);
         return this;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -198,6 +198,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
     private final boolean createTopicIfDoesNotExist;
     private final boolean poolMessages;
+    protected final String subscription;
 
     private final AtomicReference<ClientCnx> clientCnxUsedForConsumerRegistration = new AtomicReference<>();
     private final List<Throwable> previousExceptions = new CopyOnWriteArrayList<Throwable>();
@@ -250,6 +251,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
            boolean createTopicIfDoesNotExist) {
         super(client, topic, conf, conf.getReceiverQueueSize(), executorProvider, subscribeFuture, schema,
                 interceptors);
+        this.subscription = subscriptionByTopic.apply(topic);
         this.consumerId = client.newConsumerId();
         this.subscriptionMode = conf.getSubscriptionMode();
         if (startMessageId != null) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorderImpl.java
@@ -156,7 +156,7 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
                             currentNumBatchReceiveFailed, currentNumAcksFailed);
                 }
             } catch (Exception e) {
-                log.error("[{}] [{}] [{}]: {}", consumerImpl.getTopic(), consumerImpl.subscription
+                log.error("[{}] [{}] [{}]: {}", consumerImpl.getTopic(), consumerImpl.getSubscription()
                         , consumerImpl.consumerName, e.getMessage());
             } finally {
                 // schedule the next stat info

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -258,7 +258,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         messagesFuture.thenAcceptAsync(messages -> {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] [{}] Receive message from sub consumer:{}",
-                    topic, getSubscription(), consumer.getTopic());
+                    topic, consumer.getSubscription(), consumer.getTopic());
             }
             // Process the message, add to the queue and trigger listener or async callback
             messages.forEach(msg -> messageReceived(consumer, msg));
@@ -300,7 +300,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
         if (log.isDebugEnabled()) {
             log.debug("[{}][{}] Received message from topics-consumer {}",
-                    topic, getSubscription(), message.getMessageId());
+                    topic, consumer.getSubscription(), message.getMessageId());
         }
 
         // if asyncReceive is waiting : return message to callback without adding to incomingMessages queue

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -28,6 +28,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -58,6 +59,8 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
     private Pattern topicsPattern;
 
     private String subscriptionName;
+
+    private Function<String, String> subscriptionNameByTopic;
 
     private SubscriptionType subscriptionType = SubscriptionType.Exclusive;
 


### PR DESCRIPTION
Proof-of-concept:
Allow the Consumer to have a function to calculate dynamically the subscription name depending on the topic name.
This is useful for Pattern consumers and Multi Topic consumers, when you have to set a different subscription name depending on the topic name.