### PR TITLE
Admin API: stream stats-internal with StreamingOutput

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -19,16 +19,20 @@
 package org.apache.pulsar.broker.admin.v2;
 
 import static org.apache.pulsar.common.util.Codec.decode;
+import static org.apache.pulsar.common.util.FutureUtil.unwrapCompletionException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletionException;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.Encoded;
@@ -42,8 +46,10 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.admin.impl.PersistentTopicsBase;
@@ -83,6 +89,7 @@ import org.apache.pulsar.common.policies.data.impl.DispatchRateImpl;
 import org.apache.pulsar.common.policies.data.stats.PartitionedTopicStatsImpl;
 import org.apache.pulsar.common.util.Codec;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1120,7 +1127,7 @@ public class PersistentTopics extends PersistentTopicsBase {
         internalDeleteTopicAsync(authoritative, force)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    Throwable t = FutureUtil.unwrapCompletionException(ex);
+                    Throwable t = unwrapCompletionException(ex);
                     if (!force && (t instanceof BrokerServiceException.TopicBusyException)) {
                         ex = new RestException(Response.Status.PRECONDITION_FAILED,
                                 t.getMessage());
@@ -1215,6 +1222,8 @@ public class PersistentTopics extends PersistentTopicsBase {
                 });
     }
 
+    @Context HttpServletRequest servletRequest;
+
     @GET
     @Path("{tenant}/{namespace}/{topic}/internalStats")
     @ApiOperation(value = "Get the internal stats for the topic.", response = PersistentTopicInternalStats.class)
@@ -1226,8 +1235,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiResponse(code = 412, message = "Topic name is not valid"),
             @ApiResponse(code = 500, message = "Internal server error"),
             @ApiResponse(code = 503, message = "Failed to validate global cluster configuration") })
-    public void getInternalStats(
-            @Suspended final AsyncResponse asyncResponse,
+    public StreamingOutput getInternalStats(
             @ApiParam(value = "Specify the tenant", required = true)
             @PathParam("tenant") String tenant,
             @ApiParam(value = "Specify the namespace", required = true)
@@ -1238,15 +1246,22 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @QueryParam("metadata") @DefaultValue("false") boolean metadata) {
         validateTopicName(tenant, namespace, encodedTopic);
-        internalGetInternalStatsAsync(authoritative, metadata)
-                .thenAccept(asyncResponse::resume)
-                .exceptionally(ex -> {
-                    if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to get internal stats for topic {}", clientAppId(), topicName, ex);
-                    }
-                    resumeAsyncResponseExceptionally(asyncResponse, ex);
-                    return null;
-                });
+        return output -> {
+            internalGetInternalStatsAsync(authoritative, metadata)
+                    .thenAccept(stats -> {
+                        try {
+                            ObjectMapperFactory.getMapper().getObjectMapper().writeValue(output, stats);
+                        } catch (IOException error) {
+                            throw new CompletionException(error);
+                        }
+                    })
+                    .exceptionally(ex -> {
+                        if (isNot307And404Exception(ex)) {
+                            log.error("[{}] Failed to get internal stats for topic {}", clientAppId(), topicName, ex);
+                        }
+                        throw translateToWebApplicationException(ex);
+                    });
+        };
     }
 
     @GET

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
-import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.Encoded;
@@ -46,7 +45,6 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
@@ -1221,8 +1219,6 @@ public class PersistentTopics extends PersistentTopicsBase {
                     return null;
                 });
     }
-
-    @Context HttpServletRequest servletRequest;
 
     @GET
     @Path("{tenant}/{namespace}/{topic}/internalStats")

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -1314,6 +1314,23 @@ public abstract class PulsarWebResource {
         }
     }
 
+    protected static WebApplicationException translateToWebApplicationException(Throwable exception) {
+        Throwable realCause = FutureUtil.unwrapCompletionException(exception);
+        if (realCause instanceof WebApplicationException) {
+            return (WebApplicationException) realCause;
+        } else if (realCause instanceof BrokerServiceException.NotAllowedException) {
+            return new RestException(Status.CONFLICT, realCause);
+        } else if (realCause instanceof MetadataStoreException.NotFoundException) {
+            return new RestException(Status.NOT_FOUND, realCause);
+        } else if (realCause instanceof MetadataStoreException.BadVersionException) {
+            return new RestException(Status.CONFLICT, "Concurrent modification");
+        } else if (realCause instanceof PulsarAdminException) {
+            return new RestException(((PulsarAdminException) realCause));
+        } else {
+            return new RestException(realCause);
+        }
+    }
+
     protected static void resumeAsyncResponseExceptionally(AsyncResponse asyncResponse, Throwable exception) {
         Throwable realCause = FutureUtil.unwrapCompletionException(exception);
         if (realCause instanceof WebApplicationException) {


### PR DESCRIPTION
Modifications:
- use the StreamingOutput API to stream the results of GetInternalStats, as the JSON may be huge when individuallyDeletedMessages inside ManagedLedgerInternalStats$CursorStats contains many ranges
- this approach is already used in other APIs, so nothing new