### PR TITLE
ManagedCursor: compress data written to BookKeeper (POC)

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -23,6 +23,7 @@ on:
     branches:
       - master
       - 3.1_ds
+      - 3.1_fx
   schedule:
     - cron: '0 12 * * *'
   workflow_dispatch:

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/LedgerMetadataUtils.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/LedgerMetadataUtils.java
@@ -74,8 +74,12 @@ public final class LedgerMetadataUtils {
      * @see #buildBaseManagedLedgerMetadata(java.lang.String)
      */
     static Map<String, byte[]> buildAdditionalMetadataForCursor(String name, String compressionType) {
-        return Map.of(METADATA_PROPERTY_CURSOR_NAME, name.getBytes(StandardCharsets.UTF_8),
-                METADATA_PROPERTY_CURSOR_COMPRESSION_TYPE, compressionType.getBytes(StandardCharsets.UTF_8));
+        if (compressionType != null) {
+            return Map.of(METADATA_PROPERTY_CURSOR_NAME, name.getBytes(StandardCharsets.UTF_8),
+                    METADATA_PROPERTY_CURSOR_COMPRESSION_TYPE, compressionType.getBytes(StandardCharsets.UTF_8));
+        } else {
+            return Map.of(METADATA_PROPERTY_CURSOR_NAME, name.getBytes(StandardCharsets.UTF_8));
+        }
     }
 
     /**

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/LedgerMetadataUtils.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/LedgerMetadataUtils.java
@@ -44,6 +44,7 @@ public final class LedgerMetadataUtils {
 
     private static final String METADATA_PROPERTY_MANAGED_LEDGER_NAME = "pulsar/managed-ledger";
     private static final String METADATA_PROPERTY_CURSOR_NAME = "pulsar/cursor";
+    public static final String METADATA_PROPERTY_CURSOR_COMPRESSION_TYPE = "pulsar/cursor-compressionType";
     private static final String METADATA_PROPERTY_COMPACTEDTOPIC = "pulsar/compactedTopic";
     private static final String METADATA_PROPERTY_COMPACTEDTO = "pulsar/compactedTo";
     private static final String METADATA_PROPERTY_SCHEMAID = "pulsar/schemaId";
@@ -72,8 +73,9 @@ public final class LedgerMetadataUtils {
      * @return an immutable map which describes the cursor
      * @see #buildBaseManagedLedgerMetadata(java.lang.String)
      */
-    static Map<String, byte[]> buildAdditionalMetadataForCursor(String name) {
-        return Map.of(METADATA_PROPERTY_CURSOR_NAME, name.getBytes(StandardCharsets.UTF_8));
+    static Map<String, byte[]> buildAdditionalMetadataForCursor(String name, String compressionType) {
+        return Map.of(METADATA_PROPERTY_CURSOR_NAME, name.getBytes(StandardCharsets.UTF_8),
+                METADATA_PROPERTY_CURSOR_COMPRESSION_TYPE, compressionType.getBytes(StandardCharsets.UTF_8));
     }
 
     /**

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -640,7 +640,8 @@ public class ManagedCursorImpl implements ManagedCursor {
     }
 
     private void recoverIndividualDeletedMessages(List<MLDataFormats.MessageRange> individualDeletedMessagesList) {
-        log.info("[{}] [{}] Recovering individual deleted messages. Number of ranges: {}", ledger.getName(), name, individualDeletedMessagesList.size());
+        log.info("[{}] [{}] Recovering individual deleted messages. Number of ranges: {}",
+                ledger.getName(), name, individualDeletedMessagesList.size());
         lock.writeLock().lock();
         try {
             individualDeletedMessages.clear();
@@ -3015,7 +3016,8 @@ public class ManagedCursorImpl implements ManagedCursor {
     private List<MLDataFormats.MessageRange> buildIndividualDeletedMessageRanges() {
         lock.readLock().lock();
         try {
-            log.info("[{}] [{}] buildIndividualDeletedMessageRanges, numRanges {}", ledger.getName(), name, individualDeletedMessages.size());
+            log.info("[{}] [{}] buildIndividualDeletedMessageRanges, numRanges {}",
+                    ledger.getName(), name, individualDeletedMessages.size());
             if (individualDeletedMessages.isEmpty()) {
                 this.individualDeletedMessagesSerializedSize = 0;
                 return Collections.emptyList();
@@ -3054,8 +3056,11 @@ public class ManagedCursorImpl implements ManagedCursor {
 
             this.individualDeletedMessagesSerializedSize = acksSerializedSize.get();
             individualDeletedMessages.resetDirtyKeys();
-            log.info("[{}] [{}] buildIndividualDeletedMessageRanges, numRanges {} individualDeletedMessagesSerializedSize {} rangeListSize {} maxUnackedRangesToPersist {}",
-                    ledger.getName(), name, individualDeletedMessages.size(), individualDeletedMessagesSerializedSize, rangeList.size(), config.getMaxUnackedRangesToPersist());
+            log.info("[{}] [{}] buildIndividualDeletedMessageRanges, numRanges {} "
+                            + "individualDeletedMessagesSerializedSize {} rangeListSize {} "
+                            + "maxUnackedRangesToPersist {}",
+                    ledger.getName(), name, individualDeletedMessages.size(),
+                    individualDeletedMessagesSerializedSize, rangeList.size(), config.getMaxUnackedRangesToPersist());
 
             return rangeList;
         } finally {
@@ -3114,7 +3119,8 @@ public class ManagedCursorImpl implements ManagedCursor {
 
         byte[] data = compressDataIfNeeded(rawData, lh);
 
-        log.info("[{}] Cursor {} Appending to ledger={} position={} data size {} bytes", ledger.getName(), name, lh.getId(),
+        log.info("[{}] Cursor {} Appending to ledger={} position={} data size {} bytes",
+                ledger.getName(), name, lh.getId(),
                 position, data.length);
 
         lh.asyncAddEntry(data, (rc, lh1, entryId, ctx) -> {
@@ -3143,7 +3149,8 @@ public class ManagedCursorImpl implements ManagedCursor {
     }
 
     private byte[] compressDataIfNeeded(byte[] data, LedgerHandle lh) {
-        byte[] pulsarCursorInfoCompression = lh.getCustomMetadata().get(METADATA_PROPERTY_CURSOR_COMPRESSION_TYPE);
+        byte[] pulsarCursorInfoCompression =
+                lh.getCustomMetadata().get(METADATA_PROPERTY_CURSOR_COMPRESSION_TYPE);
         if (pulsarCursorInfoCompression != null) {
             String pulsarCursorInfoCompressionString = new String(pulsarCursorInfoCompression);
             CompressionCodec compressionCodec = CompressionCodecProvider.getCompressionCodec(
@@ -3172,7 +3179,8 @@ public class ManagedCursorImpl implements ManagedCursor {
     }
 
     private static byte[] decompressDataIfNeeded(byte[] data, LedgerHandle lh) {
-        byte[] pulsarCursorInfoCompression = lh.getCustomMetadata().get(METADATA_PROPERTY_CURSOR_COMPRESSION_TYPE);
+        byte[] pulsarCursorInfoCompression =
+                lh.getCustomMetadata().get(METADATA_PROPERTY_CURSOR_COMPRESSION_TYPE);
         if (pulsarCursorInfoCompression != null) {
             String pulsarCursorInfoCompressionString = new String(pulsarCursorInfoCompression);
             CompressionCodec compressionCodec = CompressionCodecProvider.getCompressionCodec(

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -21,6 +21,7 @@ package org.apache.bookkeeper.mledger.impl;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 import static org.apache.bookkeeper.mledger.ManagedLedgerException.getManagedLedgerException;
+import static org.apache.bookkeeper.mledger.impl.LedgerMetadataUtils.METADATA_PROPERTY_CURSOR_COMPRESSION_TYPE;
 import static org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.DEFAULT_LEDGER_DELETE_BACKOFF_TIME_SEC;
 import static org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.DEFAULT_LEDGER_DELETE_RETRIES;
 import static org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.createManagedLedgerException;
@@ -32,6 +33,14 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.protobuf.InvalidProtocolBufferException;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.time.Clock;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -96,6 +105,9 @@ import org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.PositionInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.StringProperty;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pulsar.common.api.proto.CompressionType;
+import org.apache.pulsar.common.compression.CompressionCodec;
+import org.apache.pulsar.common.compression.CompressionCodecProvider;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.collections.BitSetRecyclable;
 import org.apache.pulsar.common.util.collections.LongPairRangeSet;
@@ -122,6 +134,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     protected final ManagedLedgerConfig config;
     protected final ManagedLedgerImpl ledger;
     private final String name;
+    private final String cursorInfoCompressionType;
 
     public static final String CURSOR_INTERNAL_PROPERTY_PREFIX = "#pulsar.internal.";
 
@@ -329,6 +342,7 @@ public class ManagedCursorImpl implements ManagedCursor {
             markDeleteLimiter = null;
         }
         this.mbean = new ManagedCursorMXBeanImpl(this);
+        this.cursorInfoCompressionType = ledger.getFactory().getConfig().getManagedCursorInfoCompressionType();
     }
 
     private void updateCursorLedgerStat(ManagedCursorInfo cursorInfo, Stat stat) {
@@ -582,11 +596,14 @@ public class ManagedCursorImpl implements ManagedCursor {
                 mbean.addReadCursorLedgerSize(entry.getLength());
                 PositionInfo positionInfo;
                 try {
-                    positionInfo = PositionInfo.parseFrom(entry.getEntry());
+                    byte[] data = entry.getEntry();
+                    data = decompressDataIfNeeded(data, lh);
+                    positionInfo = PositionInfo.parseFrom(data);
                 } catch (InvalidProtocolBufferException e) {
                     callback.operationFailed(new ManagedLedgerException(e));
                     return;
                 }
+                log.info("[{}] Cursor {} recovered to position {}", ledger.getName(), name, positionInfo);
 
                 Map<String, Long> recoveredProperties = Collections.emptyMap();
                 if (positionInfo.getPropertiesCount() > 0) {
@@ -597,6 +614,9 @@ public class ManagedCursorImpl implements ManagedCursor {
                         recoveredProperties.put(property.getName(), property.getValue());
                     }
                 }
+
+                log.info("[{}] Cursor {} recovered with recoveredProperties {}, individualDeletedMessagesCount {}",
+                        ledger.getName(), name, recoveredProperties, positionInfo.getIndividualDeletedMessagesCount());
 
                 PositionImpl position = new PositionImpl(positionInfo);
                 if (positionInfo.getIndividualDeletedMessagesCount() > 0) {
@@ -620,6 +640,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     }
 
     private void recoverIndividualDeletedMessages(List<MLDataFormats.MessageRange> individualDeletedMessagesList) {
+        log.info("[{}] [{}] Recovering individual deleted messages. Number of ranges: {}", ledger.getName(), name, individualDeletedMessagesList.size());
         lock.writeLock().lock();
         try {
             individualDeletedMessages.clear();
@@ -2943,7 +2964,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                 }
                 future.complete(lh);
             });
-        }, LedgerMetadataUtils.buildAdditionalMetadataForCursor(name));
+        }, LedgerMetadataUtils.buildAdditionalMetadataForCursor(name, cursorInfoCompressionType));
 
         return future;
     }
@@ -2994,6 +3015,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     private List<MLDataFormats.MessageRange> buildIndividualDeletedMessageRanges() {
         lock.readLock().lock();
         try {
+            log.info("[{}] [{}] buildIndividualDeletedMessageRanges, numRanges {}", ledger.getName(), name, individualDeletedMessages.size());
             if (individualDeletedMessages.isEmpty()) {
                 this.individualDeletedMessagesSerializedSize = 0;
                 return Collections.emptyList();
@@ -3032,6 +3054,9 @@ public class ManagedCursorImpl implements ManagedCursor {
 
             this.individualDeletedMessagesSerializedSize = acksSerializedSize.get();
             individualDeletedMessages.resetDirtyKeys();
+            log.info("[{}] [{}] buildIndividualDeletedMessageRanges, numRanges {} individualDeletedMessagesSerializedSize {} rangeListSize {} maxUnackedRangesToPersist {}",
+                    ledger.getName(), name, individualDeletedMessages.size(), individualDeletedMessagesSerializedSize, rangeList.size(), config.getMaxUnackedRangesToPersist());
+
             return rangeList;
         } finally {
             lock.readLock().unlock();
@@ -3085,7 +3110,13 @@ public class ManagedCursorImpl implements ManagedCursor {
         }
 
         requireNonNull(lh);
-        byte[] data = pi.toByteArray();
+        byte[] rawData = pi.toByteArray();
+
+        byte[] data = compressDataIfNeeded(rawData, lh);
+
+        log.info("[{}] Cursor {} Appending to ledger={} position={} data size {} bytes", ledger.getName(), name, lh.getId(),
+                position, data.length);
+
         lh.asyncAddEntry(data, (rc, lh1, entryId, ctx) -> {
             if (rc == BKException.Code.OK) {
                 if (log.isDebugEnabled()) {
@@ -3109,6 +3140,60 @@ public class ManagedCursorImpl implements ManagedCursor {
                 persistPositionToMetaStore(mdEntry, callback);
             }
         }, null);
+    }
+
+    private byte[] compressDataIfNeeded(byte[] data, LedgerHandle lh) {
+        byte[] pulsarCursorInfoCompression = lh.getCustomMetadata().get(METADATA_PROPERTY_CURSOR_COMPRESSION_TYPE);
+        if (pulsarCursorInfoCompression != null) {
+            String pulsarCursorInfoCompressionString = new String(pulsarCursorInfoCompression);
+            CompressionCodec compressionCodec = CompressionCodecProvider.getCompressionCodec(
+                    CompressionType.valueOf(pulsarCursorInfoCompressionString));
+            ByteBuf encode = compressionCodec.encode(Unpooled.wrappedBuffer(data));
+            try {
+                int uncompressedSize = data.length;
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                DataOutputStream dataOutputStream = new DataOutputStream(out);
+                dataOutputStream.writeInt(uncompressedSize);
+                dataOutputStream.write(ByteBufUtil.getBytes(encode));
+                dataOutputStream.flush();
+                byte[] result =  out.toByteArray();
+                int ratio = (int) (result.length * 100.0 / uncompressedSize);
+                log.info("[{}] Cursor {} Compressed data size {} bytes (with {}, original size {} bytes, ratio {}%)",
+                        ledger.getName(), name, result.length, pulsarCursorInfoCompressionString, data.length, ratio);
+                return result;
+            } catch (IOException error) {
+                throw new RuntimeException(error);
+            } finally {
+                encode.release();
+            }
+        } else {
+            return data;
+        }
+    }
+
+    private static byte[] decompressDataIfNeeded(byte[] data, LedgerHandle lh) {
+        byte[] pulsarCursorInfoCompression = lh.getCustomMetadata().get(METADATA_PROPERTY_CURSOR_COMPRESSION_TYPE);
+        if (pulsarCursorInfoCompression != null) {
+            String pulsarCursorInfoCompressionString = new String(pulsarCursorInfoCompression);
+            CompressionCodec compressionCodec = CompressionCodecProvider.getCompressionCodec(
+                    CompressionType.valueOf(pulsarCursorInfoCompressionString));
+            ByteArrayInputStream input = new ByteArrayInputStream(data);
+            DataInputStream dataInputStream = new DataInputStream(input);
+            try {
+                int uncompressedSize = dataInputStream.readInt();
+                byte[] compressedData = dataInputStream.readNBytes(uncompressedSize);
+                ByteBuf decode = compressionCodec.decode(Unpooled.wrappedBuffer(compressedData), uncompressedSize);
+                try {
+                    return ByteBufUtil.getBytes(decode);
+                } finally {
+                    decode.release();
+                }
+            } catch (IOException error) {
+                throw new RuntimeException(error);
+            }
+        } else {
+            return data;
+        }
     }
 
     public boolean periodicRollover() {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
@@ -453,8 +453,13 @@ public class MetaStoreImpl implements MetaStore, Consumer<Notification> {
             try {
                 MLDataFormats.ManagedLedgerInfoMetadata metadata =
                         MLDataFormats.ManagedLedgerInfoMetadata.parseFrom(metadataBytes);
-                return ManagedLedgerInfo.parseFrom(getCompressionCodec(metadata.getCompressionType())
-                        .decode(byteBuf, metadata.getUncompressedSize()).nioBuffer());
+                ByteBuf decode = getCompressionCodec(metadata.getCompressionType())
+                        .decode(byteBuf, metadata.getUncompressedSize());
+                try {
+                    return ManagedLedgerInfo.parseFrom(decode.nioBuffer());
+                } finally {
+                    decode.release();
+                }
             } catch (Exception e) {
                 log.error("Failed to parse managedLedgerInfo metadata, "
                         + "fall back to parse managedLedgerInfo directly.", e);
@@ -475,8 +480,13 @@ public class MetaStoreImpl implements MetaStore, Consumer<Notification> {
             try {
                 MLDataFormats.ManagedCursorInfoMetadata metadata =
                         MLDataFormats.ManagedCursorInfoMetadata.parseFrom(metadataBytes);
-                return ManagedCursorInfo.parseFrom(getCompressionCodec(metadata.getCompressionType())
-                        .decode(byteBuf, metadata.getUncompressedSize()).nioBuffer());
+                ByteBuf decode = getCompressionCodec(metadata.getCompressionType())
+                        .decode(byteBuf, metadata.getUncompressedSize());
+                try {
+                    return ManagedCursorInfo.parseFrom(decode.nioBuffer());
+                } finally {
+                    decode.release();
+                }
             } catch (Exception e) {
                 log.error("Failed to parse ManagedCursorInfo metadata, "
                         + "fall back to parse ManagedCursorInfo directly", e);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -21,6 +21,7 @@ package org.apache.bookkeeper.mledger.impl;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -3412,6 +3413,11 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         when(ml.getNextValidLedger(markDeleteLedgerId)).thenReturn(3L);
         when(ml.getNextValidPosition(lastPosition)).thenReturn(nextPosition);
         when(ml.ledgerExists(markDeleteLedgerId)).thenReturn(false);
+
+        ManagedLedgerFactoryImpl factory = mock(ManagedLedgerFactoryImpl.class);
+        ManagedLedgerFactoryConfig factoryConfig = new ManagedLedgerFactoryConfig();
+        doReturn(factoryConfig).when(factory).getConfig();
+        when(ml.getFactory()).thenReturn(factory);
 
         BookKeeper mockBookKeeper = mock(BookKeeper.class);
         final ManagedCursorImpl cursor = new ManagedCursorImpl(mockBookKeeper, new ManagedLedgerConfig(), ml,


### PR DESCRIPTION
Modification:
- compress the cursor info when it is written to the ledger, before this patch only the data written to zookeeper was compressed
- fix a memory leak in the compression mechanism while writing to zookeeper
- add some debug lines to see the size of the data being written and the efficiency of compression, apparently ZSTD is the best for this kind of data (the compressed size is 12% of the original size)

Please note that in BK the max entry size is 5MB

With this patch it is possible to reach these values:
```
managedLedgerMaxUnackedRangesToPersist=2000000
managedCursorInfoCompressionType=ZSTD
managedCursorInfoCompressionThresholdInBytes=262144
managedLedgerMaxUnackedRangesToPersistInMetadataStore=1000
```

Please note that managedLedgerMaxUnackedRangesToPersist is per subscription and per partition, if you have 3 partitions and acks are equally distributed across the partions you can store up to 6 million ranges of holes


The serialized size is around 17 * numRanges, and if compressed data is 12% of the original data you have a maximum value of ~2.500.000 for numRanges.

This means that ideally you can store up to 2.500.000 "ranges" per partition, but this really depends on the numbers and the charactheristics of the "holes" in the sequence

A follow up work is to dump the data into multiple BK entries instead of only one, but the change is a little more involved