### PR TITLE
Cherry-picks of apache PRs 17909 and 17638

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
@@ -292,14 +292,19 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
 
     protected void receivedSessionEvent(SessionEvent event) {
         isConnected = event.isConnected();
-
-        sessionListeners.forEach(l -> {
-            try {
-                l.accept(event);
-            } catch (Throwable t) {
-                log.warn("Error in processing session event", t);
-            }
-        });
+        try {
+            executor.execute(() -> {
+                sessionListeners.forEach(l -> {
+                    try {
+                        l.accept(event);
+                    } catch (Throwable t) {
+                        log.warn("Error in processing session event " + event, t);
+                    }
+                });
+            });
+        } catch (RejectedExecutionException e) {
+            log.warn("Error in processing session event " + event, e);
+        }
     }
 
     @Override

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -98,7 +98,7 @@ public class ZKMetadataStore extends AbstractBatchedMetadataStore
                     .sessionTimeoutMs(metadataStoreConfig.getSessionTimeoutMillis())
                     .watchers(Collections.singleton(event -> {
                         if (sessionWatcher != null) {
-                            sessionWatcher.ifPresent(sw -> sw.process(event));
+                            sessionWatcher.ifPresent(sw -> executor.execute(() -> sw.process(event)));
                         }
                     }))
                     .build();


### PR DESCRIPTION
Cherry-picks of:

https://github.com/apache/pulsar/pull/17638
```
Author: Lari Hotari <lhotari@users.noreply.github.com>
Date:   Mon Sep 19 05:40:18 2022 +0300

    [fix][metadata] Handle session events in separate thread (#17638)

    (cherry picked from commit 69f3f7471fa6faf24d4776d65e0509538c105d37)
```

https://github.com/apache/pulsar/pull/17909
```
Author: Penghui Li <penghui@apache.org>
Date:   Sun Oct 2 08:46:09 2022 +0800

    [fix][broker] Fix the broker shutdown issue after Zookeeper node crashed (#17909)

    (cherry picked from commit e26060a1e15a3488fc93cdff6bb0e95e7ec52fed)
```