### PR TITLE
[proxy] Close proxy->broker connections during proxy graceful termination

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
@@ -66,6 +66,7 @@ import org.apache.pulsar.common.api.proto.ProtocolVersion;
 import org.apache.pulsar.common.api.proto.ServerError;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.protocol.PulsarHandler;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.Reflections;
 import org.apache.pulsar.policies.data.loadbalancer.ServiceLookupData;
 import org.slf4j.Logger;
@@ -687,9 +688,10 @@ public class ProxyConnection extends PulsarHandler {
     public CompletableFuture<?> onServiceShutdown() {
         LOG.info("[{}] Shutdown connection {} {}", remoteAddress,
                 directProxyHandler, connectionPool);
-
+        if (ctx == null) {
+            return CompletableFuture.completedFuture(null);
+        }
         CompletableFuture<?> handle = new CompletableFuture<>();
-
         ctx.executor().execute(() -> {
             try {
                 if (state == State.Closed) {
@@ -714,6 +716,8 @@ public class ProxyConnection extends PulsarHandler {
                 }
 
                 state = State.Closed;
+
+                ctx.close();
             } finally {
                 handle.complete(null);
             }

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
@@ -33,6 +33,8 @@ import io.netty.resolver.dns.DnsNameResolverBuilder;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
+
+import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -78,7 +80,7 @@ import org.slf4j.LoggerFactory;
  * Pulsar proxy service.
  */
 @Slf4j
-public class ProxyService {
+public class ProxyService implements Closeable {
 
     private final ProxyConfiguration proxyConfig;
     private final Authentication proxyClientAuthentication;


### PR DESCRIPTION
Motivation:
When the proxy service is shutting down it is possible that the client connections are closed before closing the connections opened to the brokers.

This leads to a unfortunate edge case in which the broker still thinks that the client is connected while on the client side the connection is broker. In this case the client may try to register again its own Consumers and that may lead to "Range Conflict" errors.


Motifications:
- add more logs during Proxy (graceful) shutdown
- eagerly close all the connections to the brokers
- wait for some time before letting the process exist
