### PR TITLE
[fix][monitor] topic/subscription with slash breaks the prometheus format

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGeneratorUtils.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGeneratorUtils.java
@@ -68,17 +68,14 @@ public class PrometheusMetricsGeneratorUtils {
                 stream.write(sample.name);
                 stream.write("{");
                 if (!sample.labelNames.contains("cluster")) {
-                    stream.write("cluster=\"").write(cluster).write('"');
+                    stream.write("cluster=\"").write(writeEscapedLabelValue(cluster)).write('"');
                     // If label is empty, should not append ','.
                     if (!CollectionUtils.isEmpty(sample.labelNames)){
                         stream.write(",");
                     }
                 }
                 for (int j = 0; j < sample.labelNames.size(); j++) {
-                    String labelValue = sample.labelValues.get(j);
-                    if (labelValue != null) {
-                        labelValue = labelValue.replace("\"", "\\\"");
-                    }
+                    String labelValue = writeEscapedLabelValue(sample.labelValues.get(j));
                     if (j > 0) {
                         stream.write(",");
                     }
@@ -109,6 +106,35 @@ public class PrometheusMetricsGeneratorUtils {
             default:
                 return "untyped";
         }
+    }
+
+
+    /**
+     * Write a label value to the writer, escaping backslashes, double quotes and newlines.
+     * See Promethues Exporter io.prometheus.client.exporter.common.TextFormat#writeEscapedLabelValue
+     */
+    public static String writeEscapedLabelValue(String s) {
+        if (s == null) {
+            return null;
+        }
+        StringBuilder writer = new StringBuilder();
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '\\':
+                    writer.append("\\\\");
+                    break;
+                case '\"':
+                    writer.append("\\\"");
+                    break;
+                case '\n':
+                    writer.append("\\n");
+                    break;
+                default:
+                    writer.append(c);
+            }
+        }
+        return writer.toString();
     }
 
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGeneratorUtils.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGeneratorUtils.java
@@ -35,7 +35,6 @@ import org.apache.pulsar.common.util.SimpleTextOutputStream;
  * Format specification can be found at {@link https://prometheus.io/docs/instrumenting/exposition_formats/}
  */
 public class PrometheusMetricsGeneratorUtils {
-    
     private static final Pattern METRIC_LABEL_VALUE_SPECIAL_CHARACTERS = Pattern.compile("[\\\\\"\\n]");
 
     public static void generate(String cluster, OutputStream out,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGeneratorUtils.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGeneratorUtils.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.regex.Pattern;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.util.SimpleTextOutputStream;
@@ -34,6 +35,8 @@ import org.apache.pulsar.common.util.SimpleTextOutputStream;
  * Format specification can be found at {@link https://prometheus.io/docs/instrumenting/exposition_formats/}
  */
 public class PrometheusMetricsGeneratorUtils {
+    
+    private static final Pattern METRIC_LABEL_VALUE_SPECIAL_CHARACTERS = Pattern.compile("[\\\\\"\\n]");
 
     public static void generate(String cluster, OutputStream out,
                                 List<PrometheusRawMetricsProvider> metricsProviders)
@@ -117,6 +120,9 @@ public class PrometheusMetricsGeneratorUtils {
         if (s == null) {
             return null;
         }
+        if (!labelValueNeedsEscape(s)) {
+            return s;
+        }
         StringBuilder writer = new StringBuilder();
         for (int i = 0; i < s.length(); i++) {
             char c = s.charAt(i);
@@ -135,6 +141,10 @@ public class PrometheusMetricsGeneratorUtils {
             }
         }
         return writer.toString();
+    }
+
+    static boolean labelValueNeedsEscape(String s) {
+        return METRIC_LABEL_VALUE_SPECIAL_CHARACTERS.matcher(s).find();
     }
 
 }

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGeneratorUtilsTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGeneratorUtilsTest.java
@@ -102,4 +102,26 @@ public class PrometheusMetricsGeneratorUtilsTest {
     private static String randomString(){
         return UUID.randomUUID().toString().replaceAll("-", "");
     }
+
+
+    @Test
+    public void testWriteEscapedLabelValue() throws Exception {
+        assertEquals(PrometheusMetricsGeneratorUtils.writeEscapedLabelValue(null), null);
+        assertEquals(PrometheusMetricsGeneratorUtils.writeEscapedLabelValue(""), "");
+        assertEquals(PrometheusMetricsGeneratorUtils.writeEscapedLabelValue("ok"), "ok");
+        assertEquals(PrometheusMetricsGeneratorUtils.writeEscapedLabelValue("ok_!234567890!£$%&/()"),
+                "ok_!234567890!£$%&/()");
+        assertEquals(PrometheusMetricsGeneratorUtils.writeEscapedLabelValue("repl\"\\\n"),
+                "repl\\\"\\\\\\n");
+    }
+    @Test
+    public void testWriteEscapedLabelValuePattern() throws Exception {
+        assertFalse(PrometheusMetricsGeneratorUtils.labelValueNeedsEscape(""));
+        assertFalse(PrometheusMetricsGeneratorUtils.labelValueNeedsEscape("ok"));
+        assertFalse(PrometheusMetricsGeneratorUtils.labelValueNeedsEscape("ok_!234567890!£$%&/()"));
+        assertTrue(PrometheusMetricsGeneratorUtils.labelValueNeedsEscape("repl\"\\\n"));
+        assertTrue(PrometheusMetricsGeneratorUtils.labelValueNeedsEscape("repl\""));
+        assertTrue(PrometheusMetricsGeneratorUtils.labelValueNeedsEscape("repl\\"));
+        assertTrue(PrometheusMetricsGeneratorUtils.labelValueNeedsEscape("\nrepl"));
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricStreams.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricStreams.java
@@ -41,10 +41,7 @@ public class PrometheusMetricStreams {
         SimpleTextOutputStream stream = initGaugeType(metricName);
         stream.write(metricName).write('{');
         for (int i = 0; i < labelsAndValuesArray.length; i += 2) {
-            String labelValue = labelsAndValuesArray[i + 1];
-            if (labelValue != null) {
-                labelValue = labelValue.replace("\"", "\\\"");
-            }
+            String labelValue = PrometheusMetricsGeneratorUtils.writeEscapedLabelValue(labelsAndValuesArray[i + 1]);
             stream.write(labelsAndValuesArray[i]).write("=\"").write(labelValue).write('\"');
             if (i + 2 != labelsAndValuesArray.length) {
                 stream.write(',');

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -215,9 +215,11 @@ public class PrometheusMetricsGenerator {
                     if (metric.getKey().isEmpty() || "cluster".equals(metric.getKey())) {
                         continue;
                     }
-                    stream.write(", ").write(metric.getKey()).write("=\"").write(metric.getValue()).write('"');
+                    final String metricValue = PrometheusMetricsGeneratorUtils.writeEscapedLabelValue(metric.getValue());
+                    stream.write(", ").write(metric.getKey()).write("=\"").write(metricValue).write('"');
                     if (value != null && !value.isEmpty() && !appendedQuantile) {
-                        stream.write(", ").write("quantile=\"").write(value).write('"');
+                        stream.write(", ").write("quantile=\"").write(PrometheusMetricsGeneratorUtils
+                                .writeEscapedLabelValue(value)).write('"');
                         appendedQuantile = true;
                     }
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -215,7 +215,8 @@ public class PrometheusMetricsGenerator {
                     if (metric.getKey().isEmpty() || "cluster".equals(metric.getKey())) {
                         continue;
                     }
-                    final String metricValue = PrometheusMetricsGeneratorUtils.writeEscapedLabelValue(metric.getValue());
+                    final String metricValue = PrometheusMetricsGeneratorUtils
+                            .writeEscapedLabelValue(metric.getValue());
                     stream.write(", ").write(metric.getKey()).write("=\"").write(metricValue).write('"');
                     if (value != null && !value.isEmpty() && !appendedQuantile) {
                         stream.write(", ").write("quantile=\"").write(PrometheusMetricsGeneratorUtils

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/PrometheusTextFormatUtil.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/PrometheusTextFormatUtil.java
@@ -135,4 +135,5 @@ public class PrometheusTextFormatUtil {
                 .append(success.toString()).append("\"} ")
                 .append(Double.toString(opStat.getSum(success))).append('\n');
     }
+
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -1733,6 +1733,10 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         }
     }
 
+    /**
+     * Test both subscription and topic name with special characters.
+     * @throws Exception
+     */
     @Test
     public void testEscapeLabelValue() throws Exception {
         String ns1 = "prop/ns-abc1";
@@ -1742,7 +1746,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
         @Cleanup
         final Consumer<?> consumer = pulsarClient.newConsumer()
-                .subscriptionName("sub")
+                .subscriptionName("s\"ub\\")
                 .topic(topic)
                 .subscribe();
         @Cleanup
@@ -1751,12 +1755,13 @@ public class PrometheusMetricsTest extends BrokerTestBase {
                 false, statsOut);
         String metricsStr = statsOut.toString();
         final List<String> subCountLines = Arrays.stream(metricsStr.split("\n"))
-                .filter(line -> line.startsWith("pulsar_subscriptions_count") && line.contains("topic="))
+                .filter(line -> line.startsWith("pulsar_subscription_msg_drop_rate") && line.contains("topic="))
                 .collect(Collectors.toList());
         System.out.println(subCountLines);
         assertEquals(subCountLines.size(), 1);
         assertEquals(subCountLines.get(0),
-                "pulsar_subscriptions_count{cluster=\"test\",namespace=\"prop/ns-abc1\",topic=\"persistent://prop/ns-abc1/\\\"mytopic\"} 1");
+                "pulsar_subscription_msg_drop_rate{cluster=\"test\",namespace=\"prop/ns-abc1\","
+                        + "topic=\"persistent://prop/ns-abc1/\\\"mytopic\",subscription=\"s\\\"ub\\\\\"} 0.0");
     }
 
 }

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchMetrics.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchMetrics.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClientTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClientTests.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.io.elasticsearch;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;


### PR DESCRIPTION
### Motivation

Follow up of https://github.com/apache/pulsar/pull/20230 that includes a full replacement method for special characters.
The method is now copied~inspired from the official Prometheus java client exporter (that is not in the pulsar classpath)

https://github.com/prometheus/client_java/blob/db2304d042a8f9373504b167efcfbbea13a9e1cd/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java#L155C23-L172


### Modifications

- Use the new method to replace the special characters in prometheus label values
- Added a unit test 

### Verifying this change

- [x] Make sure that the change passes the CI checks.
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
