### PR TITLE
Bringing PR 18193 to LS 2.10

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1187,7 +1187,7 @@ loadManagerClassName=org.apache.pulsar.broker.loadbalance.impl.ModularLoadManage
 # Supported algorithms name for namespace bundle split.
 # "range_equally_divide" divides the bundle into two parts with the same hash range size.
 # "topic_count_equally_divide" divides the bundle into two parts with the same topics count.
-supportedNamespaceBundleSplitAlgorithms=range_equally_divide,topic_count_equally_divide
+supportedNamespaceBundleSplitAlgorithms=range_equally_divide,topic_count_equally_divide,specified_positions_divide
 
 # Default algorithm name for namespace bundle split
 defaultNamespaceBundleSplitAlgorithm=range_equally_divide

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -933,7 +933,7 @@ loadManagerClassName=org.apache.pulsar.broker.loadbalance.impl.ModularLoadManage
 # Supported algorithms name for namespace bundle split.
 # "range_equally_divide" divides the bundle into two parts with the same hash range size.
 # "topic_count_equally_divide" divides the bundle into two parts with the same topics count.
-supportedNamespaceBundleSplitAlgorithms=range_equally_divide,topic_count_equally_divide
+supportedNamespaceBundleSplitAlgorithms=range_equally_divide,topic_count_equally_divide,specified_positions_divide
 
 # Default algorithm name for namespace bundle split
 defaultNamespaceBundleSplitAlgorithm=range_equally_divide

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2196,7 +2196,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "Supported algorithms name for namespace bundle split"
     )
     private List<String> supportedNamespaceBundleSplitAlgorithms = Lists.newArrayList("range_equally_divide",
-            "topic_count_equally_divide");
+            "topic_count_equally_divide", "specified_positions_divide");
     @FieldContext(
         dynamic = true,
         category = CATEGORY_LOAD_BALANCER,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import org.apache.pulsar.common.naming.NamespaceName;
@@ -257,6 +258,79 @@ public class NamespaceResources extends BaseResources<Policies> {
         public CompletableFuture<Void> clearPartitionedTopicTenantAsync(String tenant) {
             final String partitionedTopicPath = joinPath(PARTITIONED_TOPIC_PATH, tenant);
             return deleteIfExistsAsync(partitionedTopicPath);
+        }
+
+        public CompletableFuture<Void> markPartitionedTopicDeletedAsync(TopicName tn) {
+            if (tn.isPartitioned()) {
+                return CompletableFuture.completedFuture(null);
+            }
+            if (log.isDebugEnabled()) {
+                log.debug("markPartitionedTopicDeletedAsync {}", tn);
+            }
+            return updatePartitionedTopicAsync(tn, md -> {
+                md.deleted = true;
+                return md;
+            });
+        }
+
+        public CompletableFuture<Void> unmarkPartitionedTopicDeletedAsync(TopicName tn) {
+            if (tn.isPartitioned()) {
+                return CompletableFuture.completedFuture(null);
+            }
+            if (log.isDebugEnabled()) {
+                log.debug("unmarkPartitionedTopicDeletedAsync {}", tn);
+            }
+            return updatePartitionedTopicAsync(tn, md -> {
+                md.deleted = false;
+                return md;
+            });
+        }
+
+        public CompletableFuture<Boolean> isPartitionedTopicBeingDeletedAsync(TopicName tn) {
+            if (tn.isPartitioned()) {
+                tn = TopicName.get(tn.getPartitionedTopicName());
+            }
+            return getPartitionedTopicMetadataAsync(tn)
+                    .thenApply(mdOpt -> mdOpt.map(partitionedTopicMetadata -> partitionedTopicMetadata.deleted)
+                            .orElse(false));
+        }
+
+        public CompletableFuture<Void> runWithMarkDeleteAsync(TopicName topic,
+                                                              Supplier<CompletableFuture<Void>> supplier) {
+            CompletableFuture<Void> future = new CompletableFuture<>();
+
+            markPartitionedTopicDeletedAsync(topic).whenCompleteAsync((markResult, markExc) -> {
+                final boolean mdFound;
+                if (markExc != null) {
+                    if (markExc.getCause() instanceof MetadataStoreException.NotFoundException) {
+                        mdFound = false;
+                    } else {
+                        log.error("Failed to mark the topic {} as deleted", topic, markExc);
+                        future.completeExceptionally(markExc);
+                        return;
+                    }
+                } else {
+                    mdFound = true;
+                }
+
+                supplier.get().whenComplete((deleteResult, deleteExc) -> {
+                    if (deleteExc != null && mdFound) {
+                        unmarkPartitionedTopicDeletedAsync(topic)
+                                .thenRun(() -> future.completeExceptionally(deleteExc))
+                                .exceptionally(ex -> {
+                                    log.warn("Failed to unmark the topic {} as deleted", topic, ex);
+                                    future.completeExceptionally(deleteExc);
+                                    return null;
+                                });
+                    } else if (deleteExc != null) {
+                        future.completeExceptionally(deleteExc);
+                    } else {
+                        future.complete(deleteResult);
+                    }
+                });
+            });
+
+            return future;
         }
     }
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/TopicResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/TopicResources.java
@@ -23,11 +23,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.metadata.api.MetadataStore;
 
+@Slf4j
 public class TopicResources {
     private static final String MANAGED_LEDGER_PATH = "/managed-ledgers";
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -25,8 +25,10 @@ import static org.apache.pulsar.common.policies.data.PoliciesUtil.getBundles;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.lang.reflect.Field;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -49,6 +51,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang.mutable.MutableObject;
 import org.apache.commons.lang3.StringUtils;
@@ -61,6 +64,7 @@ import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentReplicator;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.web.RestException;
+import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespace;
@@ -70,7 +74,6 @@ import org.apache.pulsar.common.naming.NamespaceBundleFactory;
 import org.apache.pulsar.common.naming.NamespaceBundleSplitAlgorithm;
 import org.apache.pulsar.common.naming.NamespaceBundles;
 import org.apache.pulsar.common.naming.NamespaceName;
-import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.AutoSubscriptionCreationOverride;
@@ -163,14 +166,6 @@ public abstract class NamespacesBase extends AdminResource {
         }
     }
 
-    protected void internalDeleteNamespace(AsyncResponse asyncResponse, boolean authoritative, boolean force) {
-        if (force) {
-            internalDeleteNamespaceForcefully(asyncResponse, authoritative);
-        } else {
-            internalDeleteNamespace(asyncResponse, authoritative);
-        }
-    }
-
     protected CompletableFuture<List<String>> internalGetListOfTopics(Policies policies,
                                                                       CommandGetTopicsOfNamespace.Mode mode) {
         switch (mode) {
@@ -213,156 +208,180 @@ public abstract class NamespacesBase extends AdminResource {
                 });
     }
 
-    @SuppressWarnings("deprecation")
-    protected void internalDeleteNamespace(AsyncResponse asyncResponse, boolean authoritative) {
-        validateTenantOperation(namespaceName.getTenant(), TenantOperation.DELETE_NAMESPACE);
-        validatePoliciesReadOnlyAccess();
-
-        // ensure that non-global namespace is directed to the correct cluster
-        if (!namespaceName.isGlobal()) {
-            validateClusterOwnership(namespaceName.getCluster());
-        }
-
-        Policies policies = null;
-
-        // ensure the local cluster is the only cluster for the global namespace configuration
-        try {
-            policies = namespaceResources().getPolicies(namespaceName).orElseThrow(
-                    () -> new RestException(Status.NOT_FOUND, "Namespace " + namespaceName + " does not exist."));
-            if (namespaceName.isGlobal()) {
-                if (policies.replication_clusters.size() > 1) {
-                    // There are still more than one clusters configured for the global namespace
-                    throw new RestException(Status.PRECONDITION_FAILED, "Cannot delete the global namespace "
-                            + namespaceName + ". There are still more than one replication clusters configured.");
-                }
-                if (policies.replication_clusters.size() == 1
-                        && !policies.replication_clusters.contains(config().getClusterName())) {
-                    // the only replication cluster is other cluster, redirect
-                    String replCluster = Lists.newArrayList(policies.replication_clusters).get(0);
-                    ClusterData replClusterData = clusterResources().getCluster(replCluster)
-                            .orElseThrow(() -> new RestException(Status.NOT_FOUND,
-                                    "Cluster " + replCluster + " does not exist"));
-                    URL replClusterUrl;
-                    if (!config().isTlsEnabled() || !isRequestHttps()) {
-                        replClusterUrl = new URL(replClusterData.getServiceUrl());
-                    } else if (StringUtils.isNotBlank(replClusterData.getServiceUrlTls())) {
-                        replClusterUrl = new URL(replClusterData.getServiceUrlTls());
-                    } else {
-                        throw new RestException(Status.PRECONDITION_FAILED,
-                                "The replication cluster does not provide TLS encrypted service");
+    @SuppressWarnings("unchecked")
+    protected CompletableFuture<Void> internalDeleteNamespaceAsync(boolean force) {
+        CompletableFuture<Policies> preconditionCheck = precheckWhenDeleteNamespace(namespaceName, force);
+        return preconditionCheck
+                .thenCompose(policies -> {
+                    if (policies == null || CollectionUtils.isEmpty(policies.replication_clusters)){
+                        return pulsar().getNamespaceService().getListOfPersistentTopics(namespaceName);
                     }
-                    URI redirect = UriBuilder.fromUri(uri.getRequestUri()).host(replClusterUrl.getHost())
-                            .port(replClusterUrl.getPort()).replaceQueryParam("authoritative", false).build();
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] Redirecting the rest call to {}: cluster={}", clientAppId(), redirect,
-                                replCluster);
-                    }
-                    throw new WebApplicationException(Response.temporaryRedirect(redirect).build());
-                }
-            }
-        } catch (WebApplicationException wae) {
-            asyncResponse.resume(wae);
-            return;
-        } catch (Exception e) {
-            asyncResponse.resume(new RestException(e));
-            return;
-        }
-
-        boolean isEmpty;
-        List<String> topics;
-        try {
-            topics = pulsar().getNamespaceService().getListOfPersistentTopics(namespaceName)
-                    .get(config().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
-            topics.addAll(getPartitionedTopicList(TopicDomain.persistent));
-            topics.addAll(getPartitionedTopicList(TopicDomain.non_persistent));
-            isEmpty = topics.isEmpty();
-
-        } catch (Exception e) {
-            asyncResponse.resume(new RestException(e));
-            return;
-        }
-
-        if (!isEmpty) {
-            if (log.isDebugEnabled()) {
-                log.debug("Found topics on namespace {}", namespaceName);
-            }
-            boolean hasNonSystemTopic = false;
-            for (String topic : topics) {
-                if (!pulsar().getBrokerService().isSystemTopic(TopicName.get(topic))) {
-                    hasNonSystemTopic = true;
-                    break;
-                }
-            }
-            if (hasNonSystemTopic) {
-                asyncResponse.resume(new RestException(Status.CONFLICT, "Cannot delete non empty namespace"));
-                return;
-            }
-        }
-
-        // set the policies to deleted so that somebody else cannot acquire this namespace
-        try {
-            namespaceResources().setPolicies(namespaceName, old -> {
-                old.deleted = true;
-                return old;
-            });
-        } catch (Exception e) {
-            log.error("[{}] Failed to delete namespace on global ZK {}", clientAppId(), namespaceName, e);
-            asyncResponse.resume(new RestException(e));
-            return;
-        }
-
-        // remove from owned namespace map and ephemeral node from ZK
-        final List<CompletableFuture<Void>> futures = Lists.newArrayList();
-        // remove system topics first.
-        if (!topics.isEmpty()) {
-            for (String topic : topics) {
-                try {
-                    futures.add(pulsar().getAdminClient().topics().deleteAsync(topic, true, true));
-                } catch (Exception ex) {
-                    log.error("[{}] Failed to delete system topic {}", clientAppId(), topic, ex);
-                    asyncResponse.resume(new RestException(Status.INTERNAL_SERVER_ERROR, ex));
-                    return;
-                }
-            }
-        }
-        FutureUtil.waitForAll(futures).thenCompose(__ -> {
-            List<CompletableFuture<Void>> deleteBundleFutures = Lists.newArrayList();
-            NamespaceBundles bundles = pulsar().getNamespaceService().getNamespaceBundleFactory()
-                            .getBundles(namespaceName);
-            for (NamespaceBundle bundle : bundles.getBundles()) {
-                        // check if the bundle is owned by any broker, if not then we do not need to delete the bundle
-                deleteBundleFutures.add(pulsar().getNamespaceService().getOwnerAsync(bundle).thenCompose(ownership -> {
-                    if (ownership.isPresent()) {
-                        try {
-                            return pulsar().getAdminClient().namespaces()
-                                    .deleteNamespaceBundleAsync(namespaceName.toString(), bundle.getBundleRange());
-                        } catch (PulsarServerException e) {
-                            throw new RestException(e);
+                    return pulsar().getNamespaceService().getFullListOfTopics(namespaceName);
+                })
+                .thenCompose(allTopics -> pulsar().getNamespaceService().getFullListOfPartitionedTopic(namespaceName)
+                         .thenCompose(allPartitionedTopics -> {
+                             List<List<String>> topicsSum = new ArrayList<>(2);
+                             topicsSum.add(allTopics);
+                             topicsSum.add(allPartitionedTopics);
+                             return CompletableFuture.completedFuture(topicsSum);
+                         }))
+                .thenCompose(topics -> {
+                    List<String> allTopics = topics.get(0);
+                    List<String> allPartitionedTopics = topics.get(1);
+                    if (!force) {
+                        boolean hasNonSystemTopic = false;
+                        for (String topic : allTopics) {
+                            if (!pulsar().getBrokerService().isSystemTopic(TopicName.get(topic))) {
+                                hasNonSystemTopic = true;
+                                break;
+                            }
                         }
-                    } else {
-                        return CompletableFuture.completedFuture(null);
+                        if (!hasNonSystemTopic) {
+                            for (String topic : allPartitionedTopics) {
+                                if (!pulsar().getBrokerService().isSystemTopic(TopicName.get(topic))) {
+                                    hasNonSystemTopic = true;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (hasNonSystemTopic) {
+                            throw new RestException(Status.CONFLICT, "Cannot delete non empty namespace");
+                        }
                     }
-                }));
-            }
-            return FutureUtil.waitForAll(deleteBundleFutures);
-        })
-        .thenCompose(__ -> internalClearZkSources())
-        .thenAccept(__ -> {
-            log.info("[{}] Remove namespace successfully {}", clientAppId(), namespaceName);
-            asyncResponse.resume(Response.noContent().build());
-        })
-        .exceptionally(ex -> {
-            Throwable cause = FutureUtil.unwrapCompletionException(ex);
-            log.error("[{}] Failed to remove namespace {}", clientAppId(), namespaceName, cause);
-            if (cause instanceof PulsarAdminException.ConflictException) {
-                log.info("[{}] There are new topics created during the namespace deletion, "
-                        + "retry to delete the namespace again.", namespaceName);
-                pulsar().getExecutor().execute(() -> internalDeleteNamespace(asyncResponse, authoritative));
-            } else {
-                resumeAsyncResponseExceptionally(asyncResponse, ex);
-            }
-            return null;
-        });
+                    return namespaceResources().setPoliciesAsync(namespaceName, old -> {
+                        old.deleted = true;
+                        return  old;
+                    }).thenCompose(__ -> {
+                        return internalDeleteTopicsAsync(allTopics);
+                    }).thenCompose(__ -> {
+                        return internalDeletePartitionedTopicsAsync(allPartitionedTopics);
+                    });
+                })
+                .thenCompose(__ -> pulsar().getNamespaceService()
+                        .getNamespaceBundleFactory().getBundlesAsync(namespaceName))
+                .thenCompose(bundles -> FutureUtil.waitForAll(bundles.getBundles().stream()
+                        .map(bundle -> pulsar().getNamespaceService().getOwnerAsync(bundle)
+                                .thenCompose(owner -> {
+                                    // check if the bundle is owned by any broker,
+                                    // if not then we do not need to delete the bundle
+                                    if (owner.isPresent()) {
+                                        PulsarAdmin admin;
+                                        try {
+                                            admin = pulsar().getAdminClient();
+                                        } catch (PulsarServerException ex) {
+                                            log.error("[{}] Get admin client error when preparing to delete topics.",
+                                                    clientAppId(), ex);
+                                            return FutureUtil.failedFuture(ex);
+                                        }
+                                        return admin.namespaces().deleteNamespaceBundleAsync(namespaceName.toString(),
+                                                bundle.getBundleRange());
+                                    }
+                                    return CompletableFuture.completedFuture(null);
+                                })
+                        ).collect(Collectors.toList())))
+                .thenCompose(__ -> internalClearZkSources());
+    }
+
+    private CompletableFuture<Void> internalDeletePartitionedTopicsAsync(List<String> topicNames) {
+        if (CollectionUtils.isEmpty(topicNames)) {
+            return CompletableFuture.completedFuture(null);
+        }
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (String topicName : topicNames) {
+            futures.add(namespaceResources().getPartitionedTopicResources()
+                    .deletePartitionedTopicAsync(TopicName.get(topicName)));
+        }
+        return FutureUtil.waitForAll(futures);
+    }
+
+    private CompletableFuture<Void> internalDeleteTopicsAsync(List<String> topicNames) {
+        if (CollectionUtils.isEmpty(topicNames)) {
+            return CompletableFuture.completedFuture(null);
+        }
+        PulsarAdmin admin;
+        try {
+            admin = pulsar().getAdminClient();
+        } catch (Exception ex) {
+            log.error("[{}] Get admin client error when preparing to delete topics.", clientAppId(), ex);
+            return FutureUtil.failedFuture(ex);
+        }
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (String topicName : topicNames) {
+            futures.add(admin.topics().deleteAsync(topicName, true));
+        }
+        return FutureUtil.waitForAll(futures);
+    }
+
+    private CompletableFuture<Policies> precheckWhenDeleteNamespace(NamespaceName nsName, boolean force) {
+        CompletableFuture<Policies> preconditionCheck =
+                validateTenantOperationAsync(nsName.getTenant(), TenantOperation.DELETE_NAMESPACE)
+                        .thenCompose(__ -> validatePoliciesReadOnlyAccessAsync())
+                        .thenCompose(__ -> {
+                            if (force && !pulsar().getConfiguration().isForceDeleteNamespaceAllowed()) {
+                                throw new RestException(Status.METHOD_NOT_ALLOWED,
+                                        "Broker doesn't allow forced deletion of namespaces");
+                            }
+                            // ensure that non-global namespace is directed to the correct cluster
+                            if (!nsName.isGlobal()) {
+                                return validateClusterOwnershipAsync(nsName.getCluster());
+                            } else {
+                                return CompletableFuture.completedFuture(null);
+                            }
+                        })
+                        .thenCompose(__ -> namespaceResources().getPoliciesAsync(nsName))
+                        .thenCompose(policiesOpt -> {
+                            if (!policiesOpt.isPresent()) {
+                                throw new RestException(Status.NOT_FOUND, "Namespace " + nsName + " does not exist.");
+                            }
+                            if (!nsName.isGlobal()) {
+                                return CompletableFuture.completedFuture(null);
+                            }
+                            Policies policies = policiesOpt.get();
+                            Set<String> replicationClusters = policies.replication_clusters;
+                            if (replicationClusters.size() > 1) {
+                                // There are still more than one clusters configured for the global namespace
+                                throw new RestException(Status.PRECONDITION_FAILED,
+                                        "Cannot delete the global namespace " + nsName + ". There are still more than "
+                                        + "one replication clusters configured.");
+                            }
+                            if (replicationClusters.size() == 1
+                                    && !policies.replication_clusters.contains(config().getClusterName())) {
+                                // the only replication cluster is other cluster, redirect
+                                String replCluster = Lists.newArrayList(policies.replication_clusters).get(0);
+                                return clusterResources().getClusterAsync(replCluster)
+                                        .thenCompose(replClusterDataOpt -> {
+                                            ClusterData replClusterData = replClusterDataOpt
+                                                    .orElseThrow(() -> new RestException(Status.NOT_FOUND,
+                                                            "Cluster " + replCluster + " does not exist"));
+                                            URL replClusterUrl;
+                                            try {
+                                                if (!config().isTlsEnabled() || !isRequestHttps()) {
+                                                    replClusterUrl = new URL(replClusterData.getServiceUrl());
+                                                } else if (StringUtils.isNotBlank(replClusterData.getServiceUrlTls())) {
+                                                    replClusterUrl = new URL(replClusterData.getServiceUrlTls());
+                                                } else {
+                                                    throw new RestException(Status.PRECONDITION_FAILED,
+                                                    "The replication cluster does not provide TLS encrypted service");
+                                                }
+                                            } catch (MalformedURLException checkedEx) {
+                                                throw new RestException(checkedEx);
+                                            }
+                                            URI redirect = UriBuilder.fromUri(uri.getRequestUri())
+                                                    .host(replClusterUrl.getHost())
+                                                    .port(replClusterUrl.getPort())
+                                                    .replaceQueryParam("authoritative", false).build();
+                                            if (log.isDebugEnabled()) {
+                                                log.debug("[{}] Redirecting the rest call to {}: cluster={}",
+                                                        clientAppId(), redirect, replCluster);
+                                            }
+                                            throw new WebApplicationException(
+                                                    Response.temporaryRedirect(redirect).build());
+                                        });
+                            }
+                            return CompletableFuture.completedFuture(policies);
+                        });
+        return preconditionCheck;
     }
 
     // clear zk-node resources for deleting namespace
@@ -384,189 +403,6 @@ public abstract class NamespacesBase extends AdminResource {
                 // clear /loadbalance/bundle-data
                 .thenCompose(ignore -> namespaceResources().deleteBundleDataAsync(namespaceName));
 
-    }
-
-    @SuppressWarnings("deprecation")
-    protected void internalDeleteNamespaceForcefully(AsyncResponse asyncResponse, boolean authoritative) {
-        validateTenantOperation(namespaceName.getTenant(), TenantOperation.DELETE_NAMESPACE);
-        validatePoliciesReadOnlyAccess();
-
-        if (!pulsar().getConfiguration().isForceDeleteNamespaceAllowed()) {
-            asyncResponse.resume(
-                    new RestException(Status.METHOD_NOT_ALLOWED, "Broker doesn't allow forced deletion of namespaces"));
-            return;
-        }
-
-        // ensure that non-global namespace is directed to the correct cluster
-        if (!namespaceName.isGlobal()) {
-            validateClusterOwnership(namespaceName.getCluster());
-        }
-
-        Policies policies = null;
-
-        // ensure the local cluster is the only cluster for the global namespace configuration
-        try {
-            policies = namespaceResources().getPolicies(namespaceName).orElseThrow(
-                    () -> new RestException(Status.NOT_FOUND, "Namespace " + namespaceName + " does not exist."));
-            if (namespaceName.isGlobal()) {
-                if (policies.replication_clusters.size() > 1) {
-                    // There are still more than one clusters configured for the global namespace
-                    throw new RestException(Status.PRECONDITION_FAILED, "Cannot delete the global namespace "
-                            + namespaceName + ". There are still more than one replication clusters configured.");
-                }
-                if (policies.replication_clusters.size() == 1
-                        && !policies.replication_clusters.contains(config().getClusterName())) {
-                    // the only replication cluster is other cluster, redirect
-                    String replCluster = Lists.newArrayList(policies.replication_clusters).get(0);
-                    ClusterData replClusterData =
-                            clusterResources().getCluster(replCluster)
-                            .orElseThrow(() -> new RestException(Status.NOT_FOUND,
-                                    "Cluster " + replCluster + " does not exist"));
-                    URL replClusterUrl;
-                    if (!config().isTlsEnabled() || !isRequestHttps()) {
-                        replClusterUrl = new URL(replClusterData.getServiceUrl());
-                    } else if (StringUtils.isNotBlank(replClusterData.getServiceUrlTls())) {
-                        replClusterUrl = new URL(replClusterData.getServiceUrlTls());
-                    } else {
-                        throw new RestException(Status.PRECONDITION_FAILED,
-                                "The replication cluster does not provide TLS encrypted service");
-                    }
-                    URI redirect = UriBuilder.fromUri(uri.getRequestUri()).host(replClusterUrl.getHost())
-                            .port(replClusterUrl.getPort()).replaceQueryParam("authoritative", false).build();
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] Redirecting the rest call to {}: cluster={}", clientAppId(), redirect,
-                                replCluster);
-                    }
-                    throw new WebApplicationException(Response.temporaryRedirect(redirect).build());
-                }
-            }
-        } catch (WebApplicationException wae) {
-            asyncResponse.resume(wae);
-            return;
-        } catch (Exception e) {
-            asyncResponse.resume(new RestException(e));
-            return;
-        }
-
-        List<String> topics;
-        try {
-            topics = pulsar().getNamespaceService().getFullListOfTopics(namespaceName)
-                    .get(config().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
-        } catch (Exception e) {
-            asyncResponse.resume(new RestException(e));
-            return;
-        }
-
-        // set the policies to deleted so that somebody else cannot acquire this namespace
-        try {
-            namespaceResources().setPolicies(namespaceName, old -> {
-                old.deleted = true;
-                return old;
-            });
-        } catch (Exception e) {
-            log.error("[{}] Failed to delete namespace on global ZK {}", clientAppId(), namespaceName, e);
-            asyncResponse.resume(new RestException(e));
-            return;
-        }
-
-        // remove from owned namespace map and ephemeral node from ZK
-        final List<CompletableFuture<Void>> topicFutures = Lists.newArrayList();
-        final List<CompletableFuture<Void>> bundleFutures = Lists.newArrayList();
-        try {
-            // firstly remove all topics including system topics
-            if (!topics.isEmpty()) {
-                Set<String> partitionedTopics = new HashSet<>();
-                Set<String> nonPartitionedTopics = new HashSet<>();
-
-                for (String topic : topics) {
-                    try {
-                        TopicName topicName = TopicName.get(topic);
-                        if (topicName.isPartitioned()) {
-                            String partitionedTopic = topicName.getPartitionedTopicName();
-                            if (!partitionedTopics.contains(partitionedTopic)) {
-                                // Distinguish partitioned topic to avoid duplicate deletion of the same schema
-                                topicFutures.add(pulsar().getAdminClient().topics().deletePartitionedTopicAsync(
-                                        partitionedTopic, true, true));
-                                partitionedTopics.add(partitionedTopic);
-                            }
-                        } else {
-                            topicFutures.add(pulsar().getAdminClient().topics().deleteAsync(
-                                    topic, true, true));
-                            nonPartitionedTopics.add(topic);
-                        }
-                    } catch (Exception e) {
-                        String errorMessage = String.format("Failed to force delete topic %s, "
-                                        + "but the previous deletion command of partitioned-topics:%s "
-                                        + "and non-partitioned-topics:%s have been sent out asynchronously. "
-                                        + "Reason: %s",
-                                topic, partitionedTopics, nonPartitionedTopics, e.getCause());
-                        log.error("[{}] {}", clientAppId(), errorMessage, e);
-                        asyncResponse.resume(new RestException(Status.INTERNAL_SERVER_ERROR, errorMessage));
-                        return;
-                    }
-                }
-
-                if (log.isDebugEnabled()) {
-                    log.debug("Successfully send deletion command of partitioned-topics:{} "
-                                    + "and non-partitioned-topics:{} in namespace:{}.",
-                            partitionedTopics, nonPartitionedTopics, namespaceName);
-                }
-
-                final CompletableFuture<Throwable> topicFutureEx =
-                        FutureUtil.waitForAll(topicFutures).handle((result, exception) -> {
-                            if (exception != null) {
-                                if (exception.getCause() instanceof PulsarAdminException) {
-                                    asyncResponse
-                                            .resume(new RestException((PulsarAdminException) exception.getCause()));
-                                } else {
-                                    log.error("[{}] Failed to remove forcefully owned namespace {}",
-                                            clientAppId(), namespaceName, exception);
-                                    asyncResponse.resume(new RestException(exception.getCause()));
-                                }
-                                return exception;
-                            }
-
-                            return null;
-                        });
-                if (topicFutureEx.join() != null) {
-                    return;
-                }
-            }
-
-            // forcefully delete namespace bundles
-            NamespaceBundles bundles = pulsar().getNamespaceService().getNamespaceBundleFactory()
-                    .getBundles(namespaceName);
-            for (NamespaceBundle bundle : bundles.getBundles()) {
-                // check if the bundle is owned by any broker, if not then we do not need to delete the bundle
-                if (pulsar().getNamespaceService().getOwner(bundle).isPresent()) {
-                    bundleFutures.add(pulsar().getAdminClient().namespaces()
-                            .deleteNamespaceBundleAsync(namespaceName.toString(), bundle.getBundleRange(), true));
-                }
-            }
-        } catch (Exception e) {
-            log.error("[{}] Failed to remove forcefully owned namespace {}", clientAppId(), namespaceName, e);
-            asyncResponse.resume(new RestException(e));
-            return;
-        }
-
-        FutureUtil.waitForAll(bundleFutures).thenCompose(__ -> internalClearZkSources()).handle((result, exception) -> {
-            if (exception != null) {
-                Throwable cause = FutureUtil.unwrapCompletionException(exception);
-                if (cause instanceof PulsarAdminException.ConflictException) {
-                    log.info("[{}] There are new topics created during the namespace deletion, "
-                            + "retry to force delete the namespace again.", namespaceName);
-                    pulsar().getExecutor().execute(() ->
-                            internalDeleteNamespaceForcefully(asyncResponse, authoritative));
-                } else {
-                    log.error("[{}] Failed to remove forcefully owned namespace {}",
-                            clientAppId(), namespaceName, cause);
-                    asyncResponse.resume(new RestException(cause));
-                }
-                return null;
-            }
-            asyncResponse.resume(Response.noContent().build());
-            return null;
-        });
     }
 
     protected void internalDeleteNamespaceBundle(String bundleRange, boolean authoritative, boolean force) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -28,6 +28,7 @@ import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URL;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -98,10 +99,12 @@ import org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy;
 import org.apache.pulsar.common.policies.data.SubscribeRate;
 import org.apache.pulsar.common.policies.data.SubscriptionAuthMode;
 import org.apache.pulsar.common.policies.data.TenantOperation;
+import org.apache.pulsar.common.policies.data.TopicHashPositions;
 import org.apache.pulsar.common.policies.data.TopicType;
 import org.apache.pulsar.common.policies.data.ValidateResult;
 import org.apache.pulsar.common.policies.data.impl.AutoTopicCreationOverrideImpl;
 import org.apache.pulsar.common.policies.data.impl.DispatchRateImpl;
+import org.apache.pulsar.common.util.Codec;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.AlreadyExistsException;
@@ -1165,8 +1168,8 @@ public abstract class NamespacesBase extends AdminResource {
     }
 
     @SuppressWarnings("deprecation")
-    protected void internalSplitNamespaceBundle(AsyncResponse asyncResponse, String bundleName,
-                                                boolean authoritative, boolean unload, String splitAlgorithmName) {
+    protected void internalSplitNamespaceBundle(AsyncResponse asyncResponse, String bundleName, boolean authoritative,
+                                                boolean unload, String splitAlgorithmName, List<Long> splitBoundaries) {
         validateSuperUserAccess();
         checkNotNull(bundleName, "BundleRange should not be null");
         log.info("[{}] Split namespace bundle {}/{}", clientAppId(), namespaceName, bundleName);
@@ -1187,15 +1190,20 @@ public abstract class NamespacesBase extends AdminResource {
 
         List<String> supportedNamespaceBundleSplitAlgorithms =
                 pulsar().getConfig().getSupportedNamespaceBundleSplitAlgorithms();
-        if (StringUtils.isNotBlank(splitAlgorithmName)
-                && !supportedNamespaceBundleSplitAlgorithms.contains(splitAlgorithmName)) {
-            asyncResponse.resume(new RestException(Status.PRECONDITION_FAILED,
-                    "Unsupported namespace bundle split algorithm, supported algorithms are "
-                            + supportedNamespaceBundleSplitAlgorithms));
+        if (StringUtils.isNotBlank(splitAlgorithmName)) {
+            if (!supportedNamespaceBundleSplitAlgorithms.contains(splitAlgorithmName)) {
+                asyncResponse.resume(new RestException(Status.PRECONDITION_FAILED,
+                        "Unsupported namespace bundle split algorithm, supported algorithms are "
+                                + supportedNamespaceBundleSplitAlgorithms));
+            }
+            if (splitAlgorithmName.equalsIgnoreCase(NamespaceBundleSplitAlgorithm.SPECIFIED_POSITIONS_DIVIDE)
+                    && (splitBoundaries == null || splitBoundaries.size() == 0)) {
+                asyncResponse.resume(new RestException(Status.PRECONDITION_FAILED,
+                        "With specified_positions_divide split algorithm, splitBoundaries must not be emtpy"));
+            }
         }
 
         NamespaceBundle nsBundle;
-
         try {
             nsBundle = validateNamespaceBundleOwnership(namespaceName, policies.bundles, bundleRange,
                     authoritative, false);
@@ -1205,7 +1213,7 @@ public abstract class NamespacesBase extends AdminResource {
         }
 
         pulsar().getNamespaceService().splitAndOwnBundle(nsBundle, unload,
-                getNamespaceBundleSplitAlgorithmByName(splitAlgorithmName))
+                getNamespaceBundleSplitAlgorithmByName(splitAlgorithmName), splitBoundaries)
                 .thenRun(() -> {
                     log.info("[{}] Successfully split namespace bundle {}", clientAppId(), nsBundle.toString());
                     asyncResponse.resume(Response.noContent().build());
@@ -1221,6 +1229,56 @@ public abstract class NamespacesBase extends AdminResource {
             }
             return null;
         });
+    }
+
+    protected void internalGetTopicHashPositions(AsyncResponse asyncResponse, String bundleRange, List<String> topics) {
+        if (log.isDebugEnabled()) {
+            log.debug("[{}] Getting hash position for topic list {}, bundle {}", clientAppId(), topics, bundleRange);
+        }
+        validateNamespacePolicyOperation(namespaceName, PolicyName.PERSISTENCE, PolicyOperation.READ);
+        Policies policies = getNamespacePolicies(namespaceName);
+        NamespaceBundle bundle = validateNamespaceBundleOwnership(namespaceName, policies.bundles, bundleRange,
+                false, true);
+        pulsar().getNamespaceService().getOwnedTopicListForNamespaceBundle(bundle).whenComplete(
+                (allTopicsInThisBundle, throwable) -> {
+                    if (throwable != null) {
+                        log.error("[{}] {} Failed to get topic list for bundle {}.", clientAppId(),
+                                namespaceName, bundle);
+                        asyncResponse.resume(new RestException(throwable));
+                    }
+                    // if topics is empty, return all topics' hash position in this bundle
+                    Map<String, Long> topicHashPositions = new HashMap<>();
+                    if (topics == null || topics.size() == 0) {
+                        allTopicsInThisBundle.forEach(t -> {
+                            topicHashPositions.put(t,
+                                    pulsar().getNamespaceService().getNamespaceBundleFactory()
+                                            .getLongHashCode(t));
+                        });
+                    } else {
+                        for (String topic : topics.stream().map(Codec::decode).collect(Collectors.toList())) {
+                            TopicName topicName = TopicName.get(topic);
+                            // partitioned topic
+                            if (topicName.getPartitionIndex() == -1) {
+                                allTopicsInThisBundle.stream()
+                                        .filter(t -> TopicName.get(t).getPartitionedTopicName()
+                                                .equals(TopicName.get(topic).getPartitionedTopicName()))
+                                        .forEach(partition -> {
+                                            topicHashPositions.put(partition,
+                                                    pulsar().getNamespaceService().getNamespaceBundleFactory()
+                                                            .getLongHashCode(partition));
+                                        });
+                            } else { // topic partition
+                                if (allTopicsInThisBundle.contains(topicName.toString())) {
+                                    topicHashPositions.put(topic,
+                                            pulsar().getNamespaceService().getNamespaceBundleFactory()
+                                                    .getLongHashCode(topic));
+                                }
+                            }
+                        }
+                    }
+                    asyncResponse.resume(
+                            new TopicHashPositions(namespaceName.toString(), bundleRange, topicHashPositions));
+                });
     }
 
     private String getBundleRange(String bundleName) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -1538,10 +1538,10 @@ public abstract class NamespacesBase extends AdminResource {
         }
     }
 
-    protected void internalDeletePersistence() {
-        validateNamespacePolicyOperation(namespaceName, PolicyName.PERSISTENCE, PolicyOperation.WRITE);
-        validatePoliciesReadOnlyAccess();
-        doUpdatePersistence(null);
+    protected CompletableFuture<Void> internalDeletePersistenceAsync() {
+        return validateNamespacePolicyOperationAsync(namespaceName, PolicyName.PERSISTENCE, PolicyOperation.WRITE)
+                .thenCompose(__ -> validatePoliciesReadOnlyAccessAsync())
+                .thenCompose(__ -> doUpdatePersistenceAsync(null));
     }
 
     protected void internalSetPersistence(PersistencePolicies persistence) {
@@ -1565,6 +1565,15 @@ public abstract class NamespacesBase extends AdminResource {
                     e);
             throw new RestException(e);
         }
+    }
+
+    private CompletableFuture<Void> doUpdatePersistenceAsync(PersistencePolicies persistence) {
+        return updatePoliciesAsync(namespaceName, policies -> {
+            policies.persistence = persistence;
+            return policies;
+        }).thenAccept(__ -> log.info("[{}] Successfully updated persistence configuration: namespace={}, map={}",
+                clientAppId(), namespaceName, persistence)
+        );
     }
 
     protected PersistencePolicies internalGetPersistence() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -289,8 +289,10 @@ public abstract class NamespacesBase extends AdminResource {
         }
         List<CompletableFuture<Void>> futures = new ArrayList<>();
         for (String topicName : topicNames) {
-            futures.add(namespaceResources().getPartitionedTopicResources()
-                    .deletePartitionedTopicAsync(TopicName.get(topicName)));
+            TopicName tn = TopicName.get(topicName);
+            futures.add(pulsar().getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
+                    .runWithMarkDeleteAsync(tn,
+                            () -> namespaceResources().getPartitionedTopicResources().deletePartitionedTopicAsync(tn)));
         }
         return FutureUtil.waitForAll(futures);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -310,12 +310,12 @@ public class PersistentTopicsBase extends AdminResource {
         grantPermissions(topicName, role, actions);
     }
 
-    protected void internalDeleteTopicForcefully(boolean authoritative, boolean deleteSchema) {
+    protected void internalDeleteTopicForcefully(boolean authoritative) {
         validateTopicOwnership(topicName, authoritative);
         validateNamespaceOperation(topicName.getNamespaceObject(), NamespaceOperation.DELETE_TOPIC);
 
         try {
-            pulsar().getBrokerService().deleteTopic(topicName.toString(), true, deleteSchema).get();
+            pulsar().getBrokerService().deleteTopic(topicName.toString(), true).get();
         } catch (Exception e) {
             if (isManagedLedgerNotFoundException(e)) {
                 log.info("[{}] Topic was already not existing {}", clientAppId(), topicName, e);
@@ -610,8 +610,9 @@ public class PersistentTopicsBase extends AdminResource {
         });
     }
 
-    protected void internalDeletePartitionedTopic(AsyncResponse asyncResponse, boolean authoritative,
-                                                  boolean force, boolean deleteSchema) {
+    protected void internalDeletePartitionedTopic(AsyncResponse asyncResponse,
+                                                  boolean authoritative,
+                                                  boolean force) {
         validateTopicOwnershipAsync(topicName, authoritative)
                 .thenCompose(__ -> validateNamespaceOperationAsync(topicName.getNamespaceObject(),
                         NamespaceOperation.DELETE_TOPIC))
@@ -621,14 +622,6 @@ public class PersistentTopicsBase extends AdminResource {
                             final int numPartitions = partitionedMeta.partitions;
                             if (numPartitions < 1) {
                                 return CompletableFuture.completedFuture(null);
-                            }
-                            if (deleteSchema) {
-                                return pulsar().getBrokerService()
-                                        .deleteSchemaStorage(topicName.getPartition(0).toString())
-                                        .thenCompose(unused ->
-                                                internalRemovePartitionsAuthenticationPoliciesAsync(numPartitions))
-                                        .thenCompose(unused2 ->
-                                                internalRemovePartitionsTopicAsync(numPartitions, force));
                             }
                             return internalRemovePartitionsAuthenticationPoliciesAsync(numPartitions)
                                     .thenCompose(unused -> internalRemovePartitionsTopicAsync(numPartitions, force));
@@ -1045,20 +1038,20 @@ public class PersistentTopicsBase extends AdminResource {
                 });
     }
 
-    protected void internalDeleteTopic(boolean authoritative, boolean force, boolean deleteSchema) {
+    protected void internalDeleteTopic(boolean authoritative, boolean force) {
         if (force) {
-            internalDeleteTopicForcefully(authoritative, deleteSchema);
+            internalDeleteTopicForcefully(authoritative);
         } else {
-            internalDeleteTopic(authoritative, deleteSchema);
+            internalDeleteTopic(authoritative);
         }
     }
 
-    protected void internalDeleteTopic(boolean authoritative, boolean deleteSchema) {
+    protected void internalDeleteTopic(boolean authoritative) {
         validateNamespaceOperation(topicName.getNamespaceObject(), NamespaceOperation.DELETE_TOPIC);
         validateTopicOwnership(topicName, authoritative);
 
         try {
-            pulsar().getBrokerService().deleteTopic(topicName.toString(), false, deleteSchema).get();
+            pulsar().getBrokerService().deleteTopic(topicName.toString(), false).get();
             log.info("[{}] Successfully removed topic {}", clientAppId(), topicName);
         } catch (Exception e) {
             Throwable t = e.getCause();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -627,8 +627,9 @@ public class PersistentTopicsBase extends AdminResource {
                                     .thenCompose(unused -> internalRemovePartitionsTopicAsync(numPartitions, force));
                         })
                 // Only tries to delete the znode for partitioned topic when all its partitions are successfully deleted
-                ).thenCompose(__ -> namespaceResources()
-                                .getPartitionedTopicResources().deletePartitionedTopicAsync(topicName))
+                ).thenCompose(__ -> getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
+                        .runWithMarkDeleteAsync(topicName, () -> namespaceResources()
+                                .getPartitionedTopicResources().deletePartitionedTopicAsync(topicName)))
                 .thenAccept(__ -> {
                     log.info("[{}] Deleted partitioned topic {}", clientAppId(), topicName);
                     asyncResponse.resume(Response.noContent().build());
@@ -661,6 +662,13 @@ public class PersistentTopicsBase extends AdminResource {
     }
 
     private CompletableFuture<Void> internalRemovePartitionsTopicAsync(int numPartitions, boolean force) {
+        return pulsar().getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
+                .runWithMarkDeleteAsync(topicName,
+                    () -> internalRemovePartitionsTopicNoAutocreationDisableAsync(numPartitions, force));
+    }
+
+    private CompletableFuture<Void> internalRemovePartitionsTopicNoAutocreationDisableAsync(int numPartitions,
+                                                                                            boolean force) {
         return FutureUtil.waitForAll(IntStream.range(0, numPartitions)
                 .mapToObj(i -> {
                     TopicName topicNamePartition = topicName.getPartition(i);
@@ -2223,79 +2231,81 @@ public class PersistentTopicsBase extends AdminResource {
                 internalCreateSubscriptionForNonPartitionedTopic(asyncResponse,
                         subscriptionName, targetMessageId, authoritative, replicated, properties);
             } else {
-                boolean allowAutoTopicCreation = pulsar().getBrokerService().isAllowAutoTopicCreation(topicName);
-                getPartitionedTopicMetadataAsync(topicName,
-                        authoritative, allowAutoTopicCreation).thenAccept(partitionMetadata -> {
-                    final int numPartitions = partitionMetadata.partitions;
-                    if (numPartitions > 0) {
-                        final CompletableFuture<Void> future = new CompletableFuture<>();
-                        final AtomicInteger count = new AtomicInteger(numPartitions);
-                        final AtomicInteger failureCount = new AtomicInteger(0);
-                        final AtomicReference<Throwable> partitionException = new AtomicReference<>();
+                pulsar().getBrokerService().isAllowAutoTopicCreationAsync(topicName)
+                        .thenCompose(allowAutoTopicCreation -> getPartitionedTopicMetadataAsync(topicName,
+                                authoritative, allowAutoTopicCreation).thenAccept(partitionMetadata -> {
+                            final int numPartitions = partitionMetadata.partitions;
+                            if (numPartitions > 0) {
+                                final CompletableFuture<Void> future = new CompletableFuture<>();
+                                final AtomicInteger count = new AtomicInteger(numPartitions);
+                                final AtomicInteger failureCount = new AtomicInteger(0);
+                                final AtomicReference<Throwable> partitionException = new AtomicReference<>();
 
-                        // Create the subscription on each partition
-                        for (int i = 0; i < numPartitions; i++) {
-                            TopicName topicNamePartition = topicName.getPartition(i);
-                            try {
-                                pulsar().getAdminClient().topics()
-                                        .createSubscriptionAsync(topicNamePartition.toString(),
-                                                subscriptionName, targetMessageId, false, properties)
-                                        .handle((r, ex) -> {
-                                            if (ex != null) {
-                                                // fail the operation on unknown exception or
-                                                // if all the partitioned failed due to
-                                                // subscription-already-exist
-                                                if (failureCount.incrementAndGet() == numPartitions
-                                                        || !(ex instanceof PulsarAdminException.ConflictException)) {
-                                                    partitionException.set(ex);
-                                                }
-                                            }
+                                // Create the subscription on each partition
+                                for (int i = 0; i < numPartitions; i++) {
+                                    TopicName topicNamePartition = topicName.getPartition(i);
+                                    try {
+                                        pulsar().getAdminClient().topics()
+                                                .createSubscriptionAsync(topicNamePartition.toString(),
+                                                        subscriptionName, targetMessageId, false, properties)
+                                                .handle((r, ex) -> {
+                                                    if (ex != null) {
+                                                        // fail the operation on unknown exception or
+                                                        // if all the partitioned failed due to
+                                                        // subscription-already-exist
+                                                        if (failureCount.incrementAndGet() == numPartitions
+                                                                || !(ex instanceof PulsarAdminException
+                                                                        .ConflictException)) {
+                                                            partitionException.set(ex);
+                                                        }
+                                                    }
 
-                                            if (count.decrementAndGet() == 0) {
-                                                future.complete(null);
-                                            }
+                                                    if (count.decrementAndGet() == 0) {
+                                                        future.complete(null);
+                                                    }
 
-                                            return null;
-                                        });
-                            } catch (Exception e) {
-                                log.warn("[{}] [{}] Failed to create subscription {} at message id {}", clientAppId(),
-                                        topicNamePartition, subscriptionName, targetMessageId, e);
-                                future.completeExceptionally(e);
-                            }
-                        }
-
-                        future.whenComplete((r, ex) -> {
-                            if (ex != null) {
-                                if (ex instanceof PulsarAdminException) {
-                                    asyncResponse.resume(new RestException((PulsarAdminException) ex));
-                                    return;
-                                } else {
-                                    asyncResponse.resume(new RestException(ex));
-                                    return;
+                                                    return null;
+                                                });
+                                    } catch (Exception e) {
+                                        log.warn("[{}] [{}] Failed to create subscription {} at message id {}",
+                                              clientAppId(), topicNamePartition, subscriptionName, targetMessageId, e);
+                                        future.completeExceptionally(e);
+                                    }
                                 }
+
+                                future.whenComplete((r, ex) -> {
+                                    if (ex != null) {
+                                        if (ex instanceof PulsarAdminException) {
+                                            asyncResponse.resume(new RestException((PulsarAdminException) ex));
+                                            return;
+                                        } else {
+                                            asyncResponse.resume(new RestException(ex));
+                                            return;
+                                        }
+                                    }
+
+                                    if (partitionException.get() != null) {
+                                        log.warn("[{}] [{}] Failed to create subscription {} at message id {}",
+                                                clientAppId(), topicName,
+                                                subscriptionName, targetMessageId, partitionException.get());
+                                        if (partitionException.get() instanceof PulsarAdminException) {
+                                            asyncResponse.resume(
+                                                    new RestException((PulsarAdminException) partitionException.get()));
+                                            return;
+                                        } else {
+                                            asyncResponse.resume(new RestException(partitionException.get()));
+                                            return;
+                                        }
+                                    }
+
+                                    asyncResponse.resume(Response.noContent().build());
+                                });
+                            } else {
+                                internalCreateSubscriptionForNonPartitionedTopic(asyncResponse,
+                                        subscriptionName, targetMessageId, authoritative, replicated, properties);
                             }
 
-                            if (partitionException.get() != null) {
-                                log.warn("[{}] [{}] Failed to create subscription {} at message id {}",
-                                        clientAppId(), topicName,
-                                        subscriptionName, targetMessageId, partitionException.get());
-                                if (partitionException.get() instanceof PulsarAdminException) {
-                                    asyncResponse.resume(
-                                            new RestException((PulsarAdminException) partitionException.get()));
-                                    return;
-                                } else {
-                                    asyncResponse.resume(new RestException(partitionException.get()));
-                                    return;
-                                }
-                            }
-
-                            asyncResponse.resume(Response.noContent().build());
-                        });
-                    } else {
-                        internalCreateSubscriptionForNonPartitionedTopic(asyncResponse,
-                                subscriptionName, targetMessageId, authoritative, replicated, properties);
-                    }
-                }).exceptionally(ex -> {
+                        })).exceptionally(ex -> {
                     // If the exception is not redirect exception we need to log it.
                     if (!isRedirectException(ex)) {
                         log.error("[{}] Failed to create subscription {} on topic {}",
@@ -2321,12 +2331,12 @@ public class PersistentTopicsBase extends AdminResource {
             MessageIdImpl targetMessageId, boolean authoritative, boolean replicated,
             Map<String, String> properties) {
 
-        boolean isAllowAutoTopicCreation = pulsar().getBrokerService().isAllowAutoTopicCreation(topicName);
-
         validateTopicOwnershipAsync(topicName, authoritative)
                 .thenCompose(__ -> {
                     validateTopicOperation(topicName, TopicOperation.SUBSCRIBE);
-                    return pulsar().getBrokerService().getTopic(topicName.toString(), isAllowAutoTopicCreation);
+                    return pulsar().getBrokerService().isAllowAutoTopicCreationAsync(topicName)
+                            .thenCompose(isAllowAutoTopicCreation -> pulsar().getBrokerService()
+                                    .getTopic(topicName.toString(), isAllowAutoTopicCreation));
                 }).thenApply(optTopic -> {
             if (optTopic.isPresent()) {
                 return optTopic.get();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -619,7 +619,7 @@ public class PersistentTopicsBase extends AdminResource {
                         .fetchPartitionedTopicMetadataAsync(topicName)
                         .thenCompose(partitionedMeta -> {
                             final int numPartitions = partitionedMeta.partitions;
-                            if (numPartitions < 1){
+                            if (numPartitions < 1) {
                                 return CompletableFuture.completedFuture(null);
                             }
                             if (deleteSchema) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
@@ -649,16 +649,33 @@ public class Namespaces extends NamespacesBase {
             @PathParam("namespace") String namespace,
             @PathParam("bundle") String bundleRange,
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
-            @QueryParam("unload") @DefaultValue("false") boolean unload) {
+            @QueryParam("unload") @DefaultValue("false") boolean unload,
+            @QueryParam("splitBoundaries") @DefaultValue("") List<Long> splitBoundaries) {
         try {
             validateNamespaceName(property, cluster, namespace);
-            internalSplitNamespaceBundle(asyncResponse, bundleRange, authoritative, unload,
-                    NamespaceBundleSplitAlgorithm.RANGE_EQUALLY_DIVIDE_NAME);
+            internalSplitNamespaceBundle(asyncResponse, bundleRange,
+                    authoritative, unload, NamespaceBundleSplitAlgorithm.RANGE_EQUALLY_DIVIDE_NAME, splitBoundaries);
         } catch (WebApplicationException wae) {
             asyncResponse.resume(wae);
         } catch (Exception e) {
             asyncResponse.resume(new RestException(e));
         }
+    }
+
+    @GET
+    @Path("/{property}/{cluster}/{namespace}/{bundle}/topicHashPositions")
+    @ApiOperation(value = "Get hash positions for topics")
+    @ApiResponses(value = {
+            @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Namespace does not exist")})
+    public void getTopicHashPositions(
+            @PathParam("property") String property, @PathParam("cluster") String cluster,
+            @PathParam("namespace") String namespace,
+            @PathParam("bundle") String bundle,
+            @QueryParam("topics") List<String> topics,
+            @Suspended AsyncResponse asyncResponse) {
+        validateNamespaceName(property, cluster, namespace);
+        internalGetTopicHashPositions(asyncResponse, bundle, topics);
     }
 
     @POST

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
@@ -277,11 +277,10 @@ public class PersistentTopics extends PersistentTopicsBase {
             @PathParam("property") String property, @PathParam("cluster") String cluster,
             @PathParam("namespace") String namespace, @PathParam("topic") @Encoded String encodedTopic,
             @QueryParam("force") @DefaultValue("false") boolean force,
-            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
-            @QueryParam("deleteSchema") @DefaultValue("false") boolean deleteSchema) {
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         try {
             validateTopicName(property, cluster, namespace, encodedTopic);
-            internalDeletePartitionedTopic(asyncResponse, authoritative, force, deleteSchema);
+            internalDeletePartitionedTopic(asyncResponse, authoritative, force);
         } catch (WebApplicationException wae) {
             asyncResponse.resume(wae);
         } catch (Exception e) {
@@ -316,10 +315,9 @@ public class PersistentTopics extends PersistentTopicsBase {
     public void deleteTopic(@PathParam("property") String property, @PathParam("cluster") String cluster,
             @PathParam("namespace") String namespace, @PathParam("topic") @Encoded String encodedTopic,
             @QueryParam("force") @DefaultValue("false") boolean force,
-            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
-            @QueryParam("deleteSchema") @DefaultValue("false") boolean deleteSchema) {
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(property, cluster, namespace, encodedTopic);
-        internalDeleteTopic(authoritative, force, deleteSchema);
+        internalDeleteTopic(authoritative, force);
     }
 
     @GET

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -575,16 +575,33 @@ public class Namespaces extends NamespacesBase {
             @PathParam("bundle") String bundleRange,
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @QueryParam("unload") @DefaultValue("false") boolean unload,
-            @QueryParam("splitAlgorithmName") String splitAlgorithmName) {
-
+            @QueryParam("splitAlgorithmName") String splitAlgorithmName,
+            @ApiParam("splitBoundaries") List<Long> splitBoundaries) {
         try {
             validateNamespaceName(tenant, namespace);
-            internalSplitNamespaceBundle(asyncResponse, bundleRange, authoritative, unload, splitAlgorithmName);
+            internalSplitNamespaceBundle(asyncResponse,
+                    bundleRange, authoritative, unload, splitAlgorithmName, splitBoundaries);
         } catch (WebApplicationException wae) {
             asyncResponse.resume(wae);
         } catch (Exception e) {
             asyncResponse.resume(new RestException(e));
         }
+    }
+
+    @GET
+    @Path("/{tenant}/{namespace}/{bundle}/topicHashPositions")
+    @ApiOperation(value = "Get hash positions for topics")
+    @ApiResponses(value = {
+            @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Namespace does not exist")})
+    public void getTopicHashPositions(
+            @PathParam("tenant") String tenant,
+            @PathParam("namespace") String namespace,
+            @PathParam("bundle") String bundleRange,
+            @QueryParam("topics") List<String> topics,
+            @Suspended AsyncResponse asyncResponse) {
+            validateNamespaceName(tenant, namespace);
+            internalGetTopicHashPositions(asyncResponse, bundleRange, topics);
     }
 
     @POST

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -850,10 +850,17 @@ public class Namespaces extends NamespacesBase {
     @Path("/{tenant}/{namespace}/persistence")
     @ApiOperation(value = "Delete the persistence configuration for all topics on a namespace")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })
-    public void deletePersistence(@PathParam("tenant") String tenant,
-                                               @PathParam("namespace") String namespace) {
+    public void deletePersistence(@Suspended final AsyncResponse asyncResponse, @PathParam("tenant") String tenant,
+                                  @PathParam("namespace") String namespace) {
         validateNamespaceName(tenant, namespace);
-        internalDeletePersistence();
+        internalDeletePersistenceAsync()
+                .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
+                .exceptionally(ex -> {
+                    log.error("[{}] Failed to delete the persistence for a namespace {}", clientAppId(), namespaceName,
+                            ex);
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
     }
 
     @POST

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -49,6 +49,7 @@ import javax.ws.rs.core.StreamingOutput;
 import org.apache.pulsar.broker.admin.impl.NamespacesBase;
 import org.apache.pulsar.broker.admin.impl.OffloaderObjectsScannerUtils;
 import org.apache.pulsar.broker.web.RestException;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespace.Mode;
 import org.apache.pulsar.common.naming.NamespaceName;
@@ -76,6 +77,7 @@ import org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy;
 import org.apache.pulsar.common.policies.data.SubscribeRate;
 import org.apache.pulsar.common.policies.data.SubscriptionAuthMode;
 import org.apache.pulsar.common.policies.data.impl.DispatchRateImpl;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -158,14 +160,25 @@ public class Namespaces extends NamespacesBase {
             @PathParam("namespace") String namespace,
             @QueryParam("force") @DefaultValue("false") boolean force,
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
-        try {
-            validateNamespaceName(tenant, namespace);
-            internalDeleteNamespace(asyncResponse, authoritative, force);
-        } catch (WebApplicationException wae) {
-            asyncResponse.resume(wae);
-        } catch (Exception e) {
-            asyncResponse.resume(new RestException(e));
-        }
+        validateNamespaceName(tenant, namespace);
+        internalDeleteNamespaceAsync(force)
+                .thenAccept(__ -> {
+                    log.info("[{}] Successful delete namespace {}", clientAppId(), namespace);
+                    asyncResponse.resume(Response.noContent().build());
+                })
+                .exceptionally(ex -> {
+                    Throwable cause = FutureUtil.unwrapCompletionException(ex);
+                    if (cause instanceof PulsarAdminException.ConflictException) {
+                        log.info("[{}] There are new topics created during the namespace deletion, "
+                                + "retry to delete the namespace again.", namespaceName);
+                        pulsar().getExecutor().execute(() -> internalDeleteNamespaceAsync(force));
+                    }
+                    if (!isRedirectException(ex)) {
+                        log.error("[{}] Failed to delete namespace {}", clientAppId(), namespaceName, ex);
+                    }
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
     }
 
     @DELETE

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -933,12 +933,10 @@ public class PersistentTopics extends PersistentTopicsBase {
                     defaultValue = "false", type = "boolean")
             @QueryParam("force") @DefaultValue("false") boolean force,
             @ApiParam(value = "Whether leader broker redirected this call to this broker. For internal use.")
-            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
-            @ApiParam(value = "Delete the topic's schema storage")
-            @QueryParam("deleteSchema") @DefaultValue("false") boolean deleteSchema) {
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         try {
             validatePartitionedTopicName(tenant, namespace, encodedTopic);
-            internalDeletePartitionedTopic(asyncResponse, authoritative, force, deleteSchema);
+            internalDeletePartitionedTopic(asyncResponse, authoritative, force);
         } catch (WebApplicationException wae) {
             asyncResponse.resume(wae);
         } catch (Exception e) {
@@ -1001,11 +999,9 @@ public class PersistentTopics extends PersistentTopicsBase {
                     defaultValue = "false", type = "boolean")
             @QueryParam("force") @DefaultValue("false") boolean force,
             @ApiParam(value = "Whether leader broker redirected this call to this broker. For internal use.")
-            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
-            @ApiParam(value = "Delete the topic's schema storage")
-            @QueryParam("deleteSchema") @DefaultValue("false") boolean deleteSchema) {
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        internalDeleteTopic(authoritative, force, deleteSchema);
+        internalDeleteTopic(authoritative, force);
     }
 
     @GET

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -69,11 +69,12 @@ public class TopicLookupBase extends PulsarWebResource {
                     // Currently, it's hard to check the non-persistent-non-partitioned topic, because it only exists
                     // in the broker, it doesn't have metadata. If the topic is non-persistent and non-partitioned,
                     // we'll return the true flag.
-                    CompletableFuture<Boolean> existFuture = pulsar().getBrokerService()
-                            .isAllowAutoTopicCreation(topicName)
-                            || (!topicName.isPersistent() && !topicName.isPartitioned())
+                    CompletableFuture<Boolean> existFuture = (!topicName.isPersistent() && !topicName.isPartitioned())
                             ? CompletableFuture.completedFuture(true)
-                            : pulsar().getNamespaceService().checkTopicExists(topicName);
+                            : pulsar().getNamespaceService().checkTopicExists(topicName)
+                                .thenCompose(exists -> exists ? CompletableFuture.completedFuture(true)
+                                        : pulsar().getBrokerService().isAllowAutoTopicCreationAsync(topicName));
+
                     return existFuture;
                 })
                 .thenCompose(exist -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.broker.lookup;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.pulsar.common.protocol.Commands.newLookupErrorResponse;
 import static org.apache.pulsar.common.protocol.Commands.newLookupResponse;
 import io.netty.buffer.ByteBuf;
@@ -57,97 +56,81 @@ public class TopicLookupBase extends PulsarWebResource {
     private static final String LOOKUP_PATH_V1 = "/lookup/v2/destination/";
     private static final String LOOKUP_PATH_V2 = "/lookup/v2/topic/";
 
-    protected void internalLookupTopicAsync(TopicName topicName, boolean authoritative,
-                                            AsyncResponse asyncResponse, String listenerName) {
+    protected CompletableFuture<LookupData> internalLookupTopicAsync(TopicName topicName, boolean authoritative,
+                                                                     String listenerName) {
         if (!pulsar().getBrokerService().getLookupRequestSemaphore().tryAcquire()) {
             log.warn("No broker was found available for topic {}", topicName);
-            asyncResponse.resume(new WebApplicationException(Response.Status.SERVICE_UNAVAILABLE));
-            return;
+            return FutureUtil.failedFuture(new WebApplicationException(Response.Status.SERVICE_UNAVAILABLE));
         }
-
-        try {
-            validateClusterOwnership(topicName.getCluster());
-            validateAdminAndClientPermission(topicName);
-            validateGlobalNamespaceOwnership(topicName.getNamespaceObject());
-        } catch (WebApplicationException we) {
-            // Validation checks failed
-            log.error("Validation check failed: {}", we.getMessage());
-            completeLookupResponseExceptionally(asyncResponse, we);
-            return;
-        } catch (Throwable t) {
-            // Validation checks failed with unknown error
-            log.error("Validation check failed: {}", t.getMessage(), t);
-            completeLookupResponseExceptionally(asyncResponse, new RestException(t));
-            return;
-        }
-
-        // Currently, it's hard to check the non-persistent-non-partitioned topic, because it only exists in the broker,
-        // it doesn't have metadata. If the topic is non-persistent and non-partitioned, we'll return the true flag.
-        CompletableFuture<Boolean> existFuture = pulsar().getBrokerService().isAllowAutoTopicCreation(topicName)
-                || (!topicName.isPersistent() && !topicName.isPartitioned())
-                ? CompletableFuture.completedFuture(true) : pulsar().getNamespaceService().checkTopicExists(topicName);
-        existFuture.thenAccept(exist -> {
-            if (!exist) {
-                completeLookupResponseExceptionally(asyncResponse, new RestException(Response.Status.NOT_FOUND,
-                        "Topic not found."));
-                return;
-            }
-            CompletableFuture<Optional<LookupResult>> lookupFuture = pulsar().getNamespaceService()
-                    .getBrokerServiceUrlAsync(topicName,
-                            LookupOptions.builder().advertisedListenerName(listenerName)
-                                    .authoritative(authoritative).loadTopicsInBundle(false).build());
-
-            lookupFuture.thenAccept(optionalResult -> {
-                if (optionalResult == null || !optionalResult.isPresent()) {
-                    log.warn("No broker was found available for topic {}", topicName);
-                    completeLookupResponseExceptionally(asyncResponse,
-                            new WebApplicationException(Response.Status.SERVICE_UNAVAILABLE));
-                    return;
-                }
-
-                LookupResult result = optionalResult.get();
-                // We have found either a broker that owns the topic, or a broker to
-                // which we should redirect the client to
-                if (result.isRedirect()) {
-                    boolean newAuthoritative = result.isAuthoritativeRedirect();
-                    URI redirect;
-                    try {
-                        String redirectUrl = isRequestHttps() ? result.getLookupData().getHttpUrlTls()
-                                : result.getLookupData().getHttpUrl();
-                        checkNotNull(redirectUrl, "Redirected cluster's service url is not configured");
-                        String lookupPath = topicName.isV2() ? LOOKUP_PATH_V2 : LOOKUP_PATH_V1;
-                        String path = String.format("%s%s%s?authoritative=%s",
-                                redirectUrl, lookupPath, topicName.getLookupName(), newAuthoritative);
-                        path = listenerName == null ? path : path + "&listenerName=" + listenerName;
-                        redirect = new URI(path);
-                    } catch (URISyntaxException | NullPointerException e) {
-                        log.error("Error in preparing redirect url for {}: {}", topicName, e.getMessage(), e);
-                        completeLookupResponseExceptionally(asyncResponse, e);
-                        return;
+        return validateClusterOwnershipAsync(topicName.getCluster())
+                .thenCompose(__ -> validateGlobalNamespaceOwnershipAsync(topicName.getNamespaceObject()))
+                .thenCompose(__ -> validateTopicOperationAsync(topicName, TopicOperation.LOOKUP, null))
+                .thenCompose(__ -> {
+                    // Currently, it's hard to check the non-persistent-non-partitioned topic, because it only exists
+                    // in the broker, it doesn't have metadata. If the topic is non-persistent and non-partitioned,
+                    // we'll return the true flag.
+                    CompletableFuture<Boolean> existFuture = pulsar().getBrokerService()
+                            .isAllowAutoTopicCreation(topicName)
+                            || (!topicName.isPersistent() && !topicName.isPartitioned())
+                            ? CompletableFuture.completedFuture(true)
+                            : pulsar().getNamespaceService().checkTopicExists(topicName);
+                    return existFuture;
+                })
+                .thenCompose(exist -> {
+                    if (!exist) {
+                        throw new RestException(Response.Status.NOT_FOUND, "Topic not found.");
                     }
-                    if (log.isDebugEnabled()) {
-                        log.debug("Redirect lookup for topic {} to {}", topicName, redirect);
-                    }
-                    completeLookupResponseExceptionally(asyncResponse,
-                            new WebApplicationException(Response.temporaryRedirect(redirect).build()));
+                    CompletableFuture<Optional<LookupResult>> lookupFuture = pulsar().getNamespaceService()
+                            .getBrokerServiceUrlAsync(topicName,
+                                    LookupOptions.builder()
+                                            .advertisedListenerName(listenerName)
+                                            .authoritative(authoritative)
+                                            .loadTopicsInBundle(false)
+                                            .build());
 
-                } else {
-                    // Found broker owning the topic
-                    if (log.isDebugEnabled()) {
-                        log.debug("Lookup succeeded for topic {} -- broker: {}", topicName, result.getLookupData());
-                    }
-                    completeLookupResponseSuccessfully(asyncResponse, result.getLookupData());
-                }
-            }).exceptionally(exception -> {
-                log.warn("Failed to lookup broker for topic {}: {}", topicName, exception.getMessage(), exception);
-                completeLookupResponseExceptionally(asyncResponse, exception);
-                return null;
-            });
-        }).exceptionally(e -> {
-            log.warn("Failed to check exist for topic {}: {} when lookup", topicName, e.getMessage(), e);
-            completeLookupResponseExceptionally(asyncResponse, e);
-            return null;
-        });
+                    return lookupFuture.thenApply(optionalResult -> {
+                        if (optionalResult == null || !optionalResult.isPresent()) {
+                            log.warn("No broker was found available for topic {}", topicName);
+                            throw new WebApplicationException(Response.Status.SERVICE_UNAVAILABLE);
+                        }
+
+                        LookupResult result = optionalResult.get();
+                        // We have found either a broker that owns the topic, or a broker to
+                        // which we should redirect the client to
+                        if (result.isRedirect()) {
+                            boolean newAuthoritative = result.isAuthoritativeRedirect();
+                            URI redirect;
+                            try {
+                                String redirectUrl = isRequestHttps() ? result.getLookupData().getHttpUrlTls()
+                                        : result.getLookupData().getHttpUrl();
+                                if (redirectUrl == null) {
+                                    log.error("Redirected cluster's service url is not configured");
+                                    throw new RestException(Response.Status.PRECONDITION_FAILED,
+                                            "Redirected cluster's service url is not configured.");
+                                }
+                                String lookupPath = topicName.isV2() ? LOOKUP_PATH_V2 : LOOKUP_PATH_V1;
+                                String path = String.format("%s%s%s?authoritative=%s",
+                                        redirectUrl, lookupPath, topicName.getLookupName(), newAuthoritative);
+                                path = listenerName == null ? path : path + "&listenerName=" + listenerName;
+                                redirect = new URI(path);
+                            } catch (URISyntaxException e) {
+                                log.error("Error in preparing redirect url for {}: {}", topicName, e.getMessage(), e);
+                                throw new RestException(Response.Status.PRECONDITION_FAILED, e.getMessage());
+                            }
+                            if (log.isDebugEnabled()) {
+                                log.debug("Redirect lookup for topic {} to {}", topicName, redirect);
+                            }
+                            throw new WebApplicationException(Response.temporaryRedirect(redirect).build());
+                        } else {
+                            // Found broker owning the topic
+                            if (log.isDebugEnabled()) {
+                                log.debug("Lookup succeeded for topic {} -- broker: {}", topicName,
+                                        result.getLookupData());
+                            }
+                            return result.getLookupData();
+                        }
+                    });
+                });
     }
 
     private void validateAdminAndClientPermission(TopicName topic) throws RestException, Exception {
@@ -353,14 +336,10 @@ public class TopicLookupBase extends PulsarWebResource {
         return lookupfuture;
     }
 
-    private void completeLookupResponseExceptionally(AsyncResponse asyncResponse, Throwable t) {
+    protected void completeLookupResponseExceptionally(AsyncResponse asyncResponse, Throwable t) {
         pulsar().getBrokerService().getLookupRequestSemaphore().release();
-        asyncResponse.resume(t);
-    }
-
-    private void completeLookupResponseSuccessfully(AsyncResponse asyncResponse, LookupData lookupData) {
-        pulsar().getBrokerService().getLookupRequestSemaphore().release();
-        asyncResponse.resume(lookupData);
+        Throwable cause = FutureUtil.unwrapCompletionException(t);
+        asyncResponse.resume(cause);
     }
 
     protected TopicName getTopicName(String topicDomain, String tenant, String cluster, String namespace,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v1/TopicLookup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v1/TopicLookup.java
@@ -31,6 +31,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.lookup.TopicLookupBase;
 import org.apache.pulsar.broker.web.NoSwaggerDocumentation;
@@ -48,6 +49,7 @@ import org.apache.pulsar.common.naming.TopicName;
  */
 @Path("/v2/destination/")
 @NoSwaggerDocumentation
+@Slf4j
 public class TopicLookup extends TopicLookupBase {
 
     static final String LISTENERNAME_HEADER = "X-Pulsar-ListenerName";
@@ -57,18 +59,27 @@ public class TopicLookup extends TopicLookupBase {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiResponses(value = { @ApiResponse(code = 307,
             message = "Current broker doesn't serve the namespace of this topic") })
-    public void lookupTopicAsync(@PathParam("topic-domain") String topicDomain, @PathParam("property") String property,
+    public void lookupTopicAsync(
+            @Suspended AsyncResponse asyncResponse,
+            @PathParam("topic-domain") String topicDomain, @PathParam("property") String property,
             @PathParam("cluster") String cluster, @PathParam("namespace") String namespace,
             @PathParam("topic") @Encoded String encodedTopic,
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
-            @Suspended AsyncResponse asyncResponse,
             @QueryParam("listenerName") String listenerName,
             @HeaderParam(LISTENERNAME_HEADER) String listenerNameHeader) {
         TopicName topicName = getTopicName(topicDomain, property, cluster, namespace, encodedTopic);
         if (StringUtils.isEmpty(listenerName) && StringUtils.isNotEmpty(listenerNameHeader)) {
             listenerName = listenerNameHeader;
         }
-        internalLookupTopicAsync(topicName, authoritative, asyncResponse, listenerName);
+        internalLookupTopicAsync(topicName, authoritative, listenerName)
+                .thenAccept(lookupData -> asyncResponse.resume(lookupData))
+                .exceptionally(ex -> {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Failed to check exist for topic {} when lookup", topicName, ex);
+                    }
+                    completeLookupResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
     }
 
     @GET

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -54,6 +54,7 @@ import org.apache.pulsar.broker.loadbalance.LeaderElectionService;
 import org.apache.pulsar.broker.loadbalance.LoadManager;
 import org.apache.pulsar.broker.loadbalance.ResourceUnit;
 import org.apache.pulsar.broker.lookup.LookupResult;
+import org.apache.pulsar.broker.resources.NamespaceResources;
 import org.apache.pulsar.broker.service.BrokerServiceException.ServiceUnitNotReadyException;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopic;
@@ -1109,9 +1110,16 @@ public class NamespaceService implements AutoCloseable {
     public CompletableFuture<List<String>> getFullListOfTopics(NamespaceName namespaceName) {
         return getListOfPersistentTopics(namespaceName)
                 .thenCombine(getListOfNonPersistentTopics(namespaceName),
-                        (persistentTopics, nonPersistentTopics) -> {
-                            return ListUtils.union(persistentTopics, nonPersistentTopics);
-                        });
+                        ListUtils::union);
+    }
+
+    public CompletableFuture<List<String>> getFullListOfPartitionedTopic(NamespaceName namespaceName) {
+        NamespaceResources.PartitionedTopicResources partitionedTopicResources =
+                pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources();
+        return partitionedTopicResources.listPartitionedTopicsAsync(namespaceName, TopicDomain.persistent)
+                .thenCombine(partitionedTopicResources
+                                .listPartitionedTopicsAsync(namespaceName, TopicDomain.non_persistent),
+                        ListUtils::union);
     }
 
     public CompletableFuture<List<String>> getOwnedTopicListForNamespaceBundle(NamespaceBundle bundle) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.broker.namespace;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import com.google.common.collect.Lists;
@@ -71,6 +70,7 @@ import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.internal.PropertiesUtils;
 import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespace.Mode;
 import org.apache.pulsar.common.lookup.data.LookupData;
+import org.apache.pulsar.common.naming.BundleSplitOption;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceBundleFactory;
 import org.apache.pulsar.common.naming.NamespaceBundleSplitAlgorithm;
@@ -813,11 +813,12 @@ public class NamespaceService implements AutoCloseable {
      * @throws Exception
      */
     public CompletableFuture<Void> splitAndOwnBundle(NamespaceBundle bundle, boolean unload,
-                                                     NamespaceBundleSplitAlgorithm splitAlgorithm) {
+                                                     NamespaceBundleSplitAlgorithm splitAlgorithm,
+                                                     List<Long> boundaries) {
 
         final CompletableFuture<Void> unloadFuture = new CompletableFuture<>();
         final AtomicInteger counter = new AtomicInteger(BUNDLE_SPLIT_RETRY_LIMIT);
-        splitAndOwnBundleOnceAndRetry(bundle, unload, counter, unloadFuture, splitAlgorithm);
+        splitAndOwnBundleOnceAndRetry(bundle, unload, counter, unloadFuture, splitAlgorithm, boundaries);
 
         return unloadFuture;
     }
@@ -826,13 +827,20 @@ public class NamespaceService implements AutoCloseable {
                                        boolean unload,
                                        AtomicInteger counter,
                                        CompletableFuture<Void> completionFuture,
-                                       NamespaceBundleSplitAlgorithm splitAlgorithm) {
-        splitAlgorithm.getSplitBoundary(this, bundle).whenComplete((splitBoundary, ex) -> {
+                                       NamespaceBundleSplitAlgorithm splitAlgorithm,
+                                       List<Long> boundaries) {
+        BundleSplitOption bundleSplitOption = new BundleSplitOption(this, bundle, boundaries);
+        splitAlgorithm.getSplitBoundary(bundleSplitOption).whenComplete((splitBoundaries, ex) -> {
             CompletableFuture<List<NamespaceBundle>> updateFuture = new CompletableFuture<>();
             if (ex == null) {
+                if (splitBoundaries == null || splitBoundaries.size() == 0) {
+                    LOG.info("[{}] No valid boundary found in {} to split bundle {}",
+                            bundle.getNamespaceObject().toString(), boundaries, bundle.getBundleRange());
+                    completionFuture.complete(null);
+                    return;
+                }
                 try {
-                    bundleFactory.splitBundles(bundle,
-                        2 /* by default split into 2 */, splitBoundary)
+                    bundleFactory.splitBundles(bundle, splitBoundaries.size() + 1, splitBoundaries)
                             .thenAccept(splittedBundles -> {
                                 // Split and updateNamespaceBundles. Update may fail because of concurrent write to
                                 // Zookeeper.
@@ -845,14 +853,13 @@ public class NamespaceService implements AutoCloseable {
 
                                 checkNotNull(splittedBundles.getLeft());
                                 checkNotNull(splittedBundles.getRight());
-                                checkArgument(splittedBundles.getRight().size() == 2,
-                                        "bundle has to be split in two bundles");
+                                checkArgument(splittedBundles.getRight().size() == splitBoundaries.size() + 1,
+                                        "bundle has to be split in " + (splitBoundaries.size() + 1) + " bundles");
                                 NamespaceName nsname = bundle.getNamespaceObject();
                                 if (LOG.isDebugEnabled()) {
-                                    LOG.debug("[{}] splitAndOwnBundleOnce: {}, counter: {},  2 bundles: {}, {}",
+                                    LOG.debug("[{}] splitAndOwnBundleOnce: {}, counter: {}, bundles: {}",
                                             nsname.toString(), bundle.getBundleRange(), counter.get(),
-                                            splittedBundles.getRight().get(0).getBundleRange(),
-                                            splittedBundles.getRight().get(1).getBundleRange());
+                                            splittedBundles.getRight());
                                 }
                                 try {
                                     // take ownership of newly split bundles
@@ -894,10 +901,9 @@ public class NamespaceService implements AutoCloseable {
                     // retry several times on BadVersion
                     if ((t.getCause() instanceof MetadataStoreException.BadVersionException)
                             && (counter.decrementAndGet() >= 0)) {
-                        pulsar.getExecutor().schedule(() -> pulsar.getOrderedExecutor()
+                        pulsar.getOrderedExecutor()
                                 .execute(() -> splitAndOwnBundleOnceAndRetry(
-                                        bundle, unload, counter, completionFuture, splitAlgorithm)),
-                                100, MILLISECONDS);
+                                        bundle, unload, counter, completionFuture, splitAlgorithm, boundaries));
                     } else if (t instanceof IllegalArgumentException) {
                         completionFuture.completeExceptionally(t);
                     } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1143,7 +1143,15 @@ public class NamespaceService implements AutoCloseable {
 
     public CompletableFuture<Boolean> checkTopicExists(TopicName topic) {
         if (topic.isPersistent()) {
-            return pulsar.getPulsarResources().getTopicResources().persistentTopicExists(topic);
+            if (topic.isPartitioned()) {
+                return pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
+                        .partitionedTopicExistsAsync(TopicName.get(topic.getPartitionedTopicName()))
+                        .thenCompose(exists -> exists
+                                ? pulsar.getPulsarResources().getTopicResources().persistentTopicExists(topic)
+                                : CompletableFuture.completedFuture(false));
+            } else {
+                return pulsar.getPulsarResources().getTopicResources().persistentTopicExists(topic);
+            }
         } else {
             if (topic.isPartitioned()) {
                 final TopicName partitionedTopicName = TopicName.get(topic.getPartitionedTopicName());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -157,7 +157,6 @@ import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.TopicPolicies;
 import org.apache.pulsar.common.policies.data.TopicType;
 import org.apache.pulsar.common.policies.data.stats.TopicStatsImpl;
-import org.apache.pulsar.common.protocol.schema.SchemaVersion;
 import org.apache.pulsar.common.stats.Metrics;
 import org.apache.pulsar.common.util.FieldParser;
 import org.apache.pulsar.common.util.FutureUtil;
@@ -1007,33 +1006,13 @@ public class BrokerService implements Closeable {
         }
     }
 
-    public CompletableFuture<SchemaVersion> deleteSchemaStorage(String topic) {
-        Optional<Topic> optTopic = getTopicReference(topic);
-        if (optTopic.isPresent()) {
-            return optTopic.get().deleteSchema();
-        } else {
-            return CompletableFuture.completedFuture(null);
-        }
-    }
-
     public CompletableFuture<Void> deleteTopic(String topic, boolean forceDelete) {
-        return deleteTopic(topic, forceDelete, false);
-    }
-
-    public CompletableFuture<Void> deleteTopic(String topic, boolean forceDelete, boolean deleteSchema) {
         Optional<Topic> optTopic = getTopicReference(topic);
 
         if (optTopic.isPresent()) {
             Topic t = optTopic.get();
             if (forceDelete) {
-                if (deleteSchema) {
-                    return t.deleteSchema().thenCompose(schemaVersion -> {
-                        log.info("Successfully delete topic {}'s schema of version {}", t.getName(), schemaVersion);
-                        return t.deleteForcefully();
-                    });
-                } else {
-                    return t.deleteForcefully();
-                }
+                return t.deleteForcefully();
             }
 
             // v2 topics have a global name so check if the topic is replicated.
@@ -1045,14 +1024,7 @@ public class BrokerService implements Closeable {
                         new IllegalStateException("Delete forbidden topic is replicated on clusters " + clusters));
             }
 
-            if (deleteSchema) {
-                return t.deleteSchema().thenCompose(schemaVersion -> {
-                    log.info("Successfully delete topic {}'s schema of version {}", t.getName(), schemaVersion);
-                    return t.delete();
-                });
-            } else {
-                return t.delete();
-            }
+            return t.delete();
         }
 
         log.info("Topic {} is not loaded, try to delete from metadata", topic);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1197,11 +1197,6 @@ public class BrokerService implements Closeable {
         return topicFuture;
     }
 
-    private <T> CompletableFuture<T> futureWithDeadline() {
-        return FutureUtil.createFutureWithTimeout(FUTURE_DEADLINE_TIMEOUT_DURATION, executor(),
-                () -> FUTURE_DEADLINE_TIMEOUT_EXCEPTION);
-    }
-
     public PulsarClient getReplicationClient(String cluster, Optional<ClusterData> clusterDataOp) {
         PulsarClient client = replicationClients.get(cluster);
         if (client != null) {
@@ -2904,15 +2899,6 @@ public class BrokerService implements Closeable {
         } else {
             return Optional.empty();
         }
-    }
-
-    private void foreachCnx(Consumer<TransportCnx> consumer) {
-        Set<TransportCnx> cnxSet = new HashSet<>();
-        topics.forEach((n, t) -> {
-            Optional<Topic> topic = extractTopic(t);
-            topic.ifPresent(value -> value.getProducers().values().forEach(producer -> cnxSet.add(producer.getCnx())));
-        });
-        cnxSet.forEach(consumer);
     }
 
     public boolean isAllowAutoTopicCreation(final String topic) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -931,7 +931,9 @@ public class BrokerService implements Closeable {
     }
 
     public CompletableFuture<Topic> getOrCreateTopic(final String topic) {
-        return getTopic(topic, isAllowAutoTopicCreation(topic)).thenApply(Optional::get);
+        return isAllowAutoTopicCreationAsync(topic)
+                .thenCompose(isAllowed -> getTopic(topic, isAllowed))
+                .thenApply(Optional::get);
     }
 
     public CompletableFuture<Optional<Topic>> getTopic(final String topic, boolean createIfMissing) {
@@ -2656,30 +2658,38 @@ public class BrokerService implements Closeable {
                                     if (metadata.partitions == 0
                                             && !topicExists
                                             && !topicName.isPartitioned()
-                                            && pulsar.getBrokerService().isAllowAutoTopicCreation(topicName, policies)
                                             && pulsar.getBrokerService()
                                                             .isDefaultTopicTypePartitioned(topicName, policies)) {
-
-                                        pulsar.getBrokerService()
-                                                .createDefaultPartitionedTopicAsync(topicName, policies)
-                                                .thenAccept(md -> future.complete(md))
-                                                .exceptionally(ex -> {
-                                                    if (ex.getCause()
-                                                            instanceof MetadataStoreException.AlreadyExistsException) {
-                                                        // The partitioned topic might be created concurrently
-                                                        fetchPartitionedTopicMetadataAsync(topicName)
-                                                                .whenComplete((metadata2, ex2) -> {
-                                                                    if (ex2 == null) {
-                                                                        future.complete(metadata2);
-                                                                    } else {
-                                                                        future.completeExceptionally(ex2);
-                                                                    }
-                                                                });
-                                                    } else {
-                                                        future.completeExceptionally(ex);
-                                                    }
-                                                    return null;
-                                                });
+                                        isAllowAutoTopicCreationAsync(topicName, policies).thenAccept(allowed -> {
+                                            if (allowed) {
+                                                pulsar.getBrokerService()
+                                                        .createDefaultPartitionedTopicAsync(topicName, policies)
+                                                        .thenAccept(md -> future.complete(md))
+                                                        .exceptionally(ex -> {
+                                                            if (ex.getCause()
+                                                                    instanceof MetadataStoreException
+                                                                        .AlreadyExistsException) {
+                                                                // The partitioned topic might be created concurrently
+                                                                fetchPartitionedTopicMetadataAsync(topicName)
+                                                                        .whenComplete((metadata2, ex2) -> {
+                                                                            if (ex2 == null) {
+                                                                                future.complete(metadata2);
+                                                                            } else {
+                                                                                future.completeExceptionally(ex2);
+                                                                            }
+                                                                        });
+                                                            } else {
+                                                                future.completeExceptionally(ex);
+                                                            }
+                                                            return null;
+                                                        });
+                                            } else {
+                                                future.complete(metadata);
+                                            }
+                                        }).exceptionally(ex -> {
+                                            future.completeExceptionally(ex);
+                                            return null;
+                                        });
                                     } else {
                                         future.complete(metadata);
                                     }
@@ -2873,34 +2883,46 @@ public class BrokerService implements Closeable {
         }
     }
 
-    public boolean isAllowAutoTopicCreation(final String topic) {
+    public CompletableFuture<Boolean> isAllowAutoTopicCreationAsync(final String topic) {
         TopicName topicName = TopicName.get(topic);
-        return isAllowAutoTopicCreation(topicName);
+        return isAllowAutoTopicCreationAsync(topicName);
     }
 
-    public boolean isAllowAutoTopicCreation(final TopicName topicName) {
+    public CompletableFuture<Boolean> isAllowAutoTopicCreationAsync(final TopicName topicName) {
         Optional<Policies> policies =
                 pulsar.getPulsarResources().getNamespaceResources()
                         .getPoliciesIfCached(topicName.getNamespaceObject());
-        return isAllowAutoTopicCreation(topicName, policies);
+        return isAllowAutoTopicCreationAsync(topicName, policies);
     }
 
-    public boolean isAllowAutoTopicCreation(final TopicName topicName, final Optional<Policies> policies) {
+    private CompletableFuture<Boolean> isAllowAutoTopicCreationAsync(final TopicName topicName,
+                                                                     final Optional<Policies> policies) {
         if (policies.isPresent() && policies.get().deleted) {
             log.info("Preventing AutoTopicCreation on a namespace that is being deleted {}",
                     topicName.getNamespaceObject());
-            return false;
+            return CompletableFuture.completedFuture(false);
         }
         //System topic can always be created automatically
         if (pulsar.getConfiguration().isSystemTopicEnabled() && isSystemTopic(topicName)) {
-            return true;
+            return CompletableFuture.completedFuture(true);
         }
+        final boolean allowed;
         AutoTopicCreationOverride autoTopicCreationOverride = getAutoTopicCreationOverride(topicName, policies);
         if (autoTopicCreationOverride != null) {
-            return autoTopicCreationOverride.isAllowAutoTopicCreation();
+            allowed = autoTopicCreationOverride.isAllowAutoTopicCreation();
         } else {
-            return pulsar.getConfiguration().isAllowAutoTopicCreation();
+            allowed = pulsar.getConfiguration().isAllowAutoTopicCreation();
         }
+
+        if (allowed && topicName.isPartitioned()) {
+            // cannot re-create topic while it is being deleted
+            return pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
+                    .isPartitionedTopicBeingDeletedAsync(topicName)
+                    .thenApply(beingDeleted -> !beingDeleted);
+        } else {
+            return CompletableFuture.completedFuture(allowed);
+        }
+
     }
 
     public boolean isDefaultTopicTypePartitioned(final TopicName topicName, final Optional<Policies> policies) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1062,9 +1062,6 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                     return null;
                 }
 
-                boolean createTopicIfDoesNotExist = forceTopicCreation
-                        && service.isAllowAutoTopicCreation(topicName.toString());
-
                 final long consumerEpoch;
                 if (subscribe.hasConsumerEpoch()) {
                     consumerEpoch = subscribe.getConsumerEpoch();
@@ -1073,7 +1070,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 }
                 Optional<Map<String, String>> subscriptionProperties = SubscriptionOption.getPropertiesMap(
                         subscribe.getSubscriptionPropertiesList());
-                service.getTopic(topicName.toString(), createTopicIfDoesNotExist)
+                service.isAllowAutoTopicCreationAsync(topicName.toString())
+                        .thenApply(isAllowed -> forceTopicCreation && isAllowed)
+                        .thenCompose(createTopicIfDoesNotExist ->
+                                service.getTopic(topicName.toString(), createTopicIfDoesNotExist))
                         .thenCompose(optTopic -> {
                             if (!optTopic.isPresent()) {
                                 return FutureUtil

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -369,7 +369,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
 
     @Override
     public CompletableFuture<Void> delete() {
-        return delete(false, false, false);
+        return delete(false, false);
     }
 
     /**
@@ -379,11 +379,10 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
      */
     @Override
     public CompletableFuture<Void> deleteForcefully() {
-        return delete(false, true, false);
+        return delete(false, true);
     }
 
-    private CompletableFuture<Void> delete(boolean failIfHasSubscriptions, boolean closeIfClientsConnected,
-            boolean deleteSchema) {
+    private CompletableFuture<Void> delete(boolean failIfHasSubscriptions, boolean closeIfClientsConnected) {
         CompletableFuture<Void> deleteFuture = new CompletableFuture<>();
 
         lock.writeLock().lock();
@@ -428,9 +427,8 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                     } else {
                         subscriptions.forEach((s, sub) -> futures.add(sub.delete()));
                     }
-                    if (deleteSchema) {
-                        futures.add(deleteSchema().thenApply(schemaVersion -> null));
-                    }
+
+                    futures.add(deleteSchema().thenApply(schemaVersion -> null));
                     futures.add(deleteTopicPolicies());
                     FutureUtil.waitForAll(futures).whenComplete((v, ex) -> {
                         if (ex != null) {
@@ -947,7 +945,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                             maxInactiveDurationInSec);
                     }
 
-                    stopReplProducers().thenCompose(v -> delete(true, false, true))
+                    stopReplProducers().thenCompose(v -> delete(true, false))
                             .thenCompose(__ -> tryToDeletePartitionedMetadata())
                             .thenRun(() -> log.info("[{}] Topic deleted successfully due to inactivity", topic))
                             .exceptionally(e -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -980,7 +980,9 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                     if (!partitionedTopicExist) {
                         return CompletableFuture.completedFuture(null);
                     } else {
-                        return partitionedTopicResources.deletePartitionedTopicAsync(topicName);
+                        return getBrokerService().pulsar().getPulsarResources().getNamespaceResources()
+                                .getPartitionedTopicResources().runWithMarkDeleteAsync(topicName,
+                                        () -> partitionedTopicResources.deletePartitionedTopicAsync(topicName));
                     }
                 });
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1086,11 +1086,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         return delete(false, false, false);
     }
 
-    private CompletableFuture<Void> delete(boolean failIfHasSubscriptions,
-                                           boolean failIfHasBacklogs, boolean deleteSchema) {
-        return delete(failIfHasSubscriptions, failIfHasBacklogs, false, deleteSchema);
-    }
-
     /**
      * Forcefully close all producers/consumers/replicators and deletes the topic. this function is used when local
      * cluster is removed from global-namespace replication list. Because broker doesn't allow lookup if local cluster
@@ -1100,7 +1095,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
      */
     @Override
     public CompletableFuture<Void> deleteForcefully() {
-        return delete(false, false, true, false);
+        return delete(false, false, true);
     }
 
     /**
@@ -1114,16 +1109,13 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
      *            Flag indicate whether explicitly close connected
      *            producers/consumers/replicators before trying to delete topic.
      *            If any client is connected to a topic and if this flag is disable then this operation fails.
-     * @param deleteSchema
-     *            Flag indicating whether delete the schema defined for topic if exist.
      *
      * @return Completable future indicating completion of delete operation Completed exceptionally with:
      *         IllegalStateException if topic is still active ManagedLedgerException if ledger delete operation fails
      */
     private CompletableFuture<Void> delete(boolean failIfHasSubscriptions,
                                            boolean failIfHasBacklogs,
-                                           boolean closeIfClientsConnected,
-                                           boolean deleteSchema) {
+                                           boolean closeIfClientsConnected) {
         CompletableFuture<Void> deleteFuture = new CompletableFuture<>();
 
         lock.writeLock().lock();
@@ -1165,8 +1157,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     CompletableFuture<Void> deleteTopicAuthenticationFuture = new CompletableFuture<>();
                     brokerService.deleteTopicAuthenticationWithRetry(topic, deleteTopicAuthenticationFuture, 5);
 
-                    deleteTopicAuthenticationFuture.thenCompose(
-                                    __ -> deleteSchema ? deleteSchema() : CompletableFuture.completedFuture(null))
+                    deleteTopicAuthenticationFuture.thenCompose(__ -> deleteSchema())
                             .thenAccept(__ -> deleteTopicPolicies())
                             .thenCompose(__ -> transactionBufferCleanupAndClose())
                             .whenComplete((v, ex) -> {
@@ -2266,7 +2257,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             }
 
             replCloseFuture.thenCompose(v -> delete(deleteMode == InactiveTopicDeleteMode.delete_when_no_subscriptions,
-                deleteMode == InactiveTopicDeleteMode.delete_when_subscriptions_caught_up, true))
+                deleteMode == InactiveTopicDeleteMode.delete_when_subscriptions_caught_up, false))
                     .thenApply((res) -> tryToDeletePartitionedMetadata())
                     .thenRun(() -> log.info("[{}] Topic deleted successfully due to inactivity", topic))
                     .exceptionally(e -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1116,7 +1116,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     private CompletableFuture<Void> delete(boolean failIfHasSubscriptions,
                                            boolean failIfHasBacklogs,
                                            boolean closeIfClientsConnected) {
-        CompletableFuture<Void> deleteFuture = new CompletableFuture<>();
 
         lock.writeLock().lock();
         try {
@@ -1130,105 +1129,112 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             }
 
             fenceTopicToCloseOrDelete(); // Avoid clients reconnections while deleting
-            CompletableFuture<Void> closeClientFuture = new CompletableFuture<>();
-            if (closeIfClientsConnected) {
-                List<CompletableFuture<Void>> futures = Lists.newArrayList();
-                replicators.forEach((cluster, replicator) -> futures.add(replicator.disconnect()));
-                producers.values().forEach(producer -> futures.add(producer.disconnect()));
-                subscriptions.forEach((s, sub) -> futures.add(sub.disconnect()));
-                FutureUtil.waitForAll(futures).thenRun(() -> {
+
+            return getBrokerService().getPulsar().getPulsarResources().getNamespaceResources()
+                        .getPartitionedTopicResources().runWithMarkDeleteAsync(TopicName.get(topic), () -> {
+                CompletableFuture<Void> deleteFuture = new CompletableFuture<>();
+
+                CompletableFuture<Void> closeClientFuture = new CompletableFuture<>();
+                if (closeIfClientsConnected) {
+                    List<CompletableFuture<Void>> futures = new ArrayList<>();
+                    replicators.forEach((cluster, replicator) -> futures.add(replicator.disconnect()));
+                    producers.values().forEach(producer -> futures.add(producer.disconnect()));
+                    subscriptions.forEach((s, sub) -> futures.add(sub.disconnect()));
+                    FutureUtil.waitForAll(futures).thenRun(() -> {
+                        closeClientFuture.complete(null);
+                    }).exceptionally(ex -> {
+                        log.error("[{}] Error closing clients", topic, ex);
+                        unfenceTopicToResume();
+                        closeClientFuture.completeExceptionally(ex);
+                        return null;
+                    });
+                } else {
                     closeClientFuture.complete(null);
-                }).exceptionally(ex -> {
-                    log.error("[{}] Error closing clients", topic, ex);
+                }
+
+                closeClientFuture.thenAccept(delete -> {
+                    // We can proceed with the deletion if either:
+                    //  1. No one is connected
+                    //  2. We want to kick out everyone and forcefully delete the topic.
+                    //     In this case, we shouldn't care if the usageCount is 0 or not, just proceed
+                    if (currentUsageCount() ==  0 || (closeIfClientsConnected && !failIfHasSubscriptions)) {
+                        CompletableFuture<Void> deleteTopicAuthenticationFuture = new CompletableFuture<>();
+                        brokerService.deleteTopicAuthenticationWithRetry(topic, deleteTopicAuthenticationFuture, 5);
+
+                        deleteTopicAuthenticationFuture.thenCompose(__ -> deleteSchema())
+                                .thenCompose(__ -> deleteTopicPolicies())
+                                .thenCompose(__ -> transactionBufferCleanupAndClose())
+                                .whenComplete((v, ex) -> {
+                                    if (ex != null) {
+                                        log.error("[{}] Error deleting topic", topic, ex);
+                                        unfenceTopicToResume();
+                                        deleteFuture.completeExceptionally(ex);
+                                    } else {
+                                        List<CompletableFuture<Void>> subsDeleteFutures = new ArrayList<>();
+                                        subscriptions.forEach((sub, p) -> subsDeleteFutures.add(unsubscribe(sub)));
+
+                                        FutureUtil.waitForAll(subsDeleteFutures).whenComplete((f, e) -> {
+                                            if (e != null) {
+                                                log.error("[{}] Error deleting topic", topic, e);
+                                                unfenceTopicToResume();
+                                                deleteFuture.completeExceptionally(e);
+                                            } else {
+                                                ledger.asyncDelete(new AsyncCallbacks.DeleteLedgerCallback() {
+                                                    @Override
+                                                    public void deleteLedgerComplete(Object ctx) {
+                                                        brokerService.removeTopicFromCache(PersistentTopic.this);
+
+                                                        dispatchRateLimiter.ifPresent(DispatchRateLimiter::close);
+
+                                                        subscribeRateLimiter.ifPresent(SubscribeRateLimiter::close);
+
+                                                        unregisterTopicPolicyListener();
+
+                                                        log.info("[{}] Topic deleted", topic);
+                                                        deleteFuture.complete(null);
+                                                    }
+
+                                                    @Override
+                                                    public void
+                                                    deleteLedgerFailed(ManagedLedgerException exception,
+                                                                       Object ctx) {
+                                                        if (exception.getCause()
+                                                                instanceof MetadataStoreException.NotFoundException) {
+                                                            log.info("[{}] Topic is already deleted {}",
+                                                                    topic, exception.getMessage());
+                                                            deleteLedgerComplete(ctx);
+                                                        } else {
+                                                            unfenceTopicToResume();
+                                                            log.error("[{}] Error deleting topic",
+                                                                    topic, exception);
+                                                            deleteFuture.completeExceptionally(
+                                                                    new PersistenceException(exception));
+                                                        }
+                                                    }
+                                                }, null);
+
+                                            }
+                                        });
+                                    }
+                                });
+                    } else {
+                        unfenceTopicToResume();
+                        deleteFuture.completeExceptionally(new TopicBusyException(
+                                "Topic has " + currentUsageCount() + " connected producers/consumers"));
+                    }
+                }).exceptionally(ex->{
                     unfenceTopicToResume();
-                    closeClientFuture.completeExceptionally(ex);
+                    deleteFuture.completeExceptionally(
+                            new TopicBusyException("Failed to close clients before deleting topic."));
                     return null;
                 });
-            } else {
-                closeClientFuture.complete(null);
-            }
 
-            closeClientFuture.thenAccept(delete -> {
-                // We can proceed with the deletion if either:
-                //  1. No one is connected
-                //  2. We want to kick out everyone and forcefully delete the topic.
-                //     In this case, we shouldn't care if the usageCount is 0 or not, just proceed
-                if (currentUsageCount() ==  0 || (closeIfClientsConnected && !failIfHasSubscriptions)) {
-                    CompletableFuture<Void> deleteTopicAuthenticationFuture = new CompletableFuture<>();
-                    brokerService.deleteTopicAuthenticationWithRetry(topic, deleteTopicAuthenticationFuture, 5);
-
-                    deleteTopicAuthenticationFuture.thenCompose(__ -> deleteSchema())
-                            .thenAccept(__ -> deleteTopicPolicies())
-                            .thenCompose(__ -> transactionBufferCleanupAndClose())
-                            .whenComplete((v, ex) -> {
-                                if (ex != null) {
-                                    log.error("[{}] Error deleting topic", topic, ex);
-                                    unfenceTopicToResume();
-                                    deleteFuture.completeExceptionally(ex);
-                                } else {
-                                    List<CompletableFuture<Void>> subsDeleteFutures = new ArrayList<>();
-                                    subscriptions.forEach((sub, p) -> subsDeleteFutures.add(unsubscribe(sub)));
-
-                                    FutureUtil.waitForAll(subsDeleteFutures).whenComplete((f, e) -> {
-                                        if (e != null) {
-                                            log.error("[{}] Error deleting topic", topic, e);
-                                            unfenceTopicToResume();
-                                            deleteFuture.completeExceptionally(e);
-                                        } else {
-                                            ledger.asyncDelete(new AsyncCallbacks.DeleteLedgerCallback() {
-                                                @Override
-                                                public void deleteLedgerComplete(Object ctx) {
-                                                    brokerService.removeTopicFromCache(PersistentTopic.this);
-
-                                                    dispatchRateLimiter.ifPresent(DispatchRateLimiter::close);
-
-                                                    subscribeRateLimiter.ifPresent(SubscribeRateLimiter::close);
-
-                                                    unregisterTopicPolicyListener();
-
-                                                    log.info("[{}] Topic deleted", topic);
-                                                    deleteFuture.complete(null);
-                                                }
-
-                                                @Override
-                                                public void
-                                                deleteLedgerFailed(ManagedLedgerException exception,
-                                                                   Object ctx) {
-                                                    if (exception.getCause()
-                                                        instanceof MetadataStoreException.NotFoundException) {
-                                                        log.info("[{}] Topic is already deleted {}",
-                                                                topic, exception.getMessage());
-                                                        deleteLedgerComplete(ctx);
-                                                    } else {
-                                                        unfenceTopicToResume();
-                                                        log.error("[{}] Error deleting topic",
-                                                                topic, exception);
-                                                        deleteFuture.completeExceptionally(
-                                                                new PersistenceException(exception));
-                                                    }
-                                                }
-                                            }, null);
-
-                                        }
-                                    });
-                                }
-                            });
-                } else {
-                    unfenceTopicToResume();
-                    deleteFuture.completeExceptionally(new TopicBusyException(
-                            "Topic has " + currentUsageCount() + " connected producers/consumers"));
-                }
-            }).exceptionally(ex->{
-                unfenceTopicToResume();
-                deleteFuture.completeExceptionally(
-                        new TopicBusyException("Failed to close clients before deleting topic."));
-                return null;
-            });
+                return deleteFuture;
+                });
         } finally {
             lock.writeLock().unlock();
         }
 
-        return deleteFuture;
     }
 
     public CompletableFuture<Void> close() {
@@ -2287,7 +2293,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     if (!partitionedTopicExist) {
                         return CompletableFuture.completedFuture(null);
                     } else {
-                        return getBrokerService()
+                        return getBrokerService().pulsar().getPulsarResources().getNamespaceResources()
+                                .getPartitionedTopicResources().runWithMarkDeleteAsync(topicName, () ->
+                            getBrokerService()
                                 .fetchPartitionedTopicMetadataAsync(topicName)
                                 .thenCompose((metadata -> {
                                     List<CompletableFuture<Boolean>> persistentTopicExists =
@@ -2318,7 +2326,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                                                             .deletePartitionedTopicAsync(topicName);
                                                 }
                                             });
-                                }));
+                                }))
+                            );
                     }
                 });
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/BundleSplitOption.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/BundleSplitOption.java
@@ -18,19 +18,17 @@
  */
 package org.apache.pulsar.common.naming;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.apache.pulsar.broker.namespace.NamespaceService;
 
-/**
- * This algorithm divides the bundle into two parts with the same hash range size.
- */
-public class RangeEquallyDivideBundleSplitAlgorithm implements NamespaceBundleSplitAlgorithm {
-
-    @Override
-    public CompletableFuture<List<Long>> getSplitBoundary(BundleSplitOption bundleSplitOption) {
-        NamespaceBundle bundle = bundleSplitOption.getBundle();
-        return CompletableFuture.completedFuture(Collections.singletonList(bundle.getLowerEndpoint()
-                + (bundle.getUpperEndpoint() - bundle.getLowerEndpoint()) / 2));
-    }
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BundleSplitOption {
+    private NamespaceService service;
+    private NamespaceBundle bundle;
+    private List<Long> positions;
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleFactory.java
@@ -32,6 +32,7 @@ import com.google.common.collect.Range;
 import com.google.common.hash.HashFunction;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -306,20 +307,22 @@ public class NamespaceBundleFactory {
      *            {@link NamespaceBundle} needs to be split
      * @param argNumBundles
      *            split into numBundles
-     * @param splitBoundary
-     *            split into 2 numBundles by the given split key. The given split key must between the key range of the
-     *            given split bundle.
+     * @param splitBoundaries
+     *            split into multi numBundles by the given split boundaries. All these given split boundaries must
+     *            between the key range of the given split bundle.
      * @return List of split {@link NamespaceBundle} and {@link NamespaceBundles} that contains final bundles including
      *         split bundles for a given namespace
      */
     public CompletableFuture<Pair<NamespaceBundles, List<NamespaceBundle>>> splitBundles(
-            NamespaceBundle targetBundle, int argNumBundles, Long splitBoundary) {
-        checkArgument(canSplitBundle(targetBundle), "%s bundle can't be split further", targetBundle);
-        if (splitBoundary != null) {
-            checkArgument(splitBoundary > targetBundle.getLowerEndpoint()
-                            && splitBoundary < targetBundle.getUpperEndpoint(),
-                    "The given fixed key must between the key range of the %s bundle", targetBundle);
-            argNumBundles = 2;
+            NamespaceBundle targetBundle, int argNumBundles, List<Long> splitBoundaries) {
+        checkArgument(canSplitBundle(targetBundle),
+                "%s bundle can't be split further since range not larger than 1", targetBundle);
+        if (splitBoundaries != null && splitBoundaries.size() > 0) {
+            Collections.sort(splitBoundaries);
+            checkArgument(splitBoundaries.get(0) > targetBundle.getLowerEndpoint()
+                            && splitBoundaries.get(splitBoundaries.size() - 1) < targetBundle.getUpperEndpoint(),
+                    "The given fixed keys must between the key range of the %s bundle", targetBundle);
+            argNumBundles = splitBoundaries.size() + 1;
         }
         checkNotNull(targetBundle, "can't split null bundle");
         checkNotNull(targetBundle.getNamespaceObject(), "namespace must be present");
@@ -338,15 +341,22 @@ public class NamespaceBundleFactory {
                 if (sourceBundle.partitions[i] == range.lowerEndpoint()
                         && (range.upperEndpoint() == sourceBundle.partitions[i + 1])) {
                     splitPartition = i;
-                    long maxVal = sourceBundle.partitions[i + 1];
                     long minVal = sourceBundle.partitions[i];
-                    long segSize = splitBoundary == null ? (maxVal - minVal) / numBundles : splitBoundary - minVal;
                     partitions[pos++] = minVal;
-                    long curPartition = minVal + segSize;
-                    for (int j = 0; j < numBundles - 1; j++) {
-                        partitions[pos++] = curPartition;
-                        curPartition += segSize;
+                    if (splitBoundaries == null || splitBoundaries.size() == 0) {
+                        long maxVal = sourceBundle.partitions[i + 1];
+                        long segSize = (maxVal - minVal) / numBundles;
+                        long curPartition = minVal + segSize;
+                        for (int j = 0; j < numBundles - 1; j++) {
+                            partitions[pos++] = curPartition;
+                            curPartition += segSize;
+                        }
+                    } else {
+                        for (long splitBoundary : splitBoundaries) {
+                            partitions[pos++] = splitBoundary;
+                        }
                     }
+
                 } else {
                     partitions[pos++] = sourceBundle.partitions[i];
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleSplitAlgorithm.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleSplitAlgorithm.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.common.naming;
 import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import org.apache.pulsar.broker.namespace.NamespaceService;
 
 /**
  * Algorithm interface for namespace bundle split.
@@ -30,11 +29,15 @@ public interface NamespaceBundleSplitAlgorithm {
 
     String RANGE_EQUALLY_DIVIDE_NAME = "range_equally_divide";
     String TOPIC_COUNT_EQUALLY_DIVIDE = "topic_count_equally_divide";
+    String SPECIFIED_POSITIONS_DIVIDE = "specified_positions_divide";
 
-    List<String> AVAILABLE_ALGORITHMS = Lists.newArrayList(RANGE_EQUALLY_DIVIDE_NAME, TOPIC_COUNT_EQUALLY_DIVIDE);
+    List<String> AVAILABLE_ALGORITHMS = Lists.newArrayList(RANGE_EQUALLY_DIVIDE_NAME,
+            TOPIC_COUNT_EQUALLY_DIVIDE, SPECIFIED_POSITIONS_DIVIDE);
 
     NamespaceBundleSplitAlgorithm RANGE_EQUALLY_DIVIDE_ALGO = new RangeEquallyDivideBundleSplitAlgorithm();
     NamespaceBundleSplitAlgorithm TOPIC_COUNT_EQUALLY_DIVIDE_ALGO = new TopicCountEquallyDivideBundleSplitAlgorithm();
+    NamespaceBundleSplitAlgorithm SPECIFIED_POSITIONS_DIVIDE_ALGO =
+            new SpecifiedPositionsBundleSplitAlgorithm();
 
     static NamespaceBundleSplitAlgorithm of(String algorithmName) {
         if (algorithmName == null) {
@@ -45,10 +48,12 @@ public interface NamespaceBundleSplitAlgorithm {
                 return RANGE_EQUALLY_DIVIDE_ALGO;
             case TOPIC_COUNT_EQUALLY_DIVIDE:
                 return TOPIC_COUNT_EQUALLY_DIVIDE_ALGO;
+            case SPECIFIED_POSITIONS_DIVIDE:
+                return SPECIFIED_POSITIONS_DIVIDE_ALGO;
             default:
                 return null;
         }
     }
 
-    CompletableFuture<Long> getSplitBoundary(NamespaceService service, NamespaceBundle bundle);
+    CompletableFuture<List<Long>> getSplitBoundary(BundleSplitOption bundleSplitOption);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/SpecifiedPositionsBundleSplitAlgorithm.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/SpecifiedPositionsBundleSplitAlgorithm.java
@@ -18,34 +18,40 @@
  */
 package org.apache.pulsar.common.naming;
 
-import java.util.ArrayList;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 
 /**
- * This algorithm divides the bundle into two parts with the same topics count.
+ * This algorithm divides the bundle into several parts by the specified positions.
  */
-public class TopicCountEquallyDivideBundleSplitAlgorithm implements NamespaceBundleSplitAlgorithm  {
-
+public class SpecifiedPositionsBundleSplitAlgorithm implements NamespaceBundleSplitAlgorithm{
     @Override
     public CompletableFuture<List<Long>> getSplitBoundary(BundleSplitOption bundleSplitOption) {
         NamespaceService service = bundleSplitOption.getService();
         NamespaceBundle bundle = bundleSplitOption.getBundle();
+        List<Long> positions = bundleSplitOption.getPositions();
+        if (positions == null || positions.size() == 0) {
+            throw new IllegalArgumentException("SplitBoundaries can't be empty");
+        }
+        // sort all positions
+        Collections.sort(positions);
         return service.getOwnedTopicListForNamespaceBundle(bundle).thenCompose(topics -> {
             if (topics == null || topics.size() <= 1) {
                 return CompletableFuture.completedFuture(null);
             }
-            List<Long> topicNameHashList = new ArrayList<>(topics.size());
-            for (String topic : topics) {
-                topicNameHashList.add(bundle.getNamespaceBundleFactory().getLongHashCode(topic));
+            List<Long> splitBoundaries = positions
+                    .stream()
+                    .filter(position -> position > bundle.getLowerEndpoint() && position < bundle.getUpperEndpoint())
+                    .collect(Collectors.toList());
+
+            if (splitBoundaries.size() == 0) {
+                return CompletableFuture.completedFuture(null);
             }
-            Collections.sort(topicNameHashList);
-            long splitStart = topicNameHashList.get(Math.max((topicNameHashList.size() / 2) - 1, 0));
-            long splitEnd = topicNameHashList.get(topicNameHashList.size() / 2);
-            long splitMiddle = splitStart + (splitEnd - splitStart) / 2;
-            return CompletableFuture.completedFuture(Collections.singletonList(splitMiddle));
+            return CompletableFuture.completedFuture(splitBoundaries);
         });
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiMultiBrokersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiMultiBrokersTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.admin;
 
+import static org.junit.Assert.assertFalse;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
@@ -26,6 +27,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.Sets;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.pulsar.broker.MultiBrokerBaseTest;
@@ -33,9 +37,16 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.loadbalance.LeaderBroker;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.admin.internal.TopicsImpl;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
+import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -54,6 +65,7 @@ public class AdminApiMultiBrokersTest extends MultiBrokerBaseTest {
     @Override
     protected void doInitConf() throws Exception {
         super.doInitConf();
+        this.conf.setManagedLedgerMaxEntriesPerLedger(10);
     }
 
     @Override
@@ -122,4 +134,80 @@ public class AdminApiMultiBrokersTest extends MultiBrokerBaseTest {
         Assert.assertEquals(lookupResultSet.size(), 1);
     }
 
+    @Test
+    public void testForceDeletePartitionedTopicWithSub() throws Exception {
+        final int numPartitions = 10;
+        TenantInfoImpl tenantInfo = new TenantInfoImpl(Sets.newHashSet("role1", "role2"), Sets.newHashSet("test"));
+        admin.tenants().createTenant("tenant-xyz", tenantInfo);
+        admin.namespaces().createNamespace("tenant-xyz/ns-abc", Sets.newHashSet("test"));
+
+        admin.namespaces().setAutoTopicCreation("tenant-xyz/ns-abc",
+                AutoTopicCreationOverride.builder()
+                        .allowAutoTopicCreation(true)
+                        .topicType("partitioned")
+                        .defaultNumPartitions(5)
+                        .build());
+
+        RetentionPolicies retention = new RetentionPolicies(10, 10);
+        admin.namespaces().setRetention("tenant-xyz/ns-abc", retention);
+        final String topic = "persistent://tenant-xyz/ns-abc/topic-"
+                + RandomStringUtils.randomAlphabetic(5)
+                + "-testDeletePartitionedTopicWithSub";
+        final String subscriptionName = "sub";
+        ((TopicsImpl) admin.topics()).createPartitionedTopicAsync(topic, numPartitions, true, null).get();
+
+        log.info("Creating producer and consumer");
+        Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                .topic(topic)
+                .subscriptionName(subscriptionName)
+                .subscribe();
+
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING).enableBatching(false).topic(topic).create();
+
+        log.info("producing messages");
+        for (int i = 0; i < numPartitions * 100; ++i) {
+            producer.newMessage()
+                    .key("" + i)
+                    .value("value-" + i)
+                    .send();
+        }
+        producer.flush();
+
+        log.info("consuming some messages");
+        for (int i = 0; i < numPartitions * 5; i++) {
+            Message<byte[]> m = consumer.receive(1, TimeUnit.MINUTES);
+        }
+
+        log.info("trying to delete the topic {}", topic);
+        admin.topics().deletePartitionedTopic(topic, true);
+
+        log.info("closing producer and consumer");
+        producer.close();
+        consumer.close();
+
+        // topic autocreate might sneak in after the delete / before close
+        // but the topic metadata should be consistent to go through deletion again
+        if (admin.topics().getList("tenant-xyz/ns-abc")
+                .stream().anyMatch(t -> t.contains(topic))) {
+            try {
+                admin.topics().deletePartitionedTopic(topic, true);
+            } catch (PulsarAdminException.NotFoundException nfe) {
+                // pass
+            }
+
+            assertEquals(0, admin.topics().getList("tenant-xyz/ns-abc")
+                    .stream().filter(t -> t.contains(topic)).count());
+            assertEquals(0,
+                    pulsar.getPulsarResources().getTopicResources()
+                            .getExistingPartitions(TopicName.getPartitionedTopicName(topic))
+                            .get()
+                            .stream().filter(t -> t.contains(topic)).count());
+            assertFalse(admin.topics()
+                    .getPartitionedTopicList("tenant-xyz/ns-abc")
+                    .contains(topic));
+        } else {
+            log.info("trying to create the topic again");
+            ((TopicsImpl) admin.topics()).createPartitionedTopicAsync(topic, numPartitions, true, null).get();
+        }
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -30,11 +30,13 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
+import com.google.common.base.Charsets;
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
+import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import java.lang.reflect.Field;
 import java.net.URL;
@@ -43,6 +45,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -112,6 +115,7 @@ import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
 import org.apache.pulsar.common.policies.data.BacklogQuota.RetentionPolicy;
 import org.apache.pulsar.common.policies.data.BrokerAssignment;
 import org.apache.pulsar.common.policies.data.BrokerInfo;
+import org.apache.pulsar.common.policies.data.BundlesData;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.ConsumerStats;
 import org.apache.pulsar.common.policies.data.NamespaceIsolationData;
@@ -127,6 +131,7 @@ import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.SubscriptionStats;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
+import org.apache.pulsar.common.policies.data.TopicHashPositions;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.util.Codec;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
@@ -1468,6 +1473,184 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
             assertNotEquals(bundles.getBundles().get(i).toString(), splitRange[i]);
         }
         producers.forEach(Producer::closeAsync);
+    }
+
+    @Test
+    public void testNamespacesGetTopicHashPositions() throws Exception {
+        // Force to create a namespace with only one bundle and create a topic
+        final String namespace = "prop-xyz/ns-one-bundle";
+        final String topic = "persistent://"+ namespace + "/topic";
+        final int topicPartitionNumber = 4;
+
+        Policies policies = new Policies();
+        policies.bundles  = PoliciesUtil.getBundles(1);
+        admin.namespaces().createNamespace(namespace, policies);
+        admin.topics().createPartitionedTopic(topic, topicPartitionNumber);
+        admin.lookups().lookupPartitionedTopic(topic);
+
+        // check bundles and bundle boundaries
+        BundlesData bundleData = admin.namespaces().getBundles(namespace);
+        assertEquals(bundleData.getNumBundles(), 1);
+        assertEquals(bundleData.getBoundaries().size(), 2);
+        assertEquals(bundleData.getBoundaries().get(0), "0x00000000");
+        assertEquals(bundleData.getBoundaries().get(1), "0xffffffff");
+
+        // test get topic position for partitioned-topic name
+        String bundleRange = "0x00000000_0xffffffff";
+        TopicHashPositions topicHashPositions =
+                admin.namespaces().getTopicHashPositions(namespace, bundleRange, Collections.singletonList(topic));
+        assertEquals(topicHashPositions.getNamespace(), "prop-xyz/ns-one-bundle");
+        assertEquals(topicHashPositions.getBundle(), "0x00000000_0xffffffff");
+        assertEquals(topicHashPositions.getTopicHashPositions().size(), topicPartitionNumber);
+
+        final HashFunction hashFunction = Hashing.crc32();
+        assertEquals((long) topicHashPositions.getTopicHashPositions().get(topic + "-partition-0"),
+                hashFunction.hashString(topic + "-partition-0", Charsets.UTF_8).padToLong());
+        assertEquals((long) topicHashPositions.getTopicHashPositions().get(topic + "-partition-1"),
+                hashFunction.hashString(topic + "-partition-1", Charsets.UTF_8).padToLong());
+        assertEquals((long) topicHashPositions.getTopicHashPositions().get(topic + "-partition-2"),
+                hashFunction.hashString(topic + "-partition-2", Charsets.UTF_8).padToLong());
+        assertEquals((long) topicHashPositions.getTopicHashPositions().get(topic + "-partition-3"),
+                hashFunction.hashString(topic + "-partition-3", Charsets.UTF_8).padToLong());
+
+        // test get hash position for topic partition
+        List<String> partitions = new ArrayList<>();
+        partitions.add(topic + "-partition-0");
+        partitions.add(topic + "-partition-1");
+        partitions.add(topic + "-partition-2");
+        partitions.add(topic + "-partition-3");
+        topicHashPositions = admin.namespaces().getTopicHashPositions(namespace, bundleRange, partitions);
+
+        assertEquals(topicHashPositions.getNamespace(), "prop-xyz/ns-one-bundle");
+        assertEquals(topicHashPositions.getBundle(), "0x00000000_0xffffffff");
+        assertEquals(topicHashPositions.getTopicHashPositions().size(), topicPartitionNumber);
+
+        assertEquals((long) topicHashPositions.getTopicHashPositions().get(topic + "-partition-0"),
+                hashFunction.hashString(topic + "-partition-0", Charsets.UTF_8).padToLong());
+        assertEquals((long) topicHashPositions.getTopicHashPositions().get(topic + "-partition-1"),
+                hashFunction.hashString(topic + "-partition-1", Charsets.UTF_8).padToLong());
+        assertEquals((long) topicHashPositions.getTopicHashPositions().get(topic + "-partition-2"),
+                hashFunction.hashString(topic + "-partition-2", Charsets.UTF_8).padToLong());
+        assertEquals((long) topicHashPositions.getTopicHashPositions().get(topic + "-partition-3"),
+                hashFunction.hashString(topic + "-partition-3", Charsets.UTF_8).padToLong());
+
+        // test non-exist topic
+        topicHashPositions = admin.namespaces().getTopicHashPositions(namespace,
+                bundleRange, Collections.singletonList(topic + "no-exist"));
+        assertEquals(topicHashPositions.getTopicHashPositions().size(), 0);
+
+        // test topics is null
+        topicHashPositions = admin.namespaces().getTopicHashPositions(namespace,
+                bundleRange, null);
+        assertEquals((long) topicHashPositions.getTopicHashPositions().get(topic + "-partition-0"),
+                hashFunction.hashString(topic + "-partition-0", Charsets.UTF_8).padToLong());
+        assertEquals((long) topicHashPositions.getTopicHashPositions().get(topic + "-partition-1"),
+                hashFunction.hashString(topic + "-partition-1", Charsets.UTF_8).padToLong());
+        assertEquals((long) topicHashPositions.getTopicHashPositions().get(topic + "-partition-2"),
+                hashFunction.hashString(topic + "-partition-2", Charsets.UTF_8).padToLong());
+        assertEquals((long) topicHashPositions.getTopicHashPositions().get(topic + "-partition-3"),
+                hashFunction.hashString(topic + "-partition-3", Charsets.UTF_8).padToLong());
+
+        // test topics is empty
+        topicHashPositions = admin.namespaces().getTopicHashPositions(namespace,
+                bundleRange, new ArrayList<>());
+        assertEquals((long) topicHashPositions.getTopicHashPositions().get(topic + "-partition-0"),
+                hashFunction.hashString(topic + "-partition-0", Charsets.UTF_8).padToLong());
+        assertEquals((long) topicHashPositions.getTopicHashPositions().get(topic + "-partition-1"),
+                hashFunction.hashString(topic + "-partition-1", Charsets.UTF_8).padToLong());
+        assertEquals((long) topicHashPositions.getTopicHashPositions().get(topic + "-partition-2"),
+                hashFunction.hashString(topic + "-partition-2", Charsets.UTF_8).padToLong());
+        assertEquals((long) topicHashPositions.getTopicHashPositions().get(topic + "-partition-3"),
+                hashFunction.hashString(topic + "-partition-3", Charsets.UTF_8).padToLong());
+    }
+
+
+    @Test
+    public void testNamespaceSplitBundleWithSpecifiedPositionsDivideAlgorithm() throws Exception {
+        // 1. Force to create a topic
+        final String namespace = "prop-xyz/ns-one-bundle";
+        final String topic = "persistent://"+ namespace + "/topic";
+        final int topicPartitionNumber = 4;
+
+        Policies policies = new Policies();
+        policies.bundles  = PoliciesUtil.getBundles(1);
+        admin.namespaces().createNamespace(namespace, policies);
+        admin.topics().createPartitionedTopic(topic, topicPartitionNumber);
+        // 2. trigger bundle loading
+        admin.lookups().lookupPartitionedTopic(topic);
+
+        // 3. check namespace bundle and topics exist
+        List<String> topics = admin.topics().getList(namespace);
+        assertTrue(topics.contains(topic + "-partition-0"));
+        assertTrue(topics.contains(topic + "-partition-1"));
+        assertTrue(topics.contains(topic + "-partition-2"));
+        assertTrue(topics.contains(topic + "-partition-3"));
+
+        // 4. check bundles and bundle boundaries
+        BundlesData bundleData = admin.namespaces().getBundles(namespace);
+        assertEquals(bundleData.getNumBundles(), 1);
+        assertEquals(bundleData.getBoundaries().size(), 2);
+        assertEquals(bundleData.getBoundaries().get(0), "0x00000000");
+        assertEquals(bundleData.getBoundaries().get(1), "0xffffffff");
+
+        // 5. calculate positions for split
+        final HashFunction hashFunction = Hashing.crc32();
+        List<Long> hashPositions = new ArrayList<>();
+        hashPositions.add(hashFunction.hashString(topic + "-partition-0", Charsets.UTF_8).padToLong());
+        hashPositions.add(hashFunction.hashString(topic + "-partition-1", Charsets.UTF_8).padToLong());
+        hashPositions.add(hashFunction.hashString(topic + "-partition-2", Charsets.UTF_8).padToLong());
+        hashPositions.add(hashFunction.hashString(topic + "-partition-3", Charsets.UTF_8).padToLong());
+
+        // 6. do split by SPECIFIED_POSITIONS_DIVIDE
+        admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", false,
+                NamespaceBundleSplitAlgorithm.SPECIFIED_POSITIONS_DIVIDE, hashPositions);
+
+        // 7. check split result
+        NamespaceBundles bundles = bundleFactory.getBundles(NamespaceName.get(namespace));
+        assertEquals(bundles.getBundles().size(), 5);
+
+        Collections.sort(hashPositions);
+        String[] splitRange = {
+                "0x00000000_" + String.format("0x%08x",hashPositions.get(0)),
+                String.format("0x%08x", hashPositions.get(0)) + "_" + String.format("0x%08x", hashPositions.get(1)),
+                String.format("0x%08x", hashPositions.get(1)) + "_" + String.format("0x%08x", hashPositions.get(2)),
+                String.format("0x%08x", hashPositions.get(2)) + "_" + String.format("0x%08x", hashPositions.get(3)),
+                String.format("0x%08x", hashPositions.get(3)) + "_0xffffffff"
+        };
+
+        Set<String> bundleRanges = new HashSet<>();
+        bundles.getBundles().forEach(bundle -> bundleRanges.add(bundle.getBundleRange()));
+        Lists.newArrayList(splitRange).forEach(bundleRanges::remove);
+        assertEquals(bundleRanges.size(), 0);
+
+        // 8. check split result from admin cli tool
+        BundlesData adminBundleData = admin.namespaces().getBundles(namespace);
+        assertEquals(adminBundleData.getNumBundles(), 5);
+        String[] boundaries = {
+                "0x00000000",
+                String.format("0x%08x", hashPositions.get(0)),
+                String.format("0x%08x", hashPositions.get(1)),
+                String.format("0x%08x", hashPositions.get(2)),
+                String.format("0x%08x", hashPositions.get(3)),
+                "0xffffffff"
+        };
+        Lists.newArrayList(boundaries).forEach(adminBundleData.getBoundaries()::remove);
+        assertEquals(adminBundleData.getBoundaries().size(), 0);
+
+        // 9. test split at full upper and lower boundaries
+        List<Long> fullBoundaries =
+                Lists.newArrayList(NamespaceBundles.FULL_UPPER_BOUND, NamespaceBundles.FULL_UPPER_BOUND);
+        admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_" + String.format("0x%08x",hashPositions.get(0)),
+                false, NamespaceBundleSplitAlgorithm.SPECIFIED_POSITIONS_DIVIDE, fullBoundaries);
+        admin.namespaces().splitNamespaceBundle(namespace, String.format("0x%08x", hashPositions.get(3)) + "_0xffffffff",
+                false, NamespaceBundleSplitAlgorithm.SPECIFIED_POSITIONS_DIVIDE, fullBoundaries);
+
+        // 10. full upper or lower boundaries does not split bundle
+        NamespaceBundles nbs = bundleFactory.getBundles(NamespaceName.get(namespace));
+        assertEquals(nbs.getBundles().size(), 5);
+        BundlesData adminBD = admin.namespaces().getBundles(namespace);
+        assertEquals(adminBD.getNumBundles(), 5);
+        assertEquals(adminBD.getBoundaries().size(), 6);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -896,7 +896,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         try {
             AsyncResponse response = mock(AsyncResponse.class);
             namespaces.splitNamespaceBundle(response, testTenant, testLocalCluster, bundledNsLocal, "0x00000000_0xffffffff",
-                    false, true);
+                    false, true, null);
             ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
             verify(response, timeout(5000).times(1)).resume(captor.capture());
             // verify split bundles
@@ -933,7 +933,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         // split bundles
         AsyncResponse response = mock(AsyncResponse.class);
         namespaces.splitNamespaceBundle(response, testTenant, testLocalCluster, bundledNsLocal,
-                "0x08375b1a_0x08375b1b", false, false);
+                "0x08375b1a_0x08375b1b", false, false, null);
         ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
         verify(response, timeout(5000).times(1)).resume(any(RestException.class));
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -1258,6 +1258,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         pulsarClient.updateServiceUrl(lookupUrl.toString());
         Awaitility.await().untilAsserted(() -> assertTrue(consumer.isConnected()));
         pulsar.getConfiguration().setAuthorizationEnabled(true);
+        consumer.close();
         admin.topics().deletePartitionedTopic(topicName, true);
         admin.namespaces().deleteNamespace(namespace);
         admin.tenants().deleteTenant("my-tenants");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -241,7 +241,7 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
 
         // 9) Delete the partitioned topic
         response = mock(AsyncResponse.class);
-        persistentTopics.deletePartitionedTopic(response, testTenant, testNamespace, testLocalTopicName, true, true, false);
+        persistentTopics.deletePartitionedTopic(response, testTenant, testNamespace, testLocalTopicName, true, true);
         responseCaptor = ArgumentCaptor.forClass(Response.class);
         verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
@@ -579,7 +579,7 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
 
         // 4) delete partitioned topic
         response = mock(AsyncResponse.class);
-        persistentTopics.deletePartitionedTopic(response, testTenant, testNamespace, partitionTopicName, true, true, false);
+        persistentTopics.deletePartitionedTopic(response, testTenant, testNamespace, partitionTopicName, true, true);
         responseCaptor = ArgumentCaptor.forClass(Response.class);
         verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
@@ -1004,7 +1004,7 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
 
         // 10) Delete the partitioned topic
         response = mock(AsyncResponse.class);
-        persistentTopics.deletePartitionedTopic(response, testTenant, testNamespace, topicName, true, true, false);
+        persistentTopics.deletePartitionedTopic(response, testTenant, testNamespace, topicName, true, true);
         responseCaptor = ArgumentCaptor.forClass(Response.class);
         verify(response, timeout(10000).times(1)).resume(responseCaptor.capture());
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
@@ -1195,23 +1195,23 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         persistentTopics.createNonPartitionedTopic(testTenant, testNamespace, topicName, false, null);
         CompletableFuture<Void> deleteTopicFuture = new CompletableFuture<>();
         deleteTopicFuture.completeExceptionally(new MetadataStoreException.NotFoundException());
-        doReturn(deleteTopicFuture).when(brokerService).deleteTopic(anyString(), anyBoolean(), anyBoolean());
-        persistentTopics.deleteTopic(testTenant, testNamespace, topicName, true, true, true);
+        doReturn(deleteTopicFuture).when(brokerService).deleteTopic(anyString(), anyBoolean());
+        persistentTopics.deleteTopic(testTenant, testNamespace, topicName, true, true);
         //
         CompletableFuture<Void> deleteTopicFuture2 = new CompletableFuture<>();
         deleteTopicFuture2.completeExceptionally(new MetadataStoreException("test exception"));
-        doReturn(deleteTopicFuture2).when(brokerService).deleteTopic(anyString(), anyBoolean(), anyBoolean());
+        doReturn(deleteTopicFuture2).when(brokerService).deleteTopic(anyString(), anyBoolean());
         try {
-            persistentTopics.deleteTopic(testTenant, testNamespace, topicName, true, true, true);
+            persistentTopics.deleteTopic(testTenant, testNamespace, topicName, true, true);
         } catch (Exception e) {
             Assert.assertTrue(e instanceof RestException);
         }
         //
         CompletableFuture<Void> deleteTopicFuture3 = new CompletableFuture<>();
         deleteTopicFuture3.completeExceptionally(new MetadataStoreException.NotFoundException());
-        doReturn(deleteTopicFuture3).when(brokerService).deleteTopic(anyString(), anyBoolean(), anyBoolean());
+        doReturn(deleteTopicFuture3).when(brokerService).deleteTopic(anyString(), anyBoolean());
         try {
-            persistentTopics.deleteTopic(testTenant, testNamespace, topicName, false, true, true);
+            persistentTopics.deleteTopic(testTenant, testNamespace, topicName, false, true);
         } catch (RestException e) {
             Assert.assertEquals(e.getResponse().getStatus(), 404);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
@@ -104,6 +104,8 @@ public class HttpTopicLookupv2Test {
         doReturn(brokerService).when(pulsar).getBrokerService();
         doReturn(auth).when(brokerService).getAuthorizationService();
         doReturn(new Semaphore(1000)).when(brokerService).getLookupRequestSemaphore();
+        doReturn(CompletableFuture.completedFuture(false)).when(brokerService)
+                .isAllowAutoTopicCreationAsync(any(TopicName.class));
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/v2/TopicLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/v2/TopicLookupTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.broker.lookup.http.v2;
 
-import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.core.Response;
 import org.apache.pulsar.broker.lookup.v2.TopicLookup;
 import org.apache.pulsar.broker.web.PulsarWebResourceTest;
@@ -26,7 +25,7 @@ import org.apache.pulsar.common.lookup.data.LookupData;
 import org.apache.pulsar.common.naming.TopicName;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.testng.annotations.Test;
-
+import java.util.concurrent.CompletableFuture;
 import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertEquals;
 
@@ -70,10 +69,10 @@ public class TopicLookupTest extends PulsarWebResourceTest {
         private String actualListenerName;
 
         @Override
-        protected void internalLookupTopicAsync(TopicName topicName, boolean authoritative, AsyncResponse asyncResponse,
-                String listenerName) {
+        protected CompletableFuture<LookupData> internalLookupTopicAsync(TopicName topicName, boolean authoritative,
+                                                                         String listenerName) {
             this.actualListenerName = listenerName;
-            asyncResponse.resume(new LookupData());
+            return CompletableFuture.completedFuture(new LookupData());
         }
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
@@ -120,7 +120,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
         CompletableFuture<Void> result = namespaceService.splitAndOwnBundle(
                 originalBundle,
                 false,
-                NamespaceBundleSplitAlgorithm.RANGE_EQUALLY_DIVIDE_ALGO);
+                NamespaceBundleSplitAlgorithm.RANGE_EQUALLY_DIVIDE_ALGO, null);
 
         try {
             result.get();
@@ -201,7 +201,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
         CompletableFuture<Void> result = namespaceService.splitAndOwnBundle(
                 originalBundle,
                 false,
-                NamespaceBundleSplitAlgorithm.RANGE_EQUALLY_DIVIDE_ALGO);
+                NamespaceBundleSplitAlgorithm.RANGE_EQUALLY_DIVIDE_ALGO, null);
         try {
             result.get();
         } catch (Exception e) {
@@ -407,7 +407,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
         NamespaceBundle originalBundle = bundles.findBundle(topicName);
 
         // Split bundle and take ownership of split bundles
-        CompletableFuture<Void> result = namespaceService.splitAndOwnBundle(originalBundle, false, NamespaceBundleSplitAlgorithm.RANGE_EQUALLY_DIVIDE_ALGO);
+        CompletableFuture<Void> result = namespaceService.splitAndOwnBundle(originalBundle, false, NamespaceBundleSplitAlgorithm.RANGE_EQUALLY_DIVIDE_ALGO, null);
 
         try {
             result.get();
@@ -469,7 +469,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
         NamespaceBundles bundles = namespaceService.getNamespaceBundleFactory().getBundles(nsname);
         NamespaceBundle originalBundle = bundles.findBundle(topicName);
 
-        CompletableFuture<Void> result1 = namespaceService.splitAndOwnBundle(originalBundle, false, NamespaceBundleSplitAlgorithm.RANGE_EQUALLY_DIVIDE_ALGO);
+        CompletableFuture<Void> result1 = namespaceService.splitAndOwnBundle(originalBundle, false, NamespaceBundleSplitAlgorithm.RANGE_EQUALLY_DIVIDE_ALGO, null);
         try {
             result1.get();
         } catch (Exception e) {
@@ -488,7 +488,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
             }
         });
 
-        CompletableFuture<Void> result2 = namespaceService.splitAndOwnBundle(splittedBundle, true, NamespaceBundleSplitAlgorithm.RANGE_EQUALLY_DIVIDE_ALGO);
+        CompletableFuture<Void> result2 = namespaceService.splitAndOwnBundle(splittedBundle, true, NamespaceBundleSplitAlgorithm.RANGE_EQUALLY_DIVIDE_ALGO, null);
         try {
             result2.get();
         } catch (Exception e) {
@@ -514,7 +514,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
 
         NamespaceBundle splitBundle1 = bundles.findBundle(topicName);
         ownershipCache.tryAcquiringOwnership(splitBundle1);
-        CompletableFuture<Void> result1 = namespaceService.splitAndOwnBundle(splitBundle1, false, NamespaceBundleSplitAlgorithm.RANGE_EQUALLY_DIVIDE_ALGO);
+        CompletableFuture<Void> result1 = namespaceService.splitAndOwnBundle(splitBundle1, false, NamespaceBundleSplitAlgorithm.RANGE_EQUALLY_DIVIDE_ALGO, null);
         try {
             result1.get();
         } catch (Exception e) {
@@ -527,7 +527,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
         bundles = namespaceService.getNamespaceBundleFactory().getBundles(nsname);
         assertNotNull(bundles);
         NamespaceBundle splitBundle2 = bundles.findBundle(topicName);
-        CompletableFuture<Void> result2 = namespaceService.splitAndOwnBundle(splitBundle2, true, NamespaceBundleSplitAlgorithm.RANGE_EQUALLY_DIVIDE_ALGO);
+        CompletableFuture<Void> result2 = namespaceService.splitAndOwnBundle(splitBundle2, true, NamespaceBundleSplitAlgorithm.RANGE_EQUALLY_DIVIDE_ALGO, null);
         try {
             result2.get();
         } catch (Exception e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -438,6 +438,7 @@ public class BacklogQuotaManagerTest {
                         .retentionPolicy(BacklogQuota.RetentionPolicy.consumer_backlog_eviction)
                         .build(), BacklogQuota.BacklogQuotaType.message_age);
         config.setPreciseTimeBasedBacklogQuotaCheck(true);
+        @Cleanup
         PulsarClient client = PulsarClient.builder().serviceUrl(adminUrl.toString()).statsInterval(0, TimeUnit.SECONDS)
                 .build();
 
@@ -467,7 +468,6 @@ public class BacklogQuotaManagerTest {
         // All messages for both subscription should be cleaned up from backlog by backlog monitor task.
         assertEquals(stats.getSubscriptions().get(subName1).getMsgBacklog(), 0);
         assertEquals(stats.getSubscriptions().get(subName2).getMsgBacklog(), 0);
-        client.close();
     }
 
     @Test
@@ -479,6 +479,7 @@ public class BacklogQuotaManagerTest {
                         .limitTime(TIME_TO_CHECK_BACKLOG_QUOTA)
                         .retentionPolicy(BacklogQuota.RetentionPolicy.consumer_backlog_eviction)
                         .build(), BacklogQuota.BacklogQuotaType.message_age);
+        @Cleanup
         PulsarClient client = PulsarClient.builder().serviceUrl(adminUrl.toString()).statsInterval(0, TimeUnit.SECONDS)
                 .build();
 
@@ -511,7 +512,6 @@ public class BacklogQuotaManagerTest {
         // message in current ledger.
         assertEquals(stats.getSubscriptions().get(subName1).getMsgBacklog(), ml.getCurrentLedgerEntries());
         assertEquals(stats.getSubscriptions().get(subName2).getMsgBacklog(), ml.getCurrentLedgerEntries());
-        client.close();
     }
 
     @Test
@@ -524,6 +524,7 @@ public class BacklogQuotaManagerTest {
                         .retentionPolicy(BacklogQuota.RetentionPolicy.consumer_backlog_eviction)
                         .build(), BacklogQuota.BacklogQuotaType.message_age);
         config.setPreciseTimeBasedBacklogQuotaCheck(true);
+        @Cleanup
         PulsarClient client = PulsarClient.builder().serviceUrl(adminUrl.toString()).statsInterval(0, TimeUnit.SECONDS)
                 .build();
 
@@ -560,8 +561,6 @@ public class BacklogQuotaManagerTest {
                     TopicStats latestStats = getTopicStats(topic);
                     assertEquals(latestStats.getSubscriptions().get(subName).getMsgBacklog(), 0);
                 });
-
-        client.close();
     }
 
     @Test
@@ -574,6 +573,7 @@ public class BacklogQuotaManagerTest {
                         .limitTime(TIME_TO_CHECK_BACKLOG_QUOTA)
                         .retentionPolicy(BacklogQuota.RetentionPolicy.consumer_backlog_eviction)
                         .build());
+        @Cleanup
         PulsarClient client = PulsarClient.builder().serviceUrl(adminUrl.toString()).build();
 
         final String topic1 = "persistent://prop/ns-quota/topic11";
@@ -609,6 +609,7 @@ public class BacklogQuotaManagerTest {
                         .retentionPolicy(BacklogQuota.RetentionPolicy.consumer_backlog_eviction)
                         .build(), BacklogQuota.BacklogQuotaType.message_age);
         config.setPreciseTimeBasedBacklogQuotaCheck(true);
+        @Cleanup
         PulsarClient client = PulsarClient.builder().serviceUrl(adminUrl.toString()).build();
 
         final String topic1 = "persistent://prop/ns-quota/topic12";
@@ -650,7 +651,6 @@ public class BacklogQuotaManagerTest {
         stats = getTopicStats(topic1);
         // sub2 has empty backlog because it's backlog get cleaned up by backlog quota monitor task
         assertEquals(stats.getSubscriptions().get(subName2).getMsgBacklog(), 0);
-        client.close();
     }
 
     private Producer<byte[]> createProducer(PulsarClient client, String topic)
@@ -1179,6 +1179,7 @@ public class BacklogQuotaManagerTest {
                         .retentionPolicy(BacklogQuota.RetentionPolicy.producer_exception)
                         .build(), BacklogQuota.BacklogQuotaType.message_age);
         config.setPreciseTimeBasedBacklogQuotaCheck(true);
+        @Cleanup
         final PulsarClient client = PulsarClient.builder().serviceUrl(adminUrl.toString())
                 .statsInterval(0, TimeUnit.SECONDS).build();
         final String topic1 = "persistent://prop/quotahold/exceptandunblock2";
@@ -1232,7 +1233,6 @@ public class BacklogQuotaManagerTest {
             sendException = e;
         }
         assertFalse(gotException, "unable to publish due to " + sendException);
-        client.close();
     }
 
     @Test
@@ -1244,6 +1244,7 @@ public class BacklogQuotaManagerTest {
                         .limitTime(TIME_TO_CHECK_BACKLOG_QUOTA)
                         .retentionPolicy(BacklogQuota.RetentionPolicy.producer_exception)
                         .build(), BacklogQuota.BacklogQuotaType.message_age);
+        @Cleanup
         final PulsarClient client = PulsarClient.builder().serviceUrl(adminUrl.toString())
                 .statsInterval(0, TimeUnit.SECONDS).build();
         final String topic1 = "persistent://prop/quotahold/exceptandunblock2";
@@ -1297,12 +1298,12 @@ public class BacklogQuotaManagerTest {
             sendException = e;
         }
         assertFalse(gotException, "unable to publish due to " + sendException);
-        client.close();
     }
 
     @Test(dataProvider = "backlogQuotaSizeGB", priority = 1)
     public void testBacklogQuotaInGB(boolean backlogQuotaSizeGB) throws Exception {
 
+        admin.close();
         pulsar.close();
         long backlogQuotaByte = 10 * 1024;
         if (backlogQuotaSizeGB) {
@@ -1313,6 +1314,7 @@ public class BacklogQuotaManagerTest {
         config.setBacklogQuotaDefaultRetentionPolicy(BacklogQuota.RetentionPolicy.consumer_backlog_eviction);
         pulsar = new PulsarService(config);
         pulsar.start();
+        admin = PulsarAdmin.builder().serviceHttpUrl(adminUrl.toString()).build();
 
         @Cleanup
         PulsarClient client = PulsarClient.builder().serviceUrl(pulsar.getBrokerServiceUrl()).statsInterval(0, TimeUnit.SECONDS)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ExclusiveProducerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ExclusiveProducerTest.java
@@ -24,10 +24,8 @@ import static org.testng.Assert.fail;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-
 import io.netty.util.HashedWheelTimer;
 import lombok.Cleanup;
-
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerAccessMode;
 import org.apache.pulsar.client.api.PulsarClient;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -142,6 +142,7 @@ import org.apache.pulsar.compaction.Compactor;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.zookeeper.ZooKeeper;
+import org.awaitility.Awaitility;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -1295,7 +1296,9 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
                 role, false, null, SchemaVersion.Latest, 0, false, ProducerAccessMode.Shared, Optional.empty(), true);
         topic.addProducer(producer, new CompletableFuture<>()).join();
 
-        assertTrue(topic.delete().isCompletedExceptionally());
+        CompletableFuture<Void> cf = topic.delete();
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).until(() -> cf.isDone());
+        assertTrue(cf.isCompletedExceptionally());
         assertFalse((boolean) isFencedField.get(topic));
         assertFalse((boolean) isClosingOrDeletingField.get(topic));
         topic.removeProducer(producer);
@@ -1312,7 +1315,9 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         Future<Consumer> f1 = topic.subscribe(getSubscriptionOption(cmd));
         f1.get();
 
-        assertTrue(topic.delete().isCompletedExceptionally());
+        CompletableFuture<Void> cf2 = topic.delete();
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).until(() -> cf2.isDone());
+        assertTrue(cf2.isCompletedExceptionally());
         assertFalse((boolean) isFencedField.get(topic));
         assertFalse((boolean) isClosingOrDeletingField.get(topic));
         topic.unsubscribe(successSubName);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -110,6 +110,8 @@ import org.apache.pulsar.broker.service.persistent.PersistentDispatcherSingleAct
 import org.apache.pulsar.broker.service.persistent.PersistentReplicator;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.broker.service.schema.DefaultSchemaRegistryService;
+import org.apache.pulsar.broker.service.schema.SchemaRegistryService;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
@@ -155,6 +157,7 @@ import org.testng.annotations.Test;
 public class PersistentTopicTest extends MockedBookKeeperTestCase {
     protected PulsarService pulsar;
     private BrokerService brokerService;
+    private SchemaRegistryService schemaRegistryService;
     private ManagedLedgerFactory mlFactoryMock;
     private ServerCnx serverCnx;
     private MetadataStore store;
@@ -183,6 +186,10 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         pulsar = spyWithClassAndConstructorArgs(PulsarService.class, svcConfig);
         doReturn(svcConfig).when(pulsar).getConfiguration();
         doReturn(mock(Compactor.class)).when(pulsar).getCompactor();
+
+        // create SchemaRegistryService for testDeleteTopic() otherwise it will fail
+        schemaRegistryService = spyWithClassAndConstructorArgs(DefaultSchemaRegistryService.class);
+        doReturn(schemaRegistryService).when(pulsar).getSchemaRegistryService();
 
         mlFactoryMock = mock(ManagedLedgerFactory.class);
         doReturn(mlFactoryMock).when(pulsar).getManagedLedgerFactory();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -531,7 +531,7 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
      *
      * @throws Exception
      */
-    @Test(timeOut = 5000)
+    @Test(timeOut = 20000)
     public void testSplitUnloadLookupTest() throws Exception {
 
         log.info("-- Starting {} test --", methodName);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -1172,34 +1172,6 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
     }
 
     @Test(timeOut = testTimeout)
-    public void testAutoDiscoverMultiTopicsPartitions() throws Exception {
-        final String topicName = "persistent://public/default/issue-9585";
-        admin.topics().createPartitionedTopic(topicName, 3);
-        PatternMultiTopicsConsumerImpl<String> consumer = (PatternMultiTopicsConsumerImpl<String>) pulsarClient.newConsumer(Schema.STRING)
-                .topicsPattern(topicName)
-                .subscriptionName("sub-issue-9585")
-                .subscribe();
-
-        Assert.assertEquals(consumer.getPartitionsOfTheTopicMap(), 3);
-        Assert.assertEquals(consumer.getConsumers().size(), 3);
-
-        admin.topics().deletePartitionedTopic(topicName, true);
-        consumer.getPartitionsAutoUpdateTimeout().task().run(consumer.getPartitionsAutoUpdateTimeout());
-        Awaitility.await().untilAsserted(() -> {
-            Assert.assertEquals(consumer.getPartitionsOfTheTopicMap(), 0);
-            Assert.assertEquals(consumer.getConsumers().size(), 0);
-        });
-
-        admin.topics().createPartitionedTopic(topicName, 7);
-        consumer.getPartitionsAutoUpdateTimeout().task().run(consumer.getPartitionsAutoUpdateTimeout());
-        Awaitility.await().untilAsserted(() -> {
-            Assert.assertEquals(consumer.getPartitionsOfTheTopicMap(), 7);
-            Assert.assertEquals(consumer.getConsumers().size(), 7);
-        });
-    }
-
-
-    @Test(timeOut = testTimeout)
     public void testPartitionsUpdatesForMultipleTopics() throws Exception {
         final String topicName0 = "persistent://public/default/testPartitionsUpdatesForMultipleTopics-0";
         final String subName = "my-sub";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/NamespaceBundleSplitAlgorithmTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/NamespaceBundleSplitAlgorithmTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.common.naming;
 
 
 import static org.apache.pulsar.common.naming.NamespaceBundleSplitAlgorithm.RANGE_EQUALLY_DIVIDE_NAME;
+import static org.apache.pulsar.common.naming.NamespaceBundleSplitAlgorithm.SPECIFIED_POSITIONS_DIVIDE;
 import static org.apache.pulsar.common.naming.NamespaceBundleSplitAlgorithm.TOPIC_COUNT_EQUALLY_DIVIDE;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -37,5 +38,7 @@ public class NamespaceBundleSplitAlgorithmTest {
         Assert.assertTrue(rangeEquallyDivideName instanceof RangeEquallyDivideBundleSplitAlgorithm);
         NamespaceBundleSplitAlgorithm topicCountEquallyDivide = NamespaceBundleSplitAlgorithm.of(TOPIC_COUNT_EQUALLY_DIVIDE);
         Assert.assertTrue(topicCountEquallyDivide instanceof TopicCountEquallyDivideBundleSplitAlgorithm);
+        NamespaceBundleSplitAlgorithm specifiedTopicCountEquallyDivide = NamespaceBundleSplitAlgorithm.of(SPECIFIED_POSITIONS_DIVIDE);
+        Assert.assertTrue(specifiedTopicCountEquallyDivide instanceof SpecifiedPositionsBundleSplitAlgorithm);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/NamespaceBundlesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/NamespaceBundlesTest.java
@@ -32,6 +32,7 @@ import com.google.common.collect.Sets;
 import com.google.common.hash.Hashing;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -239,19 +240,20 @@ public class NamespaceBundlesTest {
         NamespaceBundle bundleToSplit = bundles.getBundles().get(0);
 
         try {
-            factory.splitBundles(bundleToSplit, 0, bundleToSplit.getLowerEndpoint());
+            factory.splitBundles(bundleToSplit, 0,
+                    Collections.singletonList(bundleToSplit.getLowerEndpoint()));
         } catch (IllegalArgumentException e) {
             //No-op
         }
         try {
-            factory.splitBundles(bundleToSplit, 0, bundleToSplit.getUpperEndpoint());
+            factory.splitBundles(bundleToSplit, 0, Collections.singletonList(bundleToSplit.getUpperEndpoint()));
         } catch (IllegalArgumentException e) {
             //No-op
         }
 
         Long fixBoundary = bundleToSplit.getLowerEndpoint() + 10;
         Pair<NamespaceBundles, List<NamespaceBundle>> splitBundles = factory.splitBundles(bundleToSplit,
-                0, fixBoundary).join();
+                0, Collections.singletonList(fixBoundary)).join();
         assertEquals(splitBundles.getRight().get(0).getLowerEndpoint(), bundleToSplit.getLowerEndpoint());
         assertEquals(splitBundles.getRight().get(1).getLowerEndpoint().longValue(), bundleToSplit.getLowerEndpoint() + fixBoundary);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/RangeEquallyDivideBundleSplitAlgorithmTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/RangeEquallyDivideBundleSplitAlgorithmTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.common.naming;
 
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Range;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -30,14 +31,14 @@ public class RangeEquallyDivideBundleSplitAlgorithmTest {
     @Test
     public void testGetSplitBoundaryMethodReturnCorrectResult() {
         RangeEquallyDivideBundleSplitAlgorithm rangeEquallyDivideBundleSplitAlgorithm = new RangeEquallyDivideBundleSplitAlgorithm();
-        Assert.assertThrows(NullPointerException.class, () -> rangeEquallyDivideBundleSplitAlgorithm.getSplitBoundary(null, null));
+        Assert.assertThrows(NullPointerException.class, () -> rangeEquallyDivideBundleSplitAlgorithm.getSplitBoundary(new BundleSplitOption()));
         long lowerRange = 10L;
         long upperRange = 0xffffffffL;
         long correctResult = lowerRange + (upperRange - lowerRange) / 2;
         NamespaceBundle namespaceBundle = new NamespaceBundle(NamespaceName.SYSTEM_NAMESPACE, Range.range(lowerRange, BoundType.CLOSED, upperRange, BoundType.CLOSED),
                 Mockito.mock(NamespaceBundleFactory.class));
-        CompletableFuture<Long> splitBoundary = rangeEquallyDivideBundleSplitAlgorithm.getSplitBoundary(null, namespaceBundle);
-        Long value = splitBoundary.join();
-        Assert.assertEquals((long) value, correctResult);
+        CompletableFuture<List<Long>> splitBoundary = rangeEquallyDivideBundleSplitAlgorithm.getSplitBoundary(new BundleSplitOption(null, namespaceBundle, null));
+        List<Long> value = splitBoundary.join();
+        Assert.assertEquals((long)value.get(0), correctResult);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/SpecifiedPositionsBundleSplitAlgorithmTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/SpecifiedPositionsBundleSplitAlgorithmTest.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.naming;
+
+import com.google.common.collect.Lists;
+import java.util.Arrays;
+import org.apache.pulsar.broker.namespace.NamespaceService;
+import org.testng.annotations.Test;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class SpecifiedPositionsBundleSplitAlgorithmTest {
+
+    @Test
+    public void testTotalTopicsSizeLessThan1() {
+        SpecifiedPositionsBundleSplitAlgorithm algorithm = new SpecifiedPositionsBundleSplitAlgorithm();
+        NamespaceService mockNamespaceService = mock(NamespaceService.class);
+        NamespaceBundle mockNamespaceBundle = mock(NamespaceBundle.class);
+        doReturn(CompletableFuture.completedFuture(Lists.newArrayList("a")))
+                .when(mockNamespaceService).getOwnedTopicListForNamespaceBundle(mockNamespaceBundle);
+        assertNull(algorithm.getSplitBoundary(new BundleSplitOption(mockNamespaceService, mockNamespaceBundle,
+                Arrays.asList(1L, 2L))).join());
+    }
+
+    @Test
+    public void testSpecifiedPositionsLessThan1() {
+        SpecifiedPositionsBundleSplitAlgorithm algorithm = new SpecifiedPositionsBundleSplitAlgorithm();
+        NamespaceService mockNamespaceService = mock(NamespaceService.class);
+        NamespaceBundle mockNamespaceBundle = mock(NamespaceBundle.class);
+        try {
+            assertNull(algorithm.getSplitBoundary(
+                    new BundleSplitOption(mockNamespaceService, mockNamespaceBundle, null)).join());
+            fail("Should fail since split boundaries is null");
+        } catch (IllegalArgumentException e) {
+            // ignore
+        }
+
+        try {
+            assertNull(algorithm.getSplitBoundary(
+                    new BundleSplitOption(mockNamespaceService, mockNamespaceBundle, new ArrayList<>())).join());
+            fail("Should fail since split boundaries is empty");
+        } catch (IllegalArgumentException e) {
+            // ignore
+        }
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    @Test
+    public void testAlgorithmReturnCorrectResult() {
+        // -- algorithm
+        SpecifiedPositionsBundleSplitAlgorithm algorithm = new SpecifiedPositionsBundleSplitAlgorithm();
+        // -- calculate the mock result
+        NamespaceService mockNamespaceService = mock(NamespaceService.class);
+        NamespaceBundle mockNamespaceBundle = mock(NamespaceBundle.class);
+        doReturn(1L).when(mockNamespaceBundle).getLowerEndpoint();
+        doReturn(1000L).when(mockNamespaceBundle).getUpperEndpoint();
+        doReturn(CompletableFuture.completedFuture(Lists.newArrayList("topic", "topic2")))
+                .when(mockNamespaceService)
+                .getOwnedTopicListForNamespaceBundle(mockNamespaceBundle);
+
+        List<Long> positions = Arrays.asList(-1L, 0L, 1L, 100L, 200L, 500L, 800L, 1000L, 1100L);
+        List<Long> splitPositions = algorithm.getSplitBoundary(
+                new BundleSplitOption(mockNamespaceService, mockNamespaceBundle, positions)).join();
+
+        assertEquals(splitPositions.size(), 4);
+        assertTrue(splitPositions.contains(100L));
+        assertTrue(splitPositions.contains(200L));
+        assertTrue(splitPositions.contains(500L));
+        assertTrue(splitPositions.contains(800L));
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/TopicCountEquallyDivideBundleSplitAlgorithmTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/TopicCountEquallyDivideBundleSplitAlgorithmTest.java
@@ -40,7 +40,7 @@ public class TopicCountEquallyDivideBundleSplitAlgorithmTest {
     @Test
     public void testWrongArg() {
         TopicCountEquallyDivideBundleSplitAlgorithm algorithm = new TopicCountEquallyDivideBundleSplitAlgorithm();
-        assertThrows(NullPointerException.class, () -> algorithm.getSplitBoundary(null, null));
+        assertThrows(NullPointerException.class, () -> algorithm.getSplitBoundary(new BundleSplitOption()));
     }
 
     @Test
@@ -50,7 +50,7 @@ public class TopicCountEquallyDivideBundleSplitAlgorithmTest {
         NamespaceBundle mockNamespaceBundle = mock(NamespaceBundle.class);
         doReturn(CompletableFuture.completedFuture(Lists.newArrayList("a")))
                 .when(mockNamespaceService).getOwnedTopicListForNamespaceBundle(mockNamespaceBundle);
-        assertNull(algorithm.getSplitBoundary(mockNamespaceService, mockNamespaceBundle).join());
+        assertNull(algorithm.getSplitBoundary(new BundleSplitOption(mockNamespaceService, mockNamespaceBundle, null)).join());
     }
 
     @SuppressWarnings("UnstableApiUsage")
@@ -91,7 +91,7 @@ public class TopicCountEquallyDivideBundleSplitAlgorithmTest {
             doReturn(hashValue)
                     .when(mockNamespaceBundleFactory).getLongHashCode(topic);
         });
-        assertEquals((long) algorithm.getSplitBoundary(mockNamespaceService, mockNamespaceBundle).join(),
+        assertEquals((long) algorithm.getSplitBoundary(new BundleSplitOption(mockNamespaceService, mockNamespaceBundle, null)).join().get(0),
                 splitMiddleForMockResult);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -781,7 +781,7 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         final String topicOne = "not-partitioned-topic";
         final String topic2 = "persistent://" + tenant + "/" + cluster + "/" + namespace + "/partitioned-topic";
 
-        // persistent, not-partitioned v1/topic
+        // persistent, non-partitioned v1/topic
         final String topic1 = TopicName.get(
                 TopicDomain.persistent.value(),
                 tenant,
@@ -836,9 +836,9 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
             assertNotNull(schema);
         }
 
-        // not-force and not-delete-schema when delete topic
+        // not-force delete topic
         try {
-            admin.topics().delete(topic1, false, false);
+            admin.topics().delete(topic1, false);
             fail();
         } catch (Exception e) {
             assertTrue(e.getMessage().startsWith("Topic has active producers/subscriptions"));
@@ -846,7 +846,7 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         assertEquals(this.getPulsar().getSchemaRegistryService()
                 .trimDeletedSchemaAndGetList(TopicName.get(topic1).getSchemaName()).get().size(), 2);
         try {
-            admin.topics().deletePartitionedTopic(topic2, false, false);
+            admin.topics().deletePartitionedTopic(topic2, false);
             fail();
         } catch (Exception e) {
             assertTrue(e.getMessage().startsWith("Topic has active producers/subscriptions"));
@@ -855,12 +855,100 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
                 .trimDeletedSchemaAndGetList(TopicName.get(topic2).getSchemaName()).get().size(), 1);
 
         // force and delete-schema when delete topic
-        admin.topics().delete(topic1, true, true);
+        admin.topics().delete(topic1, true);
         assertEquals(this.getPulsar().getSchemaRegistryService()
                 .trimDeletedSchemaAndGetList(TopicName.get(topic1).getSchemaName()).get().size(), 0);
-        admin.topics().deletePartitionedTopic(topic2, true, true);
+        admin.topics().deletePartitionedTopic(topic2, true);
         assertEquals(this.getPulsar().getSchemaRegistryService()
                 .trimDeletedSchemaAndGetList(TopicName.get(topic2).getSchemaName()).get().size(), 0);
+    }
+
+    @Test
+    public void testDeleteTopicAndSchemaForV2() throws Exception {
+        final String tenant = PUBLIC_TENANT;
+        final String namespace = "test-namespace-" + randomName(16);
+        final String topicOne = "persistent://" + tenant + "/" + namespace + "/non-partitioned-topic";
+        final String topicTwo = "persistent://" + tenant + "/" + namespace + "/partitioned-topic";
+
+        admin.namespaces().createNamespace(
+                tenant + "/" + namespace,
+                Sets.newHashSet(CLUSTER_NAME));
+        // persistent, non-partitioned v2/topic
+        admin.topics().createNonPartitionedTopic(topicOne);
+        // persistent, partitioned v2/topic
+        admin.topics().createPartitionedTopic(topicTwo, 1);
+
+        @Cleanup
+        Producer<Schemas.PersonOne> p1_1 = pulsarClient.newProducer(Schema.JSON(Schemas.PersonOne.class))
+                .topic(topicOne)
+                .create();
+
+        @Cleanup
+        Producer<Schemas.PersonThree> p1_2 = pulsarClient.newProducer(Schema.JSON(Schemas.PersonThree.class))
+                .topic(topicOne)
+                .create();
+        @Cleanup
+        Producer<Schemas.PersonThree> p2_1 = pulsarClient.newProducer(Schema.JSON(Schemas.PersonThree.class))
+                .topic(topicTwo)
+                .create();
+
+        // Get 2 schemas of topicOne
+        List<CompletableFuture<SchemaRegistry.SchemaAndMetadata>> schemaFutures1 =
+                this.getPulsar().getSchemaRegistryService().getAllSchemas(TopicName.get(topicOne).getSchemaName()).get();
+        FutureUtil.waitForAll(schemaFutures1).get();
+        List<SchemaRegistry.SchemaAndMetadata> schemas1 = schemaFutures1.stream().map(future -> {
+            try {
+                return future.get();
+            } catch (Exception e) {
+                return null;
+            }
+        }).collect(Collectors.toList());
+        assertEquals(schemas1.size(), 2);
+        for (SchemaRegistry.SchemaAndMetadata schema : schemas1) {
+            assertNotNull(schema);
+        }
+
+        // Get 1 schema of topicTwo
+        List<CompletableFuture<SchemaRegistry.SchemaAndMetadata>> schemaFutures2 =
+                this.getPulsar().getSchemaRegistryService().getAllSchemas(TopicName.get(topicTwo).getSchemaName()).get();
+        FutureUtil.waitForAll(schemaFutures2).get();
+        List<SchemaRegistry.SchemaAndMetadata> schemas2 = schemaFutures2.stream().map(future -> {
+            try {
+                return future.get();
+            } catch (Exception e) {
+                return null;
+            }
+        }).collect(Collectors.toList());
+        assertEquals(schemas2.size(), 1);
+        for (SchemaRegistry.SchemaAndMetadata schema : schemas2) {
+            assertNotNull(schema);
+        }
+
+        // not force delete topic and will fail because it has active producers or subscriptions
+        try {
+            admin.topics().delete(topicOne, false);
+            fail();
+        } catch (Exception e) {
+            assertTrue(e.getMessage().startsWith("Topic has active producers/subscriptions"));
+        }
+        assertEquals(this.getPulsar().getSchemaRegistryService()
+                .trimDeletedSchemaAndGetList(TopicName.get(topicOne).getSchemaName()).get().size(), 2);
+        try {
+            admin.topics().deletePartitionedTopic(topicTwo, false);
+            fail();
+        } catch (Exception e) {
+            assertTrue(e.getMessage().startsWith("Topic has active producers/subscriptions"));
+        }
+        assertEquals(this.getPulsar().getSchemaRegistryService()
+                .trimDeletedSchemaAndGetList(TopicName.get(topicTwo).getSchemaName()).get().size(), 1);
+
+        // force delete topic and will delete schema by default
+        admin.topics().delete(topicOne, true);
+        assertEquals(this.getPulsar().getSchemaRegistryService()
+                .trimDeletedSchemaAndGetList(TopicName.get(topicOne).getSchemaName()).get().size(), 0);
+        admin.topics().deletePartitionedTopic(topicTwo, true);
+        assertEquals(this.getPulsar().getSchemaRegistryService()
+                .trimDeletedSchemaAndGetList(TopicName.get(topicTwo).getSchemaName()).get().size(), 0);
     }
 
     @Test

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -47,6 +47,7 @@ import org.apache.pulsar.common.policies.data.SchemaAutoUpdateCompatibilityStrat
 import org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy;
 import org.apache.pulsar.common.policies.data.SubscribeRate;
 import org.apache.pulsar.common.policies.data.SubscriptionAuthMode;
+import org.apache.pulsar.common.policies.data.TopicHashPositions;
 
 /**
  * Admin interface for namespaces management.
@@ -2077,6 +2078,55 @@ public interface Namespaces {
      */
     CompletableFuture<Void> splitNamespaceBundleAsync(
             String namespace, String bundle, boolean unloadSplitBundles, String splitAlgorithmName);
+
+    /**
+     * Split namespace bundle.
+     *
+     * @param namespace
+     * @param bundle range of bundle to split
+     * @param unloadSplitBundles
+     * @param splitAlgorithmName
+     * @param splitBoundaries
+     * @throws PulsarAdminException
+     */
+    void splitNamespaceBundle(String namespace, String bundle, boolean unloadSplitBundles,
+                              String splitAlgorithmName, List<Long> splitBoundaries) throws PulsarAdminException;
+
+    /**
+     * Split namespace bundle asynchronously.
+     *
+     * @param namespace
+     * @param bundle range of bundle to split
+     * @param unloadSplitBundles
+     * @param splitAlgorithmName
+     * @param splitBoundaries
+     */
+    CompletableFuture<Void> splitNamespaceBundleAsync(String namespace, String bundle, boolean unloadSplitBundles,
+                                                      String splitAlgorithmName, List<Long> splitBoundaries);
+
+    /**
+     * Get positions for topic list in a bundle.
+     *
+     * @param namespace
+     * @param bundle range of bundle
+     * @param topics
+     * @return hash positions for all topics in topicList
+     * @throws PulsarAdminException
+     */
+    TopicHashPositions getTopicHashPositions(String namespace,
+                                             String bundle, List<String> topics) throws PulsarAdminException;
+
+    /**
+     * Get positions for topic list in a bundle.
+     *
+     * @param namespace
+     * @param bundle range of bundle
+     * @param topics
+     * @return hash positions for all topics in topicList
+     * @throws PulsarAdminException
+     */
+    CompletableFuture<TopicHashPositions> getTopicHashPositionsAsync(String namespace,
+                                                                     String bundle, List<String> topics);
 
     /**
      * Set message-publish-rate (topics under this namespace can publish this many messages per second).

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -683,7 +683,7 @@ public interface Topics {
     CompletableFuture<Map<String, String>> getPropertiesAsync(String topic);
 
     /**
-     * Delete a partitioned topic.
+     * Delete a partitioned topic and its schemas.
      * <p/>
      * It will also delete all the partitions of the topic if it exists.
      * <p/>
@@ -693,21 +693,27 @@ public interface Topics {
      * @param force
      *            Delete topic forcefully
      * @param deleteSchema
-     *            Delete topic's schema storage
+     *            Delete topic's schema storage and it is always true even if it is specified as false
      *
      * @throws PulsarAdminException
+     * @deprecated Use {@link Topics#deletePartitionedTopic(String, boolean)} instead because parameter
+     * `deleteSchema` is always true
      */
+    @Deprecated
     void deletePartitionedTopic(String topic, boolean force, boolean deleteSchema) throws PulsarAdminException;
 
     /**
      * @see Topics#deletePartitionedTopic(String, boolean, boolean)
+     * IMPORTANT NOTICE: the application is not able to connect to the topic(delete then re-create with same name) again
+     * if the schema auto uploading is disabled. Besides, users should to use the truncate method to clean up
+     * data of the topic instead of delete method if users continue to use this topic later.
      */
     default void deletePartitionedTopic(String topic, boolean force) throws PulsarAdminException {
-        deletePartitionedTopic(topic, force, false);
+        deletePartitionedTopic(topic, force, true);
     }
 
     /**
-     * Delete a partitioned topic asynchronously.
+     * Delete a partitioned topic and its schemas asynchronously.
      * <p/>
      * It will also delete all the partitions of the topic if it exists.
      * <p/>
@@ -717,17 +723,20 @@ public interface Topics {
      * @param force
      *            Delete topic forcefully
      * @param deleteSchema
-     *            Delete topic's schema storage
+     *            Delete topic's schema storage and it is always true even if it is specified as false
      *
      * @return a future that can be used to track when the partitioned topic is deleted
+     * @deprecated Use {@link Topics#deletePartitionedTopicAsync(String, boolean)} instead because parameter
+     * `deleteSchema` is always true
      */
+    @Deprecated
     CompletableFuture<Void> deletePartitionedTopicAsync(String topic, boolean force, boolean deleteSchema);
 
     /**
      * @see Topics#deletePartitionedTopic(String, boolean, boolean)
      */
     default CompletableFuture<Void> deletePartitionedTopicAsync(String topic, boolean force) {
-        return deletePartitionedTopicAsync(topic, force, false);
+        return deletePartitionedTopicAsync(topic, force, true);
     }
 
     /**
@@ -755,7 +764,7 @@ public interface Topics {
     CompletableFuture<Void> deletePartitionedTopicAsync(String topic);
 
     /**
-     * Delete a topic.
+     * Delete a topic and its schemas.
      * <p/>
      * Delete a topic. The topic cannot be deleted if force flag is disable and there's any active
      * subscription or producer connected to the it. Force flag deletes topic forcefully by closing
@@ -767,7 +776,7 @@ public interface Topics {
      * @param force
      *            Delete topic forcefully
      * @param deleteSchema
-     *            Delete topic's schema storage
+     *            Delete topic's schema storage and it is always true even if it is specified as false
      *
      * @throws NotAuthorizedException
      *             Don't have admin permission
@@ -777,18 +786,24 @@ public interface Topics {
      *             Topic has active subscriptions or producers
      * @throws PulsarAdminException
      *             Unexpected error
+     * @deprecated Use {@link Topics#delete(String, boolean)} instead because
+     * parameter `deleteSchema` is always true
      */
+    @Deprecated
     void delete(String topic, boolean force, boolean deleteSchema) throws PulsarAdminException;
 
     /**
      * @see Topics#delete(String, boolean, boolean)
+     * IMPORTANT NOTICE: the application is not able to connect to the topic(delete then re-create with same name) again
+     * if the schema auto uploading is disabled. Besides, users should to use the truncate method to clean up
+     * data of the topic instead of delete method if users continue to use this topic later.
      */
     default void delete(String topic, boolean force) throws PulsarAdminException {
-        delete(topic, force, false);
+        delete(topic, force, true);
     }
 
     /**
-     * Delete a topic asynchronously.
+     * Delete a topic and its schemas asynchronously.
      * <p/>
      * Delete a topic asynchronously. The topic cannot be deleted if force flag is disable and there's any active
      * subscription or producer connected to the it. Force flag deletes topic forcefully by closing all active producers
@@ -800,17 +815,20 @@ public interface Topics {
      * @param force
      *            Delete topic forcefully
      * @param deleteSchema
-     *            Delete topic's schema storage
+     *            Delete topic's schema storage and it is always true even if it is specified as false
      *
      * @return a future that can be used to track when the topic is deleted
+     * @deprecated Use {@link Topics#deleteAsync(String, boolean)} instead because
+     * parameter `deleteSchema` is always true
      */
+    @Deprecated
     CompletableFuture<Void> deleteAsync(String topic, boolean force, boolean deleteSchema);
 
     /**
      * @see Topics#deleteAsync(String, boolean, boolean)
      */
     default CompletableFuture<Void> deleteAsync(String topic, boolean force) {
-        return deleteAsync(topic, force, false);
+        return deleteAsync(topic, force, true);
     }
 
     /**

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/partition/PartitionedTopicMetadata.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/partition/PartitionedTopicMetadata.java
@@ -28,6 +28,7 @@ public class PartitionedTopicMetadata {
 
     /* Number of partitions for the topic */
     public int partitions;
+    public boolean deleted;
 
     /* Topic properties */
     public Map<String, String> properties;

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/TopicHashPositions.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/TopicHashPositions.java
@@ -16,21 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.common.naming;
+package org.apache.pulsar.common.policies.data;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-/**
- * This algorithm divides the bundle into two parts with the same hash range size.
- */
-public class RangeEquallyDivideBundleSplitAlgorithm implements NamespaceBundleSplitAlgorithm {
-
-    @Override
-    public CompletableFuture<List<Long>> getSplitBoundary(BundleSplitOption bundleSplitOption) {
-        NamespaceBundle bundle = bundleSplitOption.getBundle();
-        return CompletableFuture.completedFuture(Collections.singletonList(bundle.getLowerEndpoint()
-                + (bundle.getUpperEndpoint() - bundle.getLowerEndpoint()) / 2));
-    }
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TopicHashPositions {
+    private String namespace;
+    private String bundle;
+    private Map<String, Long> topicHashPositions;
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -56,6 +56,8 @@ import org.apache.pulsar.common.policies.data.SchemaAutoUpdateCompatibilityStrat
 import org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy;
 import org.apache.pulsar.common.policies.data.SubscribeRate;
 import org.apache.pulsar.common.policies.data.SubscriptionAuthMode;
+import org.apache.pulsar.common.policies.data.TopicHashPositions;
+import org.apache.pulsar.common.util.Codec;
 
 public class NamespacesImpl extends BaseResource implements Namespaces {
 
@@ -1106,20 +1108,67 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     }
 
     @Override
-    public void splitNamespaceBundle(
-            String namespace, String bundle, boolean unloadSplitBundles, String splitAlgorithmName)
-            throws PulsarAdminException {
-        sync(() -> splitNamespaceBundleAsync(namespace, bundle, unloadSplitBundles, splitAlgorithmName));
+    public void splitNamespaceBundle(String namespace, String bundle, boolean unloadSplitBundles,
+                                     String splitAlgorithmName) throws PulsarAdminException {
+        splitNamespaceBundle(namespace, bundle, unloadSplitBundles, splitAlgorithmName, null);
     }
 
     @Override
-    public CompletableFuture<Void> splitNamespaceBundleAsync(
-            String namespace, String bundle, boolean unloadSplitBundles, String splitAlgorithmName) {
+    public CompletableFuture<Void> splitNamespaceBundleAsync(String namespace, String bundle,
+                                                             boolean unloadSplitBundles, String splitAlgorithmName) {
+        return splitNamespaceBundleAsync(namespace, bundle, unloadSplitBundles, splitAlgorithmName, null);
+    }
+
+    @Override
+    public void splitNamespaceBundle(String namespace, String bundle, boolean unloadSplitBundles,
+            String splitAlgorithmName, List<Long> splitBoundaries)
+            throws PulsarAdminException {
+        sync(() ->
+                splitNamespaceBundleAsync(namespace, bundle, unloadSplitBundles, splitAlgorithmName, splitBoundaries));
+    }
+
+    @Override
+    public CompletableFuture<Void> splitNamespaceBundleAsync(String namespace, String bundle,
+                                                             boolean unloadSplitBundles, String splitAlgorithmName,
+                                                             List<Long> splitBoundaries) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, bundle, "split")
                 .queryParam("unload", Boolean.toString(unloadSplitBundles))
                 .queryParam("splitAlgorithmName", splitAlgorithmName);
-        return asyncPutRequest(path, Entity.entity("", MediaType.APPLICATION_JSON));
+
+        return (splitBoundaries == null || splitBoundaries.size() == 0)
+                ? asyncPutRequest(path, Entity.entity("", MediaType.APPLICATION_JSON))
+                : asyncPutRequest(path, Entity.entity(splitBoundaries, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public TopicHashPositions getTopicHashPositions(String namespace, String bundle, List<String> topics)
+            throws PulsarAdminException {
+        return sync(() -> getTopicHashPositionsAsync(namespace, bundle, topics));
+    }
+
+    @Override
+    public CompletableFuture<TopicHashPositions>
+    getTopicHashPositionsAsync(String namespace, String bundle, List<String> topics) {
+        NamespaceName ns = NamespaceName.get(namespace);
+        WebTarget path = namespacePath(ns, bundle, "topicHashPositions");
+        if (topics != null && topics.size() > 0) {
+            path = path.queryParam("topics", topics.stream().map(Codec::encode).toArray());
+        }
+        final CompletableFuture<TopicHashPositions> future = new CompletableFuture<>();
+        asyncGetRequest(path,
+                new InvocationCallback<TopicHashPositions>() {
+                    @Override
+                    public void completed(TopicHashPositions topicHashPositions) {
+                        future.complete(topicHashPositions);
+                    }
+
+                    @Override
+                    public void failed(Throwable throwable) {
+                        future.completeExceptionally(getApiException(throwable.getCause()));
+                    }
+                });
+        return future;
     }
 
     @Override

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -488,7 +488,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void deletePartitionedTopic(String topic, boolean force, boolean deleteSchema) throws PulsarAdminException {
-        sync(() -> deletePartitionedTopicAsync(topic, force, deleteSchema));
+        sync(() -> deletePartitionedTopicAsync(topic, force, true));
     }
 
     @Override
@@ -496,7 +496,7 @@ public class TopicsImpl extends BaseResource implements Topics {
         TopicName tn = validateTopic(topic);
         WebTarget path = topicPath(tn, "partitions") //
                 .queryParam("force", Boolean.toString(force)) //
-                .queryParam("deleteSchema", Boolean.toString(deleteSchema));
+                .queryParam("deleteSchema", "true");
         return asyncDeleteRequest(path);
     }
 
@@ -512,7 +512,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void delete(String topic, boolean force, boolean deleteSchema) throws PulsarAdminException {
-        sync(() -> deleteAsync(topic, force, deleteSchema));
+        sync(() -> deleteAsync(topic, force, true));
     }
 
     @Override
@@ -520,7 +520,7 @@ public class TopicsImpl extends BaseResource implements Topics {
         TopicName tn = validateTopic(topic);
         WebTarget path = topicPath(tn) //
                 .queryParam("force", Boolean.toString(force)) //
-                .queryParam("deleteSchema", Boolean.toString(deleteSchema));
+                .queryParam("deleteSchema", "true");
         return asyncDeleteRequest(path);
     }
 

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -1313,8 +1313,8 @@ public class PulsarAdminToolTest {
         cmdTopics.run(split("truncate persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).truncate("persistent://myprop/clust/ns1/ds1");
 
-        cmdTopics.run(split("delete persistent://myprop/clust/ns1/ds1 -f -d"));
-        verify(mockTopics).delete("persistent://myprop/clust/ns1/ds1", true, true);
+        cmdTopics.run(split("delete persistent://myprop/clust/ns1/ds1 -f"));
+        verify(mockTopics).delete("persistent://myprop/clust/ns1/ds1", true);
 
         cmdTopics.run(split("unload persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).unload("persistent://myprop/clust/ns1/ds1");
@@ -1470,8 +1470,8 @@ public class PulsarAdminToolTest {
         cmdTopics.run(split("get-partitioned-topic-metadata persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).getPartitionedTopicMetadata("persistent://myprop/clust/ns1/ds1");
 
-        cmdTopics.run(split("delete-partitioned-topic persistent://myprop/clust/ns1/ds1 -d -f"));
-        verify(mockTopics).deletePartitionedTopic("persistent://myprop/clust/ns1/ds1", true, true);
+        cmdTopics.run(split("delete-partitioned-topic persistent://myprop/clust/ns1/ds1 -f"));
+        verify(mockTopics).deletePartitionedTopic("persistent://myprop/clust/ns1/ds1", true);
 
         cmdTopics.run(split("peek-messages persistent://myprop/clust/ns1/ds1 -s sub1 -n 3"));
         verify(mockTopics).peekMessages("persistent://myprop/clust/ns1/ds1", "sub1", 3);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -878,9 +878,14 @@ public class CmdNamespaces extends CmdBase {
         private boolean unload;
 
         @Parameter(names = { "--split-algorithm-name", "-san" }, description = "Algorithm name for split "
-                + "namespace bundle. Valid options are: [range_equally_divide, topic_count_equally_divide]."
-                + " Use broker side config if absent", required = false)
+                + "namespace bundle. Valid options are: [range_equally_divide, topic_count_equally_divide, "
+                + "specified_positions_divide]. Use broker side config if absent", required = false)
         private String splitAlgorithmName;
+
+        @Parameter(names = { "--split-boundaries",
+                "-sb" }, description = "Specified split boundary for bundle split, will split one bundle "
+                + "to multi bundles only works with specified_positions_divide algorithm", required = false)
+        private List<Long> splitBoundaries;
 
         @Override
         void run() throws PulsarAdminException {
@@ -892,7 +897,41 @@ public class CmdNamespaces extends CmdBase {
                 throw new ParameterException("--bundle and --bundle-type are mutually exclusive");
             }
             bundle = bundleType != null ? bundleType.toString() : bundle;
-            getAdmin().namespaces().splitNamespaceBundle(namespace, bundle, unload, splitAlgorithmName);
+            if (splitBoundaries == null || splitBoundaries.size() == 0) {
+                getAdmin().namespaces().splitNamespaceBundle(
+                        namespace, bundle, unload, splitAlgorithmName);
+            } else {
+                getAdmin().namespaces().splitNamespaceBundle(
+                        namespace, bundle, unload, splitAlgorithmName, splitBoundaries);
+            }
+        }
+    }
+
+    @Parameters(commandDescription = "Get the positions for one or more topic(s) in a namespace bundle")
+    private class GetTopicHashPositions extends CliCommand {
+        @Parameter(description = "tenant/namespace", required = true)
+        private java.util.List<String> params;
+
+        @Parameter(
+                names = { "--bundle", "-b" },
+                description = "{start-boundary}_{end-boundary} format namespace bundle",
+                required = false)
+        private String bundle;
+
+        @Parameter(
+                names = { "--topic-list",  "-tl" },
+                description = "The list of topics(both non-partitioned topic and partitioned topic) to get positions "
+                        + "in this bundle, if none topic provided, will get the positions of all topics in this bundle",
+                required = false)
+        private List<String> topics;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String namespace = validateNamespace(params);
+            if (StringUtils.isBlank(bundle)) {
+                throw new ParameterException("Must pass one of the params: --bundle ");
+            }
+            print(getAdmin().namespaces().getTopicHashPositions(namespace, bundle, topics));
         }
     }
 
@@ -2624,6 +2663,7 @@ public class CmdNamespaces extends CmdBase {
         jcommander.addCommand("unload", new Unload());
 
         jcommander.addCommand("split-bundle", new SplitBundle());
+        jcommander.addCommand("get-topic-positions", new GetTopicHashPositions());
 
         jcommander.addCommand("set-dispatch-rate", new SetDispatchRate());
         jcommander.addCommand("remove-dispatch-rate", new RemoveDispatchRate());

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -619,7 +619,10 @@ public class CmdTopics extends CmdBase {
     }
 
     @Parameters(commandDescription = "Delete a partitioned topic. "
-            + "It will also delete all the partitions of the topic if it exists.")
+            + "It will also delete all the partitions of the topic if it exists."
+            + "And the application is not able to connect to the topic(delete then re-create with same name) again "
+            + "if the schema auto uploading is disabled. Besides, users should to use the truncate cmd to clean up "
+            + "data of the topic instead of delete cmd if users continue to use this topic later.")
     private class DeletePartitionedCmd extends CliCommand {
 
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
@@ -629,19 +632,22 @@ public class CmdTopics extends CmdBase {
                 "--force" }, description = "Close all producer/consumer/replicator and delete topic forcefully")
         private boolean force = false;
 
-        @Parameter(names = { "-d",
-                "--deleteSchema" }, description = "Delete schema while deleting topic")
+        @Parameter(names = {"-d", "--deleteSchema"}, description = "Delete schema while deleting topic, "
+                + "but the parameter is invalid and the schema is always deleted", hidden = true)
         private boolean deleteSchema = false;
 
         @Override
         void run() throws Exception {
             String topic = validateTopicName(params);
-            getTopics().deletePartitionedTopic(topic, force, deleteSchema);
+            getTopics().deletePartitionedTopic(topic, force);
         }
     }
 
     @Parameters(commandDescription = "Delete a topic. "
-            + "The topic cannot be deleted if there's any active subscription or producers connected to it.")
+            + "The topic cannot be deleted if there's any active subscription or producers connected to it."
+            + "And the application is not able to connect to the topic(delete then re-create with same name) again "
+            + "if the schema auto uploading is disabled. Besides, users should to use the truncate cmd to clean up "
+            + "data of the topic instead of delete cmd if users continue to use this topic later.")
     private class DeleteCmd extends CliCommand {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
@@ -650,14 +656,14 @@ public class CmdTopics extends CmdBase {
                 "--force" }, description = "Close all producer/consumer/replicator and delete topic forcefully")
         private boolean force = false;
 
-        @Parameter(names = { "-d",
-                "--deleteSchema" }, description = "Delete schema while deleting topic")
+        @Parameter(names = {"-d", "--deleteSchema"}, description = "Delete schema while deleting topic, "
+                + "but the parameter is invalid and the schema is always deleted", hidden = true)
         private boolean deleteSchema = false;
 
         @Override
         void run() throws PulsarAdminException {
             String topic = validateTopicName(params);
-            getTopics().delete(topic, force, deleteSchema);
+            getTopics().delete(topic, force);
         }
     }
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topics/TestTopicDeletion.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topics/TestTopicDeletion.java
@@ -1,0 +1,183 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration.topics;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.tests.integration.docker.ContainerExecException;
+import org.apache.pulsar.tests.integration.docker.ContainerExecResult;
+import org.apache.pulsar.tests.integration.suites.PulsarTestSuite;
+import org.apache.pulsar.tests.integration.topologies.PulsarClusterSpec;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.fail;
+
+/**
+ * Test cases for compaction.
+ */
+@Slf4j
+public class TestTopicDeletion extends PulsarTestSuite {
+
+    final private boolean unload = false;
+    final private int numBrokers = 2;
+
+    public void setupCluster() throws Exception {
+        brokerEnvs.put("managedLedgerMaxEntriesPerLedger", "10");
+        brokerEnvs.put("brokerDeleteInactivePartitionedTopicMetadataEnabled", "false");
+        brokerEnvs.put("brokerDeleteInactiveTopicsEnabled", "false");
+        this.setupCluster("");
+    }
+
+    protected PulsarClusterSpec.PulsarClusterSpecBuilder beforeSetupCluster(
+            String clusterName,
+            PulsarClusterSpec.PulsarClusterSpecBuilder specBuilder) {
+        specBuilder.numBrokers(numBrokers);
+        specBuilder.enableContainerLog(true);
+        return specBuilder;
+    }
+
+    @Test(dataProvider = "ServiceUrls", timeOut=300_000)
+    public void testPartitionedTopicForceDeletion(Supplier<String> serviceUrl) throws Exception {
+
+        log.info("Creating tenant and namespace");
+
+        final String tenant = "test-partitioned-topic-" + randomName(4);
+        final String namespace = tenant + "/ns1";
+        final String topic = "persistent://" + namespace + "/partitioned-topic";
+        final int numPartitions = numBrokers * 3;
+        final int numKeys = numPartitions * 50;
+        final String subscriptionName = "sub1";
+
+        this.createTenantName(tenant, pulsarCluster.getClusterName(), "admin");
+
+        this.createNamespace(namespace);
+
+        pulsarCluster.runAdminCommandOnAnyBroker("namespaces",
+                "set-clusters", "--clusters", pulsarCluster.getClusterName(), namespace);
+
+        pulsarCluster.runAdminCommandOnAnyBroker("namespaces",
+                "set-retention", "--size", "100M", "--time", "100m", namespace);
+
+        this.createPartitionedTopic(topic, numPartitions);
+
+        try (PulsarClient client = PulsarClient.builder().serviceUrl(serviceUrl.get()).build()) {
+
+            log.info("Creating consumer");
+            Consumer<byte[]> consumer = client.newConsumer()
+                    .topic(topic)
+                    .subscriptionName(subscriptionName)
+                    .subscribe();
+
+            log.info("Producing messages");
+            try(Producer<byte[]> producer = client.newProducer()
+                .topic(topic)
+                .create()
+            ) {
+                for (int i = 0; i < numKeys; i++) {
+                    producer.newMessage()
+                        .key("" + i)
+                        .value(("value-" + i).getBytes(UTF_8))
+                        .sendAsync();
+                }
+                producer.flush();
+                log.info("Successfully wrote {} values", numKeys);
+            }
+
+            log.info("Consuming half of the messages");
+            for (int i = 0; i < numKeys / 2; i++) {
+                Message<byte[]> m = consumer.receive(1, TimeUnit.MINUTES);
+                log.info("Read value {}", m.getKey());
+            }
+
+            if (unload) {
+                log.info("Unloading topic");
+                pulsarCluster.runAdminCommandOnAnyBroker("topics",
+                        "unload", topic);
+            }
+
+            ContainerExecResult res;
+            log.info("Deleting the topic");
+            try {
+                res = pulsarCluster.runAdminCommandOnAnyBroker("topics",
+                        "delete-partitioned-topic", "--force", topic);
+                assertNotEquals(0, res.getExitCode());
+            } catch (ContainerExecException e) {
+                log.info("Second delete failed with ContainerExecException, could be ok", e);
+                if (!e.getMessage().contains("with error code 1")) {
+                    fail("Expected different error code");
+                }
+            }
+
+            log.info("Close the consumer and delete the topic again");
+            consumer.close();
+
+            res = pulsarCluster.runAdminCommandOnAnyBroker("topics",
+                    "delete-partitioned-topic", "--force", topic);
+            assertNotEquals(0, res.getExitCode());
+
+            Thread.sleep(5000);
+            // should succeed
+            log.info("Creating the topic again");
+            this.createPartitionedTopic(topic, numBrokers * 2);
+        }
+    }
+
+
+    private ContainerExecResult createTenantName(final String tenantName,
+                                                 final String allowedClusterName,
+                                                 final String adminRoleName) throws Exception {
+        ContainerExecResult result = pulsarCluster.runAdminCommandOnAnyBroker(
+            "tenants", "create", "--allowed-clusters", allowedClusterName,
+            "--admin-roles", adminRoleName, tenantName);
+        assertEquals(0, result.getExitCode());
+        return result;
+    }
+
+    private ContainerExecResult createNamespace(final String Ns) throws Exception {
+        ContainerExecResult result = pulsarCluster.runAdminCommandOnAnyBroker(
+                "namespaces",
+                "create",
+                "--clusters",
+                pulsarCluster.getClusterName(), Ns);
+        assertEquals(0, result.getExitCode());
+        return result;
+    }
+
+    private ContainerExecResult createPartitionedTopic(final String partitionedTopicName, int numPartitions)
+            throws Exception {
+        ContainerExecResult result = pulsarCluster.runAdminCommandOnAnyBroker(
+            "topics",
+            "create-partitioned-topic",
+            "--partitions", "" + numPartitions,
+            partitionedTopicName);
+        assertEquals(0, result.getExitCode());
+        return result;
+    }
+
+
+}


### PR DESCRIPTION
I had to cherry-pick a few other commits to resolve some conflicts. 
Please do not squash while merging.

Author: Andrey Yegorov <8622884+dlg99@users.noreply.github.com>
Date:   Fri Oct 28 13:00:44 2022 -0700

    [fix] Combination of autocreate + forced delete of partitioned topic with active consumer leaves topic metadata inconsistent. (#18193)

    (cherry picked from commit 3fdbc9fca6b6206bcbeef8e48937ccb3cb2d273f)

Author: Ruguo Yu <jiang7chengzitc@163.com>
Date:   Wed Apr 27 22:27:20 2022 +0800

    Ensure the deletion consistency of topic and schema (#14608)

    (cherry picked from commit c06b17d71a43328b764cff96aa4e2dd9996e0888)

Author: Xiaoyu Hou <AnonHxyGo@gmail.com>
Date:   Mon May 2 10:44:28 2022 +0800

    Clean unsed methods in BrokerService (#15257)

    (cherry picked from commit cd6dfee6ea74ae57bac689702038d8f6964855ca)

Author: Jiwei Guo <technoboy@apache.org>
Date:   Thu Apr 28 10:02:23 2022 +0800

    Make TopicLookupBase#internalLookupTopicAsync pure async (#14188)

    (cherry picked from commit 49fcc80600b35152a588c93c5dc5d9d0297b3a22)

Author: gaozhangmin <zhangmingao@apache.org>
Date:   Thu Sep 15 10:39:24 2022 +0800

    [improve][admin] Make deleteNamesapce api async (#17230)

    Co-authored-by: gavingaozhangmin <gavingaozhangmin@didiglobal.com>
    (cherry picked from commit 90d70fd3ba1752997da595a31838a15bc678d050)

Author: Aloys <lofterzhang@gmail.com>
Date:   Fri Mar 11 13:28:23 2022 +0800

    [PIP-143] Support split bundle by specified boundaries  (#13796)

    (cherry picked from commit 7998c44b0b85e8ae1af5fec64d8f873032877a2f)

Author: HuangZeGui <1023035050@qq.com>
Date:   Tue Aug 30 11:24:23 2022 +0800

    [improve][broker][PIP-149]make deletePersistence method async in Namespaces (#17206)

    Co-authored-by: huangzegui <huangzegui@didiglobal.com>
    (cherry picked from commit 814008066f0217099b2b7cf795647403c32d5204)