### PR TITLE
Prevent race condition while deleting namespace

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -345,7 +345,7 @@ public abstract class NamespacesBase extends AdminResource {
                                 } else {
                                     callback.completeExceptionally(
                                             new RestException(Status.CONFLICT, "The broker still have in-flight topics"
-                                                    + " created during namespace deletion, please try again."));
+                                                    + " created during namespace deletion or some bundle is still owned, please try again."));
                                     // drop out recursive
                                 }
                                 return;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1545,10 +1545,17 @@ public class NamespaceService implements AutoCloseable {
     }
 
     public CompletableFuture<Boolean> checkOwnershipPresentAsync(NamespaceBundle bundle) {
+        return checkOwnershipPresentAsync(bundle, false);
+    }
+
+    public CompletableFuture<Boolean> checkOwnershipPresentAsync(NamespaceBundle bundle, boolean refresh) {
         if (ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(pulsar)) {
             ExtensibleLoadManagerImpl extensibleLoadManager = ExtensibleLoadManagerImpl.get(loadManager.get());
             return extensibleLoadManager.getOwnershipAsync(Optional.empty(), bundle)
                     .thenApply(Optional::isPresent);
+        }
+        if (refresh) {
+            ownershipCache.invalidateLocalOwnerCache(bundle);
         }
         return getOwnerAsync(bundle).thenApply(Optional::isPresent);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1545,17 +1545,10 @@ public class NamespaceService implements AutoCloseable {
     }
 
     public CompletableFuture<Boolean> checkOwnershipPresentAsync(NamespaceBundle bundle) {
-        return checkOwnershipPresentAsync(bundle, false);
-    }
-
-    public CompletableFuture<Boolean> checkOwnershipPresentAsync(NamespaceBundle bundle, boolean refresh) {
         if (ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(pulsar)) {
             ExtensibleLoadManagerImpl extensibleLoadManager = ExtensibleLoadManagerImpl.get(loadManager.get());
             return extensibleLoadManager.getOwnershipAsync(Optional.empty(), bundle)
                     .thenApply(Optional::isPresent);
-        }
-        if (refresh) {
-            ownershipCache.invalidateLocalOwnerCache(bundle);
         }
         return getOwnerAsync(bundle).thenApply(Optional::isPresent);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnershipCache.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnershipCache.java
@@ -208,11 +208,11 @@ public class OwnershipCache {
      */
     public CompletableFuture<Void> removeOwnership(NamespaceBundle bundle) {
         ResourceLock<NamespaceEphemeralData> lock = locallyAcquiredLocks.remove(bundle);
+        log.info("Removing ownership of {} (current lock is {})", bundle, lock);
         if (lock == null) {
             // We don't own the specified bundle anymore
             return CompletableFuture.completedFuture(null);
         }
-
         return lock.release();
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -320,6 +320,10 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
             boolean readerCachedAndNotFailed = readerCompletableFuture != null
                     && readerCompletableFuture.isDone()
                     && !readerCompletableFuture.isCompletedExceptionally();
+            boolean completedExceptionally = readerCompletableFuture != null
+                    && readerCompletableFuture.isCompletedExceptionally();
+            log.info("[{}] addOwnedNamespaceBundleAsync, readerCachedAndNotFailed: {}, completedExceptionally: {}", namespace,
+                    readerCachedAndNotFailed, completedExceptionally);
             if (readerCachedAndNotFailed) {
                 ownedBundlesCountPerNamespace.get(namespace).incrementAndGet();
                 return CompletableFuture.completedFuture(null);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -315,7 +315,12 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
             return CompletableFuture.completedFuture(null);
         }
         synchronized (this) {
-            if (readerCaches.get(namespace) != null) {
+            CompletableFuture<SystemTopicClient.Reader<PulsarEvent>> readerCompletableFuture =
+                    readerCaches.get(namespace);
+            boolean readerCachedAndNotFailed = readerCompletableFuture != null
+                    && readerCompletableFuture.isDone()
+                    && !readerCompletableFuture.isCompletedExceptionally();
+            if (readerCachedAndNotFailed) {
                 ownedBundlesCountPerNamespace.get(namespace).incrementAndGet();
                 return CompletableFuture.completedFuture(null);
             } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -900,8 +900,7 @@ public abstract class PulsarWebResource {
                 if (!allowDeletedNamespace && policies.deleted) {
                     String msg = String.format("Namespace %s is deleted", namespace.toString());
                     log.warn(msg);
-                    validationFuture.completeExceptionally(new RestException(Status.NOT_FOUND,
-                            "Namespace is deleted"));
+                    validationFuture.completeExceptionally(new RestException(Status.NOT_FOUND, msg));
                 } else if (policies.replication_clusters.isEmpty()) {
                     String msg = String.format(
                             "Namespace does not have any clusters configured : local_cluster=%s ns=%s",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -898,7 +898,7 @@ public abstract class PulsarWebResource {
             if (policiesResult.isPresent()) {
                 Policies policies = policiesResult.get();
                 if (!allowDeletedNamespace && policies.deleted) {
-                    String msg = String.format("Namespace %s is deleted", namespace.toString());
+                    String msg = String.format("Namespace %s is marked as deleted", namespace.toString());
                     log.warn(msg);
                     validationFuture.completeExceptionally(new RestException(Status.NOT_FOUND, msg));
                 } else if (policies.replication_clusters.isEmpty()) {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
@@ -91,6 +91,7 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
                         if (store instanceof AbstractMetadataStore && ((AbstractMetadataStore) store).isConnected()) {
                             return readValueFromStore(key);
                         } else {
+                            log.error("Cannot refresh cache item for key {} because we're not connected to the metadata store", key);
                             // Do not try to refresh the cache item if we know that we're not connected to the
                             // metadata store
                             return CompletableFuture.completedFuture(oldValue);
@@ -216,6 +217,7 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
         }
 
         CompletableFuture<Void> future = new CompletableFuture<>();
+        log.info("Creating path {} with value {}", path, value);
         store.put(path, content, Optional.of(-1L))
                 .thenAccept(stat -> {
                     // Make sure we have the value cached before the operation is completed


### PR DESCRIPTION
This patch adds much debug during namespace deletion.

There is a fix for a potential race condition in which:
- the local cache that knows whether a bundle is assigned is empty
- the ephemeral z-node /namespace/tenant/namespace/XXXXXX with the id of the bundle is still there 

Under this condition the broker tries to delete the  /namespace/tenant/namespace and it fails, reporting a misleading error about topics created during the deletion.

I have reproduced the case manually a few times but I don't have a way of consistently reproducing the problem, currently I need 6 brokers with 3 zookeeper nodes.
The fact that I need such system makes me suspect of some problem in the local cache about bundle ownership, that goes out of sync: maybe because the local broker is connected to another zookeeper server in respect to the old "owner" that released the ephemeral node while unloading the bundle?

