### PR TITLE
Limit the number of pending requests to BookKeeper to save the broker from OODM

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1064,6 +1064,14 @@ managedLedgerCursorRolloverTimeInSeconds=14400
 # crashes.
 managedLedgerMaxUnackedRangesToPersist=10000
 
+# Maximum amount of memory used to execute reads from storage.
+# This mechanism prevents the broker to have too many concurrent
+# reads from storage and fall into Out of memory errors in case
+# of multiple concurrent reads.
+# Set 0 in order to disable the feature.
+#
+managedLedgerMaxPendingReadsBufferSizeInMB=0
+
 # Max number of "acknowledgment holes" that can be stored in Zookeeper. If number of unack message range is higher
 # than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
 # zookeeper.

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactoryConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactoryConfig.java
@@ -58,6 +58,11 @@ public class ManagedLedgerFactoryConfig {
     private boolean copyEntriesInCache = false;
 
     /**
+     * Maximum number of (estimated) data in-flight reading from storage.
+     */
+    private long maxPendingReadsBufferSize = 0;
+
+    /**
      * Whether trace managed ledger task execution time.
      */
     private boolean traceTaskExecution = true;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/PendingReadsLimiter.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/PendingReadsLimiter.java
@@ -1,0 +1,126 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl.cache;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.prometheus.client.Gauge;
+import lombok.AllArgsConstructor;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class PendingReadsLimiter {
+
+    private static final Gauge PULSAR_ML_PENDING_READS_BUFFER_SIZE = Gauge
+            .build()
+            .name("pulsar_ml_pending_reads_buffer_size")
+            .help("Estimated number of bytes for pending reads from storage")
+            .register();
+
+    private final long maxPendingReadsBufferSize;
+    private long remainingPendingRequestsBytes;
+
+    public PendingReadsLimiter(long maxPendingReadsBufferSize) {
+        this.maxPendingReadsBufferSize = maxPendingReadsBufferSize;
+        this.remainingPendingRequestsBytes = maxPendingReadsBufferSize;
+    }
+
+    @VisibleForTesting
+    public synchronized long getRemainingPendingRequestsBytes() {
+        return remainingPendingRequestsBytes;
+    }
+
+    @AllArgsConstructor
+    @ToString
+    static class Handle {
+        final long acquiredPermits;
+        final boolean success;
+        final int trials;
+
+        final long creationTime;
+    }
+
+    private static final Handle DISABLED = new Handle(0, true, 0, -1);
+
+    Handle acquire(long permits, Handle current) {
+        if (maxPendingReadsBufferSize <= 0) {
+            // feature is disabled
+            return DISABLED;
+        }
+        synchronized (this) {
+            try {
+                if (current == null) {
+                    if (remainingPendingRequestsBytes == 0) {
+                        return new Handle(0, false, 1, System.currentTimeMillis());
+                    }
+                    long needed = permits;
+                    if (remainingPendingRequestsBytes >= needed) {
+                        remainingPendingRequestsBytes -= needed;
+                        return new Handle(permits, true, 1, System.currentTimeMillis());
+                    } else {
+                        long possible = remainingPendingRequestsBytes;
+                        remainingPendingRequestsBytes = 0;
+                        return new Handle(possible, false, 1, System.currentTimeMillis());
+                    }
+                } else {
+                    if (current.trials >= 4 && current.acquiredPermits > 0) {
+                        remainingPendingRequestsBytes += current.acquiredPermits;
+                        return new Handle(0, false, 1, current.creationTime);
+                    }
+                    if (remainingPendingRequestsBytes == 0) {
+                        return new Handle(current.acquiredPermits, false, current.trials + 1,
+                                current.creationTime);
+                    }
+                    long needed = permits - current.acquiredPermits;
+                    if (remainingPendingRequestsBytes >= needed) {
+                        remainingPendingRequestsBytes -= needed;
+                        return new Handle(permits, true, current.trials + 1, current.creationTime);
+                    } else {
+                        long possible = remainingPendingRequestsBytes;
+                        remainingPendingRequestsBytes = 0;
+                        return new Handle(current.acquiredPermits + possible, false,
+                                current.trials + 1, current.creationTime);
+                    }
+                }
+            } finally {
+                updateMetrics();
+            }
+        }
+    }
+
+    void release(Handle handle) {
+        if (handle == DISABLED) {
+            return;
+        }
+        synchronized (this) {
+            remainingPendingRequestsBytes += handle.acquiredPermits;
+            updateMetrics();
+        }
+    }
+
+    private synchronized void updateMetrics() {
+        PULSAR_ML_PENDING_READS_BUFFER_SIZE.set(maxPendingReadsBufferSize - remainingPendingRequestsBytes);
+    }
+
+    public boolean isDisabled() {
+        return maxPendingReadsBufferSize <= 0;
+    }
+
+
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheManagerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheManagerImpl.java
@@ -51,14 +51,15 @@ public class RangeEntryCacheManagerImpl implements EntryCacheManager {
 
     private final ManagedLedgerFactoryImpl mlFactory;
     protected final ManagedLedgerFactoryMBeanImpl mlFactoryMBean;
+    private final PendingReadsLimiter pendingReadsLimiter;
 
     protected static final double MB = 1024 * 1024;
-
     private static final double evictionTriggerThresholdPercent = 0.98;
 
 
     public RangeEntryCacheManagerImpl(ManagedLedgerFactoryImpl factory) {
         this.maxSize = factory.getConfig().getMaxCacheSize();
+        this.pendingReadsLimiter = new PendingReadsLimiter(factory.getConfig().getMaxPendingReadsBufferSize());
         this.evictionTriggerThreshold = (long) (maxSize * evictionTriggerThresholdPercent);
         this.cacheEvictionWatermark = factory.getConfig().getCacheEvictionWatermark();
         this.evictionPolicy = new EntryCacheDefaultEvictionPolicy();
@@ -193,6 +194,10 @@ public class RangeEntryCacheManagerImpl implements EntryCacheManager {
             ledgerEntry.close();
         }
         return returnEntry;
+    }
+
+    public PendingReadsLimiter getPendingReadsLimiter() {
+        return pendingReadsLimiter;
     }
 
     private static final Logger log = LoggerFactory.getLogger(RangeEntryCacheManagerImpl.class);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/EntryCacheManagerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/EntryCacheManagerTest.java
@@ -38,6 +38,7 @@ import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactoryConfig;
 import org.apache.bookkeeper.mledger.impl.cache.EntryCache;
@@ -62,10 +63,12 @@ public class EntryCacheManagerTest extends MockedBookKeeperTestCase {
         when(ml1.getMbean()).thenReturn(new ManagedLedgerMBeanImpl(ml1));
         when(ml1.getExecutor()).thenReturn(super.executor);
         when(ml1.getFactory()).thenReturn(factory);
+        when(ml1.getConfig()).thenReturn(new ManagedLedgerConfig());
 
         ml2 = mock(ManagedLedgerImpl.class);
         when(ml2.getScheduledExecutor()).thenReturn(executor);
         when(ml2.getName()).thenReturn("cache2");
+        when(ml2.getConfig()).thenReturn(new ManagedLedgerConfig());
     }
 
     @Test

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/EntryCacheTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/EntryCacheTest.java
@@ -41,6 +41,7 @@ import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.client.impl.LedgerEntryImpl;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntriesCallback;
 import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.impl.cache.EntryCache;
 import org.apache.bookkeeper.mledger.impl.cache.EntryCacheManager;
@@ -58,6 +59,7 @@ public class EntryCacheTest extends MockedBookKeeperTestCase {
         when(ml.getName()).thenReturn("name");
         when(ml.getExecutor()).thenReturn(executor);
         when(ml.getMbean()).thenReturn(new ManagedLedgerMBeanImpl(ml));
+        when(ml.getConfig()).thenReturn(new ManagedLedgerConfig());
     }
 
     @Test(timeOut = 5000)

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/PendingReadsLimiterTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/PendingReadsLimiterTest.java
@@ -1,0 +1,172 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl.cache;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import lombok.extern.slf4j.Slf4j;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class PendingReadsLimiterTest {
+
+    @Test
+    public void testDisabled() throws Exception {
+
+        PendingReadsLimiter limiter = new PendingReadsLimiter(0);
+        assertTrue(limiter.isDisabled());
+
+        limiter = new PendingReadsLimiter(-1);
+        assertTrue(limiter.isDisabled());
+
+        limiter = new PendingReadsLimiter(1);
+        assertFalse(limiter.isDisabled());
+    }
+
+    @Test
+    public void testBasicAcquireRelease() throws Exception {
+        PendingReadsLimiter limiter = new PendingReadsLimiter(100);
+        assertEquals(100, limiter.getRemainingPendingRequestsBytes());
+        PendingReadsLimiter.Handle handle = limiter.acquire(100, null);
+        assertEquals(0, limiter.getRemainingPendingRequestsBytes());
+        assertTrue(handle.success);
+        assertEquals(handle.acquiredPermits, 100);
+        assertEquals(1, handle.trials);
+        limiter.release(handle);
+        assertEquals(100, limiter.getRemainingPendingRequestsBytes());
+    }
+
+    @Test
+    public void testNotEnoughPermits() throws Exception {
+        PendingReadsLimiter limiter = new PendingReadsLimiter(100);
+        assertEquals(100, limiter.getRemainingPendingRequestsBytes());
+        PendingReadsLimiter.Handle handle = limiter.acquire(100, null);
+        assertEquals(0, limiter.getRemainingPendingRequestsBytes());
+        assertTrue(handle.success);
+        assertEquals(handle.acquiredPermits, 100);
+        assertEquals(1, handle.trials);
+
+        PendingReadsLimiter.Handle handle2 = limiter.acquire(100, null);
+        assertEquals(0, limiter.getRemainingPendingRequestsBytes());
+        assertFalse(handle2.success);
+        assertEquals(handle2.acquiredPermits, 0);
+        assertEquals(1, handle2.trials);
+
+        limiter.release(handle);
+        assertEquals(100, limiter.getRemainingPendingRequestsBytes());
+
+        handle2 = limiter.acquire(100, handle2);
+        assertEquals(0, limiter.getRemainingPendingRequestsBytes());
+        assertTrue(handle2.success);
+        assertEquals(handle2.acquiredPermits, 100);
+        assertEquals(2, handle2.trials);
+
+        limiter.release(handle2);
+        assertEquals(100, limiter.getRemainingPendingRequestsBytes());
+
+    }
+
+    @Test
+    public void testPartialAcquire() throws Exception {
+        PendingReadsLimiter limiter = new PendingReadsLimiter(100);
+        assertEquals(100, limiter.getRemainingPendingRequestsBytes());
+
+        PendingReadsLimiter.Handle handle = limiter.acquire(30, null);
+        assertEquals(70, limiter.getRemainingPendingRequestsBytes());
+        assertTrue(handle.success);
+        assertEquals(handle.acquiredPermits, 30);
+        assertEquals(1, handle.trials);
+
+        PendingReadsLimiter.Handle handle2 = limiter.acquire(100, null);
+        assertEquals(0, limiter.getRemainingPendingRequestsBytes());
+        assertFalse(handle2.success);
+        assertEquals(handle2.acquiredPermits, 70);
+        assertEquals(1, handle2.trials);
+
+        limiter.release(handle);
+
+        handle2 = limiter.acquire(100, handle2);
+        assertEquals(0, limiter.getRemainingPendingRequestsBytes());
+        assertTrue(handle2.success);
+        assertEquals(handle2.acquiredPermits, 100);
+        assertEquals(2, handle2.trials);
+
+        limiter.release(handle2);
+        assertEquals(100, limiter.getRemainingPendingRequestsBytes());
+
+    }
+
+    @Test
+    public void testTooManyTrials() throws Exception {
+        PendingReadsLimiter limiter = new PendingReadsLimiter(100);
+        assertEquals(100, limiter.getRemainingPendingRequestsBytes());
+
+        PendingReadsLimiter.Handle handle = limiter.acquire(30, null);
+        assertEquals(70, limiter.getRemainingPendingRequestsBytes());
+        assertTrue(handle.success);
+        assertEquals(handle.acquiredPermits, 30);
+        assertEquals(1, handle.trials);
+
+        PendingReadsLimiter.Handle handle2 = limiter.acquire(100, null);
+        assertEquals(0, limiter.getRemainingPendingRequestsBytes());
+        assertFalse(handle2.success);
+        assertEquals(handle2.acquiredPermits, 70);
+        assertEquals(1, handle2.trials);
+
+        handle2 = limiter.acquire(100, handle2);
+        assertEquals(0, limiter.getRemainingPendingRequestsBytes());
+        assertFalse(handle2.success);
+        assertEquals(handle2.acquiredPermits, 70);
+        assertEquals(2, handle2.trials);
+
+        handle2 = limiter.acquire(100, handle2);
+        assertEquals(0, limiter.getRemainingPendingRequestsBytes());
+        assertFalse(handle2.success);
+        assertEquals(handle2.acquiredPermits, 70);
+        assertEquals(3, handle2.trials);
+
+        handle2 = limiter.acquire(100, handle2);
+        assertEquals(0, limiter.getRemainingPendingRequestsBytes());
+        assertFalse(handle2.success);
+        assertEquals(handle2.acquiredPermits, 70);
+        assertEquals(4, handle2.trials);
+
+        // too many trials, start from scratch
+        handle2 = limiter.acquire(100, handle2);
+        assertEquals(70, limiter.getRemainingPendingRequestsBytes());
+        assertFalse(handle2.success);
+        assertEquals(handle2.acquiredPermits, 0);
+        assertEquals(1, handle2.trials);
+
+        limiter.release(handle);
+
+        handle2 = limiter.acquire(100, handle2);
+        assertEquals(0, limiter.getRemainingPendingRequestsBytes());
+        assertTrue(handle2.success);
+        assertEquals(handle2.acquiredPermits, 100);
+        assertEquals(2, handle2.trials);
+
+        limiter.release(handle2);
+        assertEquals(100, limiter.getRemainingPendingRequestsBytes());
+
+    }
+
+}

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/PendingReadsManagerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/PendingReadsManagerTest.java
@@ -24,6 +24,7 @@ import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.EntryImpl;
@@ -80,12 +81,19 @@ public class PendingReadsManagerTest  {
 
     RangeEntryCacheImpl rangeEntryCache;
     PendingReadsManager pendingReadsManager;
+    PendingReadsLimiter pendingReadsLimiter;
     ReadHandle lh;
     ManagedLedgerImpl ml;
 
     @BeforeMethod(alwaysRun = true)
     void setupMocks() {
         rangeEntryCache = mock(RangeEntryCacheImpl.class);
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setReadEntryTimeoutSeconds(10000);
+        when(rangeEntryCache.getName()).thenReturn("my-topic");
+        when(rangeEntryCache.getManagedLedgerConfig()).thenReturn(config);
+        pendingReadsLimiter = new PendingReadsLimiter(0);
+        when(rangeEntryCache.getPendingReadsLimiter()).thenReturn(pendingReadsLimiter);
         pendingReadsManager = new PendingReadsManager(rangeEntryCache);
         doAnswer(new Answer() {
             @Override

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1746,6 +1746,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(category = CATEGORY_STORAGE_ML, doc = "Whether we should make a copy of the entry payloads when "
             + "inserting in cache")
     private boolean managedLedgerCacheCopyEntries = false;
+
+    @FieldContext(category = CATEGORY_STORAGE_ML, doc = "Maximum buffer size for reads from storage."
+            + " Use O to disable")
+    private long managedLedgerMaxPendingReadsBufferSizeInMB = 0;
+
     @FieldContext(
         category = CATEGORY_STORAGE_ML,
         dynamic = true,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
@@ -63,6 +63,8 @@ public class ManagedLedgerClientFactory implements ManagedLedgerStorage {
         managedLedgerFactoryConfig.setCacheEvictionTimeThresholdMillis(
                 conf.getManagedLedgerCacheEvictionTimeThresholdMillis());
         managedLedgerFactoryConfig.setCopyEntriesInCache(conf.isManagedLedgerCacheCopyEntries());
+        managedLedgerFactoryConfig.setMaxPendingReadsBufferSize(
+                conf.getManagedLedgerMaxPendingReadsBufferSizeInMB() * 1024L * 1024L);
         managedLedgerFactoryConfig.setPrometheusStatsLatencyRolloverSeconds(
                 conf.getManagedLedgerPrometheusStatsLatencyRolloverSeconds());
         managedLedgerFactoryConfig.setTraceTaskExecution(conf.isManagedLedgerTraceTaskExecution());


### PR DESCRIPTION
Modifications:
- limit the global number of pending reads to BookKeeper
- new configuration entry `managedLedgerMaxPendingReadsBufferSizeInMB` (0 = feature disabled)
- we estimate the entry size per-topic, using the size of the last read entry (new metric `pulsar_ml_pending_reads_estimated_entry_size`, per topic)
- new metric `pulsar_ml_pending_reads_buffer_size`to get the estimated size of in-flight read requests in bytes
- if the feature is disabled this changed does not add significant overhead

Result:
This prevents the broker from going to OutOfMemory (direct memory) in case of many concurrent reads from the bookie




