### PR TITLE
ManagedLedger proto to use lightproto instead of protobuf

### DIFF
--- a/managed-ledger/pom.xml
+++ b/managed-ledger/pom.xml
@@ -160,18 +160,16 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.xolstice.maven.plugins</groupId>
-        <artifactId>protobuf-maven-plugin</artifactId>
-        <version>${protobuf-maven-plugin.version}</version>
+        <groupId>com.github.splunk.lightproto</groupId>
+        <artifactId>lightproto-maven-plugin</artifactId>
+        <version>${lightproto-maven-plugin.version}</version>
         <configuration>
-          <protocArtifact>com.google.protobuf:protoc:${protoc3.version}:exe:${os.detected.classifier}</protocArtifact>
-          <checkStaleness>true</checkStaleness>
+          <singleOuterClass>true</singleOuterClass>
         </configuration>
         <executions>
           <execution>
-            <phase>generate-sources</phase>
             <goals>
-              <goal>compile</goal>
+              <goal>generate</goal>
             </goals>
           </execution>
         </executions>

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/LightProtoHelper.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/LightProtoHelper.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import org.apache.bookkeeper.mledger.proto.MLDataFormats;
+
+public abstract class LightProtoHelper {
+
+    public static MLDataFormats.ManagedLedgerInfo.LedgerInfo createLedgerInfo() {
+        MLDataFormats.ManagedLedgerInfo.LedgerInfo li =  new MLDataFormats.ManagedLedgerInfo.LedgerInfo();
+
+        // light proto doesn't return MLDataFormats.OffloadContext.getDefaultInstance()
+        // if it wasn't explicitly set and a lot of code expects that behavior
+        li.setOffloadContext()
+                .setBookkeeperDeleted(false)
+                .setComplete(false)
+                .setTimestamp(-1L); // like protobuf default instance
+        li.setOffloadContext()
+                .setDriverMetadata()
+                .setName(""); // like protobuf default instance
+
+// stuff like this seems to be a bad idea,
+// unlike protobuf that just creates empty collection,
+// these will add empty object to that collection.
+// so this is something we can't mimic from protobuf
+//   li.setOffloadContext().setDriverMetadata().addProperty();
+//   li.setOffloadContext().addOffloadSegment();
+        return li;
+    }
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/LightProtoHelper.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/LightProtoHelper.java
@@ -24,23 +24,6 @@ public abstract class LightProtoHelper {
 
     public static MLDataFormats.ManagedLedgerInfo.LedgerInfo createLedgerInfo() {
         MLDataFormats.ManagedLedgerInfo.LedgerInfo li =  new MLDataFormats.ManagedLedgerInfo.LedgerInfo();
-
-        // light proto doesn't return MLDataFormats.OffloadContext.getDefaultInstance()
-        // if it wasn't explicitly set and a lot of code expects that behavior
-        li.setOffloadContext()
-                .setBookkeeperDeleted(false)
-                .setComplete(false)
-                .setTimestamp(-1L); // like protobuf default instance
-        li.setOffloadContext()
-                .setDriverMetadata()
-                .setName(""); // like protobuf default instance
-
-// stuff like this seems to be a bad idea,
-// unlike protobuf that just creates empty collection,
-// these will add empty object to that collection.
-// so this is something we can't mimic from protobuf
-//   li.setOffloadContext().setDriverMetadata().addProperty();
-//   li.setOffloadContext().addOffloadSegment();
         return li;
     }
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -3076,12 +3076,12 @@ public class ManagedCursorImpl implements ManagedCursor {
             if (!config.isDeletionAtBatchIndexLevelEnabled() || batchDeletedIndexes.isEmpty()) {
                 return Collections.emptyList();
             }
-            MLDataFormats.BatchedEntryDeletionIndexInfo batchDeletedIndexInfoBuilder = new MLDataFormats
-                    .BatchedEntryDeletionIndexInfo();
             List<MLDataFormats.BatchedEntryDeletionIndexInfo> result = new ArrayList<>();
             Iterator<Map.Entry<PositionImpl, BitSetRecyclable>> iterator = batchDeletedIndexes.entrySet().iterator();
             while (iterator.hasNext() && result.size() < config.getMaxBatchDeletedIndexToPersist()) {
                 Map.Entry<PositionImpl, BitSetRecyclable> entry = iterator.next();
+                MLDataFormats.BatchedEntryDeletionIndexInfo batchDeletedIndexInfoBuilder = new MLDataFormats
+                        .BatchedEntryDeletionIndexInfo();
                 batchDeletedIndexInfoBuilder.setPosition()
                         .setLedgerId(entry.getKey().getLedgerId())
                         .setEntryId(entry.getKey().getEntryId());
@@ -3089,7 +3089,6 @@ public class ManagedCursorImpl implements ManagedCursor {
                 for (long l : array) {
                     batchDeletedIndexInfoBuilder.addDeleteSet(l);
                 }
-                batchDeletedIndexInfoBuilder.clearDeleteSet();
                 result.add(batchDeletedIndexInfoBuilder);
             }
             return result;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -959,7 +959,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
 
                             MLDataFormats.ManagedLedgerInfo.LedgerInfo ls = ledgerInfos.get(li.ledgerId);
 
-                            if (ls.getOffloadContext().hasUidMsb()) {
+                            if (ls.hasOffloadContext() && ls.getOffloadContext().hasUidMsb()) {
                                 MLDataFormats.ManagedLedgerInfo.LedgerInfo newInfoBuilder =
                                         new MLDataFormats.ManagedLedgerInfo.LedgerInfo().copyFrom(ls);
                                 newInfoBuilder.setOffloadContext().setBookkeeperDeleted(true);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3783,7 +3783,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             return null;
         }
         if (ledgerId > lastConfirmedEntry.getLedgerId()) {
-            checkState(ledgers.get(ledgerId).getEntries() == 0);
+            checkState(!ledgers.get(ledgerId).hasEntries() || ledgers.get(ledgerId).getEntries() == 0);
             ledgerId = lastConfirmedEntry.getLedgerId();
         }
         return new PositionImpl(ledgerId, -1);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2807,7 +2807,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             doDeleteLedgers(ledgersToDelete);
 
             for (LedgerInfo ls : offloadedLedgersToDelete) {
-                LedgerInfo newInfoBuilder = createLedgerInfo();
+                LedgerInfo newInfoBuilder = createLedgerInfo().copyFrom(ls);
                 newInfoBuilder.setOffloadContext().setBookkeeperDeleted(true);
                 String driverName = OffloadUtils.getOffloadDriverName(ls,
                         config.getLedgerOffloader().getOffloadDriverName());

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -21,6 +21,7 @@ package org.apache.bookkeeper.mledger.impl;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.Math.min;
+import static org.apache.bookkeeper.mledger.impl.LightProtoHelper.createLedgerInfo;
 import static org.apache.bookkeeper.mledger.util.Errors.isNoSuchLedgerExistsException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.BoundType;
@@ -414,7 +415,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                                 log.debug("[{}] Opened ledger {}: {}", name, id, BKException.getMessage(rc));
                             }
                             if (rc == BKException.Code.OK) {
-                                LedgerInfo info = new LedgerInfo().setLedgerId(id)
+                                LedgerInfo info = createLedgerInfo().setLedgerId(id)
                                         .setEntries(lh.getLastAddConfirmed() + 1).setSize(lh.getLength())
                                         .setTimestamp(clock.millis());
                                 ledgers.put(id, info);
@@ -546,7 +547,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     }
                 }
 
-                LedgerInfo info = new LedgerInfo().setLedgerId(lh.getId()).setTimestamp(0);
+                LedgerInfo info = createLedgerInfo().setLedgerId(lh.getId()).setTimestamp(0);
                 ledgers.put(lh.getId(), info);
 
                 // Save it back to ensure all nodes exist
@@ -1574,7 +1575,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             lastLedgerCreationFailureTimestamp = clock.millis();
         } else {
             log.info("[{}] Created new ledger {}", name, lh.getId());
-            LedgerInfo newLedger = new LedgerInfo().setLedgerId(lh.getId()).setTimestamp(0);
+            LedgerInfo newLedger = createLedgerInfo().setLedgerId(lh.getId()).setTimestamp(0);
             final MetaStoreCallback<Void> cb = new MetaStoreCallback<Void>() {
                 @Override
                 public void operationComplete(Void v, Stat stat) {
@@ -1743,7 +1744,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             log.debug("[{}] Ledger has been closed id={} entries={}", name, lh.getId(), entriesInLedger);
         }
         if (entriesInLedger > 0) {
-            LedgerInfo info = new LedgerInfo().setLedgerId(lh.getId()).setEntries(entriesInLedger)
+            LedgerInfo info = createLedgerInfo().setLedgerId(lh.getId()).setEntries(entriesInLedger)
                     .setSize(lh.getLength()).setTimestamp(clock.millis());
             ledgers.put(lh.getId(), info);
         } else {
@@ -2806,7 +2807,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             doDeleteLedgers(ledgersToDelete);
 
             for (LedgerInfo ls : offloadedLedgersToDelete) {
-                LedgerInfo newInfoBuilder = new LedgerInfo();
+                LedgerInfo newInfoBuilder = createLedgerInfo();
                 newInfoBuilder.setOffloadContext().setBookkeeperDeleted(true);
                 String driverName = OffloadUtils.getOffloadDriverName(ls,
                         config.getLedgerOffloader().getOffloadDriverName());
@@ -3456,7 +3457,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                                                name,
                                                scheduledExecutor);
                                        }
-                                       LedgerInfo builder = new LedgerInfo().copyFrom(oldInfo);
+                                       LedgerInfo builder = createLedgerInfo().copyFrom(oldInfo);
                                        builder.setOffloadContext()
                                            .setUidMsb(uuid.getMostSignificantBits())
                                            .setUidLsb(uuid.getLeastSignificantBits());
@@ -3484,7 +3485,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                                        UUID existingUuid = new UUID(oldInfo.getOffloadContext().getUidMsb(),
                                                                     oldInfo.getOffloadContext().getUidLsb());
                                        if (existingUuid.equals(uuid)) {
-                                           LedgerInfo builder = new LedgerInfo().copyFrom(oldInfo);
+                                           LedgerInfo builder = createLedgerInfo().copyFrom(oldInfo);
                                            builder.setOffloadContext()
                                                .setTimestamp(clock.millis())
                                                .setComplete(true);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
@@ -20,6 +20,7 @@ package org.apache.bookkeeper.mledger.impl;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import java.util.ArrayList;
@@ -456,9 +457,12 @@ public class MetaStoreImpl implements MetaStore, Consumer<Notification> {
                 // unfortunately have to copy buffer to unpooled instead of passing `decode` directly.
                 // parseFrom() keeps reference to ByteBuf internally
                 // and does not provide a way to release it.
-                ByteBuf uncompressed = Unpooled.copiedBuffer(decode);
-                decode.release();
-                info.parseFrom(uncompressed, uncompressed.readableBytes());
+                try {
+                    byte[] uncompressed = ByteBufUtil.getBytes(decode);
+                    info.parseFrom(uncompressed);
+                } finally {
+                    decode.release();
+                }
                 return info;
             } catch (Exception e) {
                 log.error("Failed to parse managedLedgerInfo metadata, "
@@ -492,9 +496,12 @@ public class MetaStoreImpl implements MetaStore, Consumer<Notification> {
                 // unfortunately have to copy buffer to unpooled instead of passing `decode` directly.
                 // parseFrom() keeps reference to ByteBuf internally
                 // and does not provide a way to release it.
-                ByteBuf uncompressed = Unpooled.copiedBuffer(decode);
-                decode.release();
-                info.parseFrom(uncompressed, uncompressed.readableBytes());
+                try {
+                    byte[] uncompressed = ByteBufUtil.getBytes(decode);
+                    info.parseFrom(uncompressed);
+                } finally {
+                    decode.release();
+                }
                 return info;
             } catch (Exception e) {
                 log.error("Failed to parse ManagedCursorInfo metadata, "

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/PositionImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/PositionImpl.java
@@ -163,6 +163,6 @@ public class PositionImpl implements Position, Comparable<PositionImpl> {
     }
 
     public PositionInfo getPositionInfo() {
-        return PositionInfo.newBuilder().setLedgerId(ledgerId).setEntryId(entryId).build();
+        return new PositionInfo().setLedgerId(ledgerId).setEntryId(entryId);
     }
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImpl.java
@@ -36,6 +36,8 @@ import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo;
 import org.apache.pulsar.metadata.api.Stat;
 
+import static org.apache.bookkeeper.mledger.impl.LightProtoHelper.createLedgerInfo;
+
 @Slf4j
 public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {
 
@@ -67,7 +69,7 @@ public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {
                             .withDigestType(config.getDigestType()).withPassword(config.getPassword()).execute()
                             .thenAccept(readHandle -> {
                                 readHandle.readLastAddConfirmedAsync().thenAccept(lastAddConfirmed -> {
-                                    LedgerInfo info = new LedgerInfo().setLedgerId(lastLedgerId)
+                                    LedgerInfo info = createLedgerInfo().setLedgerId(lastLedgerId)
                                             .setEntries(lastAddConfirmed + 1).setSize(readHandle.getLength())
                                             .setTimestamp(clock.millis());
                                     ledgers.put(lastLedgerId, info);
@@ -77,7 +79,7 @@ public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {
                                     if (ex instanceof CompletionException
                                             && ex.getCause() instanceof IllegalArgumentException) {
                                         // The last ledger was empty, so we cannot read the last add confirmed.
-                                        LedgerInfo info = new LedgerInfo().setLedgerId(lastLedgerId)
+                                        LedgerInfo info = createLedgerInfo().setLedgerId(lastLedgerId)
                                                 .setEntries(0).setSize(0).setTimestamp(clock.millis());
                                         ledgers.put(lastLedgerId, info);
                                         future.complete(null);
@@ -90,7 +92,7 @@ public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {
                                 if (ex instanceof CompletionException
                                         && ex.getCause() instanceof ArrayIndexOutOfBoundsException) {
                                     // The last ledger was empty, so we cannot read the last add confirmed.
-                                    LedgerInfo info = new LedgerInfo().setLedgerId(lastLedgerId).setEntries(0)
+                                    LedgerInfo info = createLedgerInfo().setLedgerId(lastLedgerId).setEntries(0)
                                             .setSize(0).setTimestamp(clock.millis());
                                     ledgers.put(lastLedgerId, info);
                                     future.complete(null);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImpl.java
@@ -60,7 +60,8 @@ public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {
                 }
 
                 // Last ledger stat may be zeroed, we must update it
-                if (ledgers.size() > 0 && ledgers.lastEntry().getValue().getEntries() == 0) {
+                if (ledgers.size() > 0 && (!ledgers.lastEntry().getValue().hasEntries()
+                        || ledgers.lastEntry().getValue().getEntries() == 0)) {
                     long lastLedgerId = ledgers.lastKey();
 
                     // Fetch last add confirmed for last ledger
@@ -122,7 +123,7 @@ public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {
     ReadOnlyCursor createReadOnlyCursor(PositionImpl startPosition) {
         if (ledgers.isEmpty()) {
             lastConfirmedEntry = PositionImpl.EARLIEST;
-        } else if (ledgers.lastEntry().getValue().getEntries() > 0) {
+        } else if (ledgers.lastEntry().getValue().hasEntries() && ledgers.lastEntry().getValue().getEntries() > 0) {
             // Last ledger has some of the entries
             lastConfirmedEntry = new PositionImpl(ledgers.lastKey(), ledgers.lastEntry().getValue().getEntries() - 1);
         } else {
@@ -130,7 +131,7 @@ public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {
             if (ledgers.size() > 1) {
                 long lastLedgerId = ledgers.lastKey();
                 LedgerInfo li = ledgers.headMap(lastLedgerId, false).lastEntry().getValue();
-                lastConfirmedEntry = new PositionImpl(li.getLedgerId(), li.getEntries() - 1);
+                lastConfirmedEntry = new PositionImpl(li.getLedgerId(), li.hasEntries() ? li.getEntries() - 1 : -1);
             } else {
                 lastConfirmedEntry = PositionImpl.EARLIEST;
             }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImpl.java
@@ -18,6 +18,7 @@
  */
 package org.apache.bookkeeper.mledger.impl;
 
+import static org.apache.bookkeeper.mledger.impl.LightProtoHelper.createLedgerInfo;
 import com.google.common.collect.Range;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -35,8 +36,6 @@ import org.apache.bookkeeper.mledger.impl.MetaStore.MetaStoreCallback;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo;
 import org.apache.pulsar.metadata.api.Stat;
-
-import static org.apache.bookkeeper.mledger.impl.LightProtoHelper.createLedgerInfo;
 
 @Slf4j
 public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImpl.java
@@ -54,7 +54,7 @@ public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {
             public void operationComplete(ManagedLedgerInfo mlInfo, Stat stat) {
                 state = State.LedgerOpened;
 
-                for (LedgerInfo ls : mlInfo.getLedgerInfoList()) {
+                for (LedgerInfo ls : mlInfo.getLedgerInfosList()) {
                     ledgers.put(ls.getLedgerId(), ls);
                 }
 
@@ -67,9 +67,9 @@ public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {
                             .withDigestType(config.getDigestType()).withPassword(config.getPassword()).execute()
                             .thenAccept(readHandle -> {
                                 readHandle.readLastAddConfirmedAsync().thenAccept(lastAddConfirmed -> {
-                                    LedgerInfo info = LedgerInfo.newBuilder().setLedgerId(lastLedgerId)
+                                    LedgerInfo info = new LedgerInfo().setLedgerId(lastLedgerId)
                                             .setEntries(lastAddConfirmed + 1).setSize(readHandle.getLength())
-                                            .setTimestamp(clock.millis()).build();
+                                            .setTimestamp(clock.millis());
                                     ledgers.put(lastLedgerId, info);
 
                                     future.complete(null);
@@ -77,8 +77,8 @@ public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {
                                     if (ex instanceof CompletionException
                                             && ex.getCause() instanceof IllegalArgumentException) {
                                         // The last ledger was empty, so we cannot read the last add confirmed.
-                                        LedgerInfo info = LedgerInfo.newBuilder().setLedgerId(lastLedgerId)
-                                                .setEntries(0).setSize(0).setTimestamp(clock.millis()).build();
+                                        LedgerInfo info = new LedgerInfo().setLedgerId(lastLedgerId)
+                                                .setEntries(0).setSize(0).setTimestamp(clock.millis());
                                         ledgers.put(lastLedgerId, info);
                                         future.complete(null);
                                     } else {
@@ -90,8 +90,8 @@ public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {
                                 if (ex instanceof CompletionException
                                         && ex.getCause() instanceof ArrayIndexOutOfBoundsException) {
                                     // The last ledger was empty, so we cannot read the last add confirmed.
-                                    LedgerInfo info = LedgerInfo.newBuilder().setLedgerId(lastLedgerId).setEntries(0)
-                                            .setSize(0).setTimestamp(clock.millis()).build();
+                                    LedgerInfo info = new LedgerInfo().setLedgerId(lastLedgerId).setEntries(0)
+                                            .setSize(0).setTimestamp(clock.millis());
                                     ledgers.put(lastLedgerId, info);
                                     future.complete(null);
                                 } else {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ShadowManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ShadowManagedLedgerImpl.java
@@ -18,6 +18,7 @@
  */
 package org.apache.bookkeeper.mledger.impl;
 
+import static org.apache.bookkeeper.mledger.impl.LightProtoHelper.createLedgerInfo;
 import static org.apache.bookkeeper.mledger.util.Errors.isNoSuchLedgerExistsException;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -113,7 +114,7 @@ public class ShadowManagedLedgerImpl extends ManagedLedgerImpl {
                     }
                     if (rc == BKException.Code.OK) {
                         LedgerInfo info =
-                                new LedgerInfo()
+                                createLedgerInfo()
                                         .setLedgerId(lastLedgerId)
                                         .setEntries(lh.getLastAddConfirmed() + 1)
                                         .setSize(lh.getLength())
@@ -323,7 +324,7 @@ public class ShadowManagedLedgerImpl extends ManagedLedgerImpl {
                             log.debug("[{}] Opened new source ledger {}", name, lastLedgerId);
                         }
                         if (rc == BKException.Code.OK) {
-                            LedgerInfo info = new LedgerInfo()
+                            LedgerInfo info = createLedgerInfo()
                                     .setLedgerId(lastLedgerId)
                                     .setEntries(lh.getLastAddConfirmed() + 1)
                                     .setSize(lh.getLength())

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ShadowManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ShadowManagedLedgerImpl.java
@@ -86,7 +86,7 @@ public class ShadowManagedLedgerImpl extends ManagedLedgerImpl {
                     return;
                 }
                 sourceLedgersStat = stat;
-                if (mlInfo.getLedgerInfoCount() == 0) {
+                if (mlInfo.getLedgerInfosCount() == 0) {
                     // Small chance here, since shadow topic is created after source topic exists.
                     log.warn("[{}] Source topic ledger list is empty! source={},mlInfo={},stat={}", name, sourceMLName,
                             mlInfo, stat);
@@ -100,7 +100,7 @@ public class ShadowManagedLedgerImpl extends ManagedLedgerImpl {
                             lastConfirmedEntry);
                 }
 
-                for (LedgerInfo ls : mlInfo.getLedgerInfoList()) {
+                for (LedgerInfo ls : mlInfo.getLedgerInfosList()) {
                     ledgers.put(ls.getLedgerId(), ls);
                 }
 
@@ -113,11 +113,11 @@ public class ShadowManagedLedgerImpl extends ManagedLedgerImpl {
                     }
                     if (rc == BKException.Code.OK) {
                         LedgerInfo info =
-                                LedgerInfo.newBuilder()
+                                new LedgerInfo()
                                         .setLedgerId(lastLedgerId)
                                         .setEntries(lh.getLastAddConfirmed() + 1)
                                         .setSize(lh.getLength())
-                                        .setTimestamp(clock.millis()).build();
+                                        .setTimestamp(clock.millis());
                         ledgers.put(lastLedgerId, info);
 
                         //Always consider the last ledger is opened in source.
@@ -283,7 +283,7 @@ public class ShadowManagedLedgerImpl extends ManagedLedgerImpl {
         }
 
         TreeMap<Long, LedgerInfo> newLedgerInfos = new TreeMap<>();
-        for (LedgerInfo ls : mlInfo.getLedgerInfoList()) {
+        for (LedgerInfo ls : mlInfo.getLedgerInfosList()) {
             newLedgerInfos.put(ls.getLedgerId(), ls);
         }
 
@@ -299,9 +299,9 @@ public class ShadowManagedLedgerImpl extends ManagedLedgerImpl {
                         log.info("[{}] Old ledger info updated in source,ledgerId={}", name, ledgerId);
                         // ledger deleted from bookkeeper by offloader.
                         if (ledgerInfo.hasOffloadContext()
-                                && ledgerInfo.getOffloadContext().getBookkeeperDeleted()
+                                && ledgerInfo.getOffloadContext().isBookkeeperDeleted()
                                 && (!oldLedgerInfo.hasOffloadContext() || !oldLedgerInfo.getOffloadContext()
-                                .getBookkeeperDeleted())) {
+                                .isBookkeeperDeleted())) {
                             log.info("[{}] Old ledger removed from bookkeeper by offloader in source,ledgerId={}", name,
                                     ledgerId);
                             invalidateReadHandle(ledgerId);
@@ -323,11 +323,11 @@ public class ShadowManagedLedgerImpl extends ManagedLedgerImpl {
                             log.debug("[{}] Opened new source ledger {}", name, lastLedgerId);
                         }
                         if (rc == BKException.Code.OK) {
-                            LedgerInfo info = LedgerInfo.newBuilder()
+                            LedgerInfo info = new LedgerInfo()
                                     .setLedgerId(lastLedgerId)
                                     .setEntries(lh.getLastAddConfirmed() + 1)
                                     .setSize(lh.getLength())
-                                    .setTimestamp(clock.millis()).build();
+                                    .setTimestamp(clock.millis());
                             ledgers.put(lastLedgerId, info);
                             currentLedger = lh;
                             currentLedgerEntries = 0;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/offload/OffloadUtils.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/offload/OffloadUtils.java
@@ -36,7 +36,6 @@ import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.common.util.Backoff;
 import org.apache.bookkeeper.common.util.Retries;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
-import org.apache.bookkeeper.mledger.proto.MLDataFormats.KeyValue;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadDriverMetadata;
@@ -91,20 +90,19 @@ public final class OffloadUtils {
         return defaultDriverName;
     }
 
-    public static void setOffloadDriverMetadata(LedgerInfo.Builder infoBuilder,
+    public static void setOffloadDriverMetadata(LedgerInfo infoBuilder,
                                                 String driverName,
                                                 Map<String, String> offloadDriverMetadata) {
-        infoBuilder.getOffloadContextBuilder()
-            .getDriverMetadataBuilder()
+        infoBuilder.setOffloadContext()
+            .setDriverMetadata()
             .setName(driverName);
-        infoBuilder.getOffloadContextBuilder().getDriverMetadataBuilder().clearProperties();
+        infoBuilder.setOffloadContext().setDriverMetadata().clearProperties();
         offloadDriverMetadata.forEach((k, v) -> infoBuilder
-                .getOffloadContextBuilder()
-                .getDriverMetadataBuilder()
-                .addProperties(KeyValue.newBuilder()
-                        .setKey(k)
-                        .setValue(v)
-                        .build()));
+                .setOffloadContext()
+                .setDriverMetadata()
+                .addProperty()
+                    .setKey(k)
+                    .setValue(v));
     }
 
     public static byte[] buildLedgerMetadataFormat(LedgerMetadata metadata) {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorIndividualDeletedMessagesTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorIndividualDeletedMessagesTest.java
@@ -114,7 +114,7 @@ public class ManagedCursorIndividualDeletedMessagesTest {
     }
 
     private static LedgerInfo createLedgerInfo(long ledgerId, long entries, long size) {
-        return new LedgerInfo().setLedgerId(ledgerId).setEntries(entries).setSize(size)
+        return LightProtoHelper.createLedgerInfo().setLedgerId(ledgerId).setEntries(entries).setSize(size)
                 .setTimestamp(System.currentTimeMillis());
     }
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorIndividualDeletedMessagesTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorIndividualDeletedMessagesTest.java
@@ -35,7 +35,6 @@ import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange;
-import org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo;
 import org.apache.pulsar.common.util.collections.LongPairRangeSet;
 import org.testng.annotations.Test;
 
@@ -99,24 +98,23 @@ public class ManagedCursorIndividualDeletedMessagesTest {
     }
 
     private static LedgerInfo createLedgerInfo(long ledgerId, long entries, long size) {
-        return LedgerInfo.newBuilder().setLedgerId(ledgerId).setEntries(entries).setSize(size)
-                .setTimestamp(System.currentTimeMillis()).build();
+        return new LedgerInfo().setLedgerId(ledgerId).setEntries(entries).setSize(size)
+                .setTimestamp(System.currentTimeMillis());
     }
 
     private static MessageRange createMessageRange(long lowerLedgerId, long lowerEntryId, long upperLedgerId,
             long upperEntryId) {
-        NestedPositionInfo.Builder nestedPositionBuilder = NestedPositionInfo.newBuilder();
-        MessageRange.Builder messageRangeBuilder = MessageRange.newBuilder();
+        MessageRange messageRangeBuilder = new MessageRange();
 
-        nestedPositionBuilder.setLedgerId(lowerLedgerId);
-        nestedPositionBuilder.setEntryId(lowerEntryId);
-        messageRangeBuilder.setLowerEndpoint(nestedPositionBuilder.build());
+        messageRangeBuilder.setLowerEndpoint()
+                .setLedgerId(lowerLedgerId)
+                .setEntryId(lowerEntryId);
 
-        nestedPositionBuilder.setLedgerId(upperLedgerId);
-        nestedPositionBuilder.setEntryId(upperEntryId);
-        messageRangeBuilder.setUpperEndpoint(nestedPositionBuilder.build());
+        messageRangeBuilder.setUpperEndpoint()
+                .setLedgerId(upperLedgerId)
+                .setEntryId(upperEntryId);
 
-        return messageRangeBuilder.build();
+        return messageRangeBuilder;
     }
 
     private static Range<PositionImpl> createPositionRange(long lowerLedgerId, long lowerEntryId, long upperLedgerId,

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorInfoMetadataTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorInfoMetadataTest.java
@@ -97,7 +97,9 @@ public class ManagedCursorInfoMetadataTest {
         // parse compression data and unCompression data, check their results.
         MLDataFormats.ManagedCursorInfo info1 = metaStore.parseManagedCursorInfo(compressionBytes);
         MLDataFormats.ManagedCursorInfo info2 = metaStore.parseManagedCursorInfo(managedCursorInfo.toByteArray());
-        assertEquals(info1, info2);
+        assertEquals(info1.toByteArray(), info2.toByteArray());
+        assertEquals(info1.getCursorsLedgerId(), info2.getCursorsLedgerId());
+        assertEquals(info1.getMarkDeleteLedgerId(), info2.getMarkDeleteLedgerId());
     }
 
     @Test(dataProvider = "compressionTypeProvider")

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -3224,8 +3224,8 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
                 lh.asyncReadEntries(lastEntry, lastEntry, (rc1, lh1, seq, ctx1) -> {
                     try {
                         LedgerEntry entry = seq.nextElement();
-                        PositionInfo positionInfo;
-                        positionInfo = PositionInfo.parseFrom(entry.getEntry());
+                        PositionInfo positionInfo = new PositionInfo();
+                        positionInfo.parseFrom(entry.getEntry());
                         individualDeletedMessagesCount.set(positionInfo.getIndividualDeletedMessagesCount());
                     } catch (Exception e) {
                     }
@@ -3405,9 +3405,9 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         MetaStore mockMetaStore = mock(MetaStore.class);
         doAnswer(new Answer<Object>() {
             public Object answer(InvocationOnMock invocation) {
-                ManagedCursorInfo info = ManagedCursorInfo.newBuilder().setCursorsLedgerId(cursorsLedgerId)
+                ManagedCursorInfo info = new ManagedCursorInfo().setCursorsLedgerId(cursorsLedgerId)
                         .setMarkDeleteLedgerId(markDeleteLedgerId).setMarkDeleteEntryId(markDeleteEntryId)
-                        .setLastActive(0L).build();
+                        .setLastActive(0L);
                 Stat stat = mock(Stat.class);
                 MetaStoreCallback<ManagedCursorInfo> callback = (MetaStoreCallback<ManagedCursorInfo>) invocation
                         .getArguments()[2];
@@ -3466,12 +3466,11 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         // Trigger the lastConfirmedEntry to move forward
         ml.addEntry(new byte[1]);
 
-        ManagedCursorInfo info = ManagedCursorInfo.newBuilder()
+        ManagedCursorInfo info = new ManagedCursorInfo()
                 .setCursorsLedgerId(c.getCursorLedger())
                 .setMarkDeleteLedgerId(markDeleteBeforeRecover.getLedgerId())
                 .setMarkDeleteEntryId(markDeleteBeforeRecover.getEntryId())
-                .setLastActive(0L)
-                .build();
+                .setLastActive(0L);
 
         CountDownLatch latch = new CountDownLatch(1);
         AtomicBoolean failed = new AtomicBoolean(false);
@@ -3533,12 +3532,11 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         final Position markDeleteBeforeRecover = c.getMarkDeletedPosition();
         final Position readPositionBeforeRecover = c.getReadPosition();
 
-        ManagedCursorInfo info = ManagedCursorInfo.newBuilder()
+        ManagedCursorInfo info = new ManagedCursorInfo()
                 .setCursorsLedgerId(c.getCursorLedger())
                 .setMarkDeleteLedgerId(markDeleteBeforeRecover.getLedgerId())
                 .setMarkDeleteEntryId(markDeleteBeforeRecover.getEntryId())
-                .setLastActive(0L)
-                .build();
+                .setLastActive(0L);
 
         CountDownLatch latch = new CountDownLatch(1);
         AtomicBoolean failed = new AtomicBoolean(false);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -3723,6 +3723,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         ManagedLedgerConfig managedLedgerConfig = new ManagedLedgerConfig();
         // Make sure the cursor metadata updated by the cursor ledger ID.
         managedLedgerConfig.setMaxUnackedRangesToPersistInMetadataStore(-1);
+        managedLedgerConfig.setDeletionAtBatchIndexLevelEnabled(true);
         ManagedLedger ledger = factory.open("test_batch_indexes_deletion_persistent", managedLedgerConfig);
         ManagedCursor cursor = ledger.openCursor("c1");
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryShutdownTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryShutdownTest.java
@@ -26,14 +26,12 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-
 import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.AsyncCallback;
 import org.apache.bookkeeper.client.BookKeeper;
@@ -77,11 +75,10 @@ public class ManagedLedgerFactoryShutdownTest {
                 throw new IllegalArgumentException("Path is null.");
             }
             if (path.endsWith(ledgerName)) { // ledger
-                MLDataFormats.ManagedLedgerInfo.Builder mli = MLDataFormats.ManagedLedgerInfo.newBuilder()
-                        .addLedgerInfo(0, MLDataFormats.ManagedLedgerInfo.LedgerInfo.newBuilder()
-                                .setLedgerId(0)
+                MLDataFormats.ManagedLedgerInfo mli = new MLDataFormats.ManagedLedgerInfo();
+                mli.addLedgerInfo().setLedgerId(0)
                                 .setEntries(0)
-                                .setTimestamp(System.currentTimeMillis()));
+                                .setTimestamp(System.currentTimeMillis());
                 Stat stat = new Stat(path, version, createTimeMillis, createTimeMillis, false, false);
                 return CompletableFuture.supplyAsync(() -> {
                     try {
@@ -89,14 +86,14 @@ public class ManagedLedgerFactoryShutdownTest {
                     } catch (InterruptedException e) {
                         e.printStackTrace();
                     }
-                    MLDataFormats.ManagedLedgerInfo managedLedgerInfo = mli.build();
+                    MLDataFormats.ManagedLedgerInfo managedLedgerInfo = mli;
                     log.info("metadataStore.get({}) returned,managedLedgerInfo={},stat={}", path, managedLedgerInfo,
                             stat);
                     return Optional.of(new GetResult(managedLedgerInfo.toByteArray(), stat));
                 });
 
             } else if (path.contains(ledgerName)) { // cursor
-                MLDataFormats.ManagedCursorInfo.Builder mci = MLDataFormats.ManagedCursorInfo.newBuilder()
+                MLDataFormats.ManagedCursorInfo mci = new MLDataFormats.ManagedCursorInfo()
                         .setCursorsLedgerId(-1)
                         .setMarkDeleteLedgerId(0)
                         .setMarkDeleteLedgerId(-1);
@@ -107,7 +104,7 @@ public class ManagedLedgerFactoryShutdownTest {
                     } catch (InterruptedException e) {
                         e.printStackTrace();
                     }
-                    MLDataFormats.ManagedCursorInfo managedCursorInfo = mci.build();
+                    MLDataFormats.ManagedCursorInfo managedCursorInfo = mci;
                     log.info("metadataStore.get({}) returned:managedCursorInfo={},stat={}", path, managedCursorInfo,
                             stat);
                     return Optional.of(new GetResult(managedCursorInfo.toByteArray(), stat));

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerInfoMetadataTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerInfoMetadataTest.java
@@ -56,17 +56,17 @@ public class ManagedLedgerInfoMetadataTest {
         };
     }
 
-    private MLDataFormats.ManagedLedgerInfo.Builder generateManagedLedgerInfo(long ledgerId, int ledgerInfoNumber) {
+    private MLDataFormats.ManagedLedgerInfo generateManagedLedgerInfo(long ledgerId, int ledgerInfoNumber) {
         List<MLDataFormats.ManagedLedgerInfo.LedgerInfo> ledgerInfoList = new ArrayList<>();
         for (int i = 0; i < ledgerInfoNumber; i++) {
-            MLDataFormats.ManagedLedgerInfo.LedgerInfo.Builder builder = MLDataFormats.ManagedLedgerInfo.LedgerInfo.newBuilder();
+            MLDataFormats.ManagedLedgerInfo.LedgerInfo builder = new MLDataFormats.ManagedLedgerInfo.LedgerInfo();
             builder.setLedgerId(ledgerId);
             builder.setEntries(RandomUtils.nextInt());
             builder.setSize(RandomUtils.nextLong());
             builder.setTimestamp(System.currentTimeMillis());
 
             UUID uuid = UUID.randomUUID();
-            builder.getOffloadContextBuilder()
+            builder.setOffloadContext()
                     .setUidMsb(uuid.getMostSignificantBits())
                     .setUidLsb(uuid.getLeastSignificantBits());
             Map<String, String> offloadDriverMetadata = new HashMap<>();
@@ -80,19 +80,18 @@ public class ManagedLedgerInfoMetadataTest {
                     offloadDriverMetadata
             );
 
-            MLDataFormats.ManagedLedgerInfo.LedgerInfo ledgerInfo = builder.build();
+            MLDataFormats.ManagedLedgerInfo.LedgerInfo ledgerInfo = builder;
             ledgerInfoList.add(ledgerInfo);
             ledgerId ++;
         }
 
-        return MLDataFormats.ManagedLedgerInfo.newBuilder()
-                .addAllLedgerInfo(ledgerInfoList);
+        return new MLDataFormats.ManagedLedgerInfo().addAllLedgerInfos(ledgerInfoList);
     }
 
     @Test(dataProvider = "compressionTypeProvider")
     public void testEncodeAndDecode(String compressionType) throws IOException {
         long ledgerId = 10000;
-        MLDataFormats.ManagedLedgerInfo managedLedgerInfo = generateManagedLedgerInfo(ledgerId,100).build();
+        MLDataFormats.ManagedLedgerInfo managedLedgerInfo = generateManagedLedgerInfo(ledgerId,100);
 
         MetaStoreImpl metaStore;
         try {
@@ -138,14 +137,14 @@ public class ManagedLedgerInfoMetadataTest {
         int compressThreshold = 512;
 
         // should not compress
-        MLDataFormats.ManagedLedgerInfo smallInfo = generateManagedLedgerInfo(ledgerId, 0).build();
+        MLDataFormats.ManagedLedgerInfo smallInfo = generateManagedLedgerInfo(ledgerId, 0);
         assertTrue(smallInfo.getSerializedSize() < compressThreshold);
 
         // should compress
-        MLDataFormats.ManagedLedgerInfo bigInfo = generateManagedLedgerInfo(ledgerId, 1000).build();
+        MLDataFormats.ManagedLedgerInfo bigInfo = generateManagedLedgerInfo(ledgerId, 1000);
         assertTrue(bigInfo.getSerializedSize() > compressThreshold);
 
-        MLDataFormats.ManagedLedgerInfo managedLedgerInfo = generateManagedLedgerInfo(ledgerId,100).build();
+        MLDataFormats.ManagedLedgerInfo managedLedgerInfo = generateManagedLedgerInfo(ledgerId,100);
 
         MetaStoreImpl metaStore;
         try {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -19,6 +19,7 @@
 package org.apache.bookkeeper.mledger.impl;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.bookkeeper.mledger.impl.LightProtoHelper.createLedgerInfo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -4249,7 +4250,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         // prepare the arguments for the offloadLoop method
         CompletableFuture<PositionImpl> future = new CompletableFuture<>();
         Queue<LedgerInfo> ledgersToOffload = new LinkedList<>();
-        LedgerInfo ledgerInfo = new LedgerInfo().setLedgerId(1).setEntries(10);
+        LedgerInfo ledgerInfo = createLedgerInfo().setLedgerId(1).setEntries(10);
         ledgersToOffload.add(ledgerInfo);
         PositionImpl firstUnoffloaded = new PositionImpl(1, 0);
         Optional<Throwable> firstError = Optional.empty();

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/MetaStoreImplTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/MetaStoreImplTest.java
@@ -167,7 +167,7 @@ public class MetaStoreImplTest extends MockedBookKeeperTestCase {
 
         final CompletableFuture<Void> promise = new CompletableFuture<>();
 
-        ManagedCursorInfo info = ManagedCursorInfo.newBuilder().setCursorsLedgerId(1).build();
+        ManagedCursorInfo info = new ManagedCursorInfo().setCursorsLedgerId(1);
         store.asyncUpdateCursorInfo("my_test", "c1", info, null, new MetaStoreCallback<Void>() {
             public void operationFailed(MetaStoreException e) {
                 promise.completeExceptionally(e);
@@ -180,7 +180,7 @@ public class MetaStoreImplTest extends MockedBookKeeperTestCase {
                                 && path.contains("my_test") && path.contains("c1")
                 );
 
-                ManagedCursorInfo info = ManagedCursorInfo.newBuilder().setCursorsLedgerId(2).build();
+                ManagedCursorInfo info = new ManagedCursorInfo().setCursorsLedgerId(2);
                 store.asyncUpdateCursorInfo("my_test", "c1", info, version, new MetaStoreCallback<Void>() {
                     public void operationFailed(MetaStoreException e) {
                         // ok

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadEvictUnusedLedgersTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadEvictUnusedLedgersTest.java
@@ -65,7 +65,7 @@ public class OffloadEvictUnusedLedgersTest extends MockedBookKeeperTestCase {
 
         assertEquals(ledger.getLedgersInfoAsList().size(), 3);
         assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete())
+                            .filter(e -> e.getOffloadContext().isComplete())
                             .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
                             offloader.offloadedLedgers());
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadEvictUnusedLedgersTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadEvictUnusedLedgersTest.java
@@ -65,6 +65,7 @@ public class OffloadEvictUnusedLedgersTest extends MockedBookKeeperTestCase {
 
         assertEquals(ledger.getLedgersInfoAsList().size(), 3);
         assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(l -> l.hasOffloadContext())
                             .filter(e -> e.getOffloadContext().isComplete())
                             .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
                             offloader.offloadedLedgers());

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadLedgerDeleteTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadLedgerDeleteTest.java
@@ -172,7 +172,7 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
 
         Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 2);
         Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete())
+                            .filter(e -> e.getOffloadContext().isComplete())
                             .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
                             offloader.offloadedLedgers());
         Assert.assertTrue(bkc.getLedgers().contains(firstLedgerId));
@@ -193,7 +193,7 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
 
         // ledger still exists in list
         Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete())
+                            .filter(e -> e.getOffloadContext().isComplete())
                             .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
                             offloader.offloadedLedgers());
 
@@ -234,14 +234,14 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
 
         Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 2);
         Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
-                        .filter(e -> e.getOffloadContext().getComplete())
+                        .filter(e -> e.getOffloadContext().isComplete())
                         .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
                 offloader.offloadedLedgers());
         Assert.assertTrue(bkc.getLedgers().contains(firstLedgerId));
 
         // ledger still exists in list
         Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
-                        .filter(e -> e.getOffloadContext().getComplete())
+                        .filter(e -> e.getOffloadContext().isComplete())
                         .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
                 offloader.offloadedLedgers());
 
@@ -282,7 +282,7 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
 
         Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 2);
         Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete())
+                            .filter(e -> e.getOffloadContext().isComplete())
                             .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
                             offloader.offloadedLedgers());
         Assert.assertTrue(bkc.getLedgers().contains(firstLedgerId));
@@ -330,7 +330,7 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
 
         Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 2);
         Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete())
+                            .filter(e -> e.getOffloadContext().isComplete())
                             .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
                             offloader.offloadedLedgers());
         Assert.assertTrue(bkc.getLedgers().contains(firstLedgerId));
@@ -352,7 +352,7 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
 
         // ledger still exists in list
         Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete())
+                            .filter(e -> e.getOffloadContext().isComplete())
                             .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
                             offloader.offloadedLedgers());
     }
@@ -370,11 +370,10 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
 
         ManagedLedgerImpl managedLedger = (ManagedLedgerImpl) factory.open("isOffloadedNeedsDeleteTest", config);
 
-        MLDataFormats.OffloadContext offloadContext = MLDataFormats.OffloadContext.newBuilder()
+        MLDataFormats.OffloadContext offloadContext = new MLDataFormats.OffloadContext()
                 .setTimestamp(config.getClock().millis() - 1000)
                 .setComplete(true)
-                .setBookkeeperDeleted(false)
-                .build();
+                .setBookkeeperDeleted(false);
 
         boolean needsDelete = managedLedger.isOffloadedNeedsDelete(offloadContext, Optional.of(offloadPolicies));
         Assert.assertFalse(needsDelete);
@@ -387,19 +386,17 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
         needsDelete = managedLedger.isOffloadedNeedsDelete(offloadContext, Optional.of(offloadPolicies));
         Assert.assertFalse(needsDelete);
 
-        offloadContext = MLDataFormats.OffloadContext.newBuilder()
+        offloadContext = new MLDataFormats.OffloadContext()
                 .setTimestamp(config.getClock().millis() - 1000)
                 .setComplete(false)
-                .setBookkeeperDeleted(false)
-                .build();
+                .setBookkeeperDeleted(false);
         needsDelete = managedLedger.isOffloadedNeedsDelete(offloadContext, Optional.of(offloadPolicies));
         Assert.assertFalse(needsDelete);
 
-        offloadContext = MLDataFormats.OffloadContext.newBuilder()
+        offloadContext = new MLDataFormats.OffloadContext()
                 .setTimestamp(config.getClock().millis() - 1000)
                 .setComplete(true)
-                .setBookkeeperDeleted(true)
-                .build();
+                .setBookkeeperDeleted(true);
         needsDelete = managedLedger.isOffloadedNeedsDelete(offloadContext, Optional.of(offloadPolicies));
         Assert.assertFalse(needsDelete);
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadLedgerDeleteTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadLedgerDeleteTest.java
@@ -172,6 +172,7 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
 
         Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 2);
         Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(e -> e.hasOffloadContext())
                             .filter(e -> e.getOffloadContext().isComplete())
                             .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
                             offloader.offloadedLedgers());
@@ -193,6 +194,7 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
 
         // ledger still exists in list
         Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(e -> e.hasOffloadContext())
                             .filter(e -> e.getOffloadContext().isComplete())
                             .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
                             offloader.offloadedLedgers());
@@ -234,6 +236,7 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
 
         Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 2);
         Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                        .filter(e -> e.hasOffloadContext())
                         .filter(e -> e.getOffloadContext().isComplete())
                         .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
                 offloader.offloadedLedgers());
@@ -241,6 +244,7 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
 
         // ledger still exists in list
         Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                        .filter(e -> e.hasOffloadContext())
                         .filter(e -> e.getOffloadContext().isComplete())
                         .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
                 offloader.offloadedLedgers());
@@ -282,6 +286,7 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
 
         Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 2);
         Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(e -> e.hasOffloadContext())
                             .filter(e -> e.getOffloadContext().isComplete())
                             .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
                             offloader.offloadedLedgers());
@@ -330,6 +335,7 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
 
         Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 2);
         Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(e -> e.hasOffloadContext())
                             .filter(e -> e.getOffloadContext().isComplete())
                             .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
                             offloader.offloadedLedgers());
@@ -352,6 +358,7 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
 
         // ledger still exists in list
         Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(e -> e.hasOffloadContext())
                             .filter(e -> e.getOffloadContext().isComplete())
                             .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
                             offloader.offloadedLedgers());

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixReadTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixReadTest.java
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
 import io.netty.buffer.ByteBuf;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -43,7 +42,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
-
 import lombok.SneakyThrows;
 import org.apache.bookkeeper.client.api.DigestType;
 import org.apache.bookkeeper.client.api.LastConfirmedAndEntry;
@@ -88,9 +86,9 @@ public class OffloadPrefixReadTest extends MockedBookKeeperTestCase {
         ledger.offloadPrefix(ledger.getLastConfirmedEntry());
 
         assertEquals(ledger.getLedgersInfoAsList().size(), 3);
-        Assert.assertTrue(ledger.getLedgersInfoAsList().get(0).getOffloadContext().getComplete());
-        Assert.assertTrue(ledger.getLedgersInfoAsList().get(1).getOffloadContext().getComplete());
-        Assert.assertFalse(ledger.getLedgersInfoAsList().get(2).getOffloadContext().getComplete());
+        Assert.assertTrue(ledger.getLedgersInfoAsList().get(0).getOffloadContext().isComplete());
+        Assert.assertTrue(ledger.getLedgersInfoAsList().get(1).getOffloadContext().isComplete());
+        Assert.assertFalse(ledger.getLedgersInfoAsList().get(2).getOffloadContext().isComplete());
 
         UUID firstLedgerUUID = new UUID(ledger.getLedgersInfoAsList().get(0).getOffloadContext().getUidMsb(),
                 ledger.getLedgersInfoAsList().get(0).getOffloadContext().getUidLsb());
@@ -154,13 +152,13 @@ public class OffloadPrefixReadTest extends MockedBookKeeperTestCase {
 
         assertEquals(ledger.getLedgersInfoAsList().size(), 3);
         assertEquals(ledger.getLedgersInfoAsList().stream()
-                .filter(e -> e.getOffloadContext().getComplete()).count(), 2);
+                .filter(e -> e.getOffloadContext().isComplete()).count(), 2);
 
         LedgerInfo firstLedger = ledger.getLedgersInfoAsList().get(0);
-        Assert.assertTrue(firstLedger.getOffloadContext().getComplete());
+        Assert.assertTrue(firstLedger.getOffloadContext().isComplete());
         LedgerInfo secondLedger;
         secondLedger = ledger.getLedgersInfoAsList().get(1);
-        Assert.assertTrue(secondLedger.getOffloadContext().getComplete());
+        Assert.assertTrue(secondLedger.getOffloadContext().isComplete());
 
         UUID firstLedgerUUID = new UUID(firstLedger.getOffloadContext().getUidMsb(),
                 firstLedger.getOffloadContext().getUidLsb());
@@ -187,8 +185,8 @@ public class OffloadPrefixReadTest extends MockedBookKeeperTestCase {
         // assert bk ledger is deleted
         assertEventuallyTrue(() -> !bkc.getLedgers().contains(firstLedger.getLedgerId()));
         assertEventuallyTrue(() -> !bkc.getLedgers().contains(secondLedger.getLedgerId()));
-        Assert.assertTrue(ledger.getLedgersInfoAsList().get(0).getOffloadContext().getBookkeeperDeleted());
-        Assert.assertTrue(ledger.getLedgersInfoAsList().get(1).getOffloadContext().getBookkeeperDeleted());
+        Assert.assertTrue(ledger.getLedgersInfoAsList().get(0).getOffloadContext().isBookkeeperDeleted());
+        Assert.assertTrue(ledger.getLedgersInfoAsList().get(1).getOffloadContext().isBookkeeperDeleted());
 
         for (Entry e : cursor.readEntries(10)) {
             Assert.assertEquals(new String(e.getData()), "entry-" + i++);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
@@ -38,7 +38,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
-
 import com.google.common.collect.Sets;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.api.ReadHandle;
@@ -89,7 +88,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         }
         assertEquals(ledger.getLedgersInfoAsList().size(), 5);
         assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete()).count(), 0);
+                            .filter(e -> e.getOffloadContext().isComplete()).count(), 0);
         try {
             ledger.offloadPrefix(p);
             fail("Should have thrown an exception");
@@ -98,7 +97,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         }
         assertEquals(ledger.getLedgersInfoAsList().size(), 5);
         assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete()).count(), 0);
+                            .filter(e -> e.getOffloadContext().isComplete()).count(), 0);
 
         // add more entries to ensure we can update the ledger list
         for (; i < 55; i++) {
@@ -107,7 +106,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         }
         assertEquals(ledger.getLedgersInfoAsList().size(), 6);
         assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete()).count(), 0);
+                            .filter(e -> e.getOffloadContext().isComplete()).count(), 0);
     }
 
     @Test
@@ -132,7 +131,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
 
         assertEquals(ledger.getLedgersInfoAsList().size(), 3);
         assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete())
+                            .filter(e -> e.getOffloadContext().isComplete())
                             .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
                             offloader.offloadedLedgers());
 
@@ -170,7 +169,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
 
         // the offloader actually wrote the data on the storage
         assertEquals(ledger.getLedgersInfoAsList().stream()
-                        .filter(e -> e.getOffloadContext().getComplete())
+                        .filter(e -> e.getOffloadContext().isComplete())
                         .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
                 offloader.offloadedLedgers());
 
@@ -214,7 +213,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         }
 
         assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete()).count(), 0);
+                            .filter(e -> e.getOffloadContext().isComplete()).count(), 0);
         assertEquals(offloader.offloadedLedgers().size(), 0);
     }
 
@@ -247,9 +246,9 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         assertEquals(ledger.getLedgersInfoAsList().size(), 3);
         assertEquals(offloader.offloadedLedgers().size(), 1);
         assertTrue(offloader.offloadedLedgers().contains(ledger.getLedgersInfoAsList().get(0).getLedgerId()));
-        assertTrue(ledger.getLedgersInfoAsList().get(0).getOffloadContext().getComplete());
+        assertTrue(ledger.getLedgersInfoAsList().get(0).getOffloadContext().isComplete());
         assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete()).count(), 1);
+                            .filter(e -> e.getOffloadContext().isComplete()).count(), 1);
         assertEquals(firstUnoffloaded.getLedgerId(), ledger.getLedgersInfoAsList().get(1).getLedgerId());
         assertEquals(firstUnoffloaded.getEntryId(), 0);
 
@@ -259,10 +258,10 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         assertEquals(offloader.offloadedLedgers().size(), 2);
         assertTrue(offloader.offloadedLedgers().contains(ledger.getLedgersInfoAsList().get(0).getLedgerId()));
         assertTrue(offloader.offloadedLedgers().contains(ledger.getLedgersInfoAsList().get(1).getLedgerId()));
-        assertTrue(ledger.getLedgersInfoAsList().get(0).getOffloadContext().getComplete());
-        assertTrue(ledger.getLedgersInfoAsList().get(1).getOffloadContext().getComplete());
+        assertTrue(ledger.getLedgersInfoAsList().get(0).getOffloadContext().isComplete());
+        assertTrue(ledger.getLedgersInfoAsList().get(1).getOffloadContext().isComplete());
         assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete()).count(), 2);
+                            .filter(e -> e.getOffloadContext().isComplete()).count(), 2);
         assertEquals(firstUnoffloaded2.getLedgerId(), ledger.getLedgersInfoAsList().get(2).getLedgerId());
     }
 
@@ -299,9 +298,9 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         assertEquals(ledger.getLedgersInfoAsList().size(), 2);
         assertEquals(offloader.offloadedLedgers().size(), 1);
         assertTrue(offloader.offloadedLedgers().contains(ledger.getLedgersInfoAsList().get(0).getLedgerId()));
-        assertTrue(ledger.getLedgersInfoAsList().get(0).getOffloadContext().getComplete());
+        assertTrue(ledger.getLedgersInfoAsList().get(0).getOffloadContext().isComplete());
         assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete()).count(), 1);
+                            .filter(e -> e.getOffloadContext().isComplete()).count(), 1);
         assertEquals(firstUnoffloaded.getLedgerId(), ledger.getLedgersInfoAsList().get(1).getLedgerId());
         assertEquals(firstUnoffloaded.getEntryId(), 0);
     }
@@ -347,7 +346,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         cursor.markDelete(startOfSecondLedger, new HashMap<>());
         assertEventuallyTrue(() -> ledger.getLedgersInfoAsList().size() == 2);
         assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete()).count(), 0);
+                            .filter(e -> e.getOffloadContext().isComplete()).count(), 0);
 
         // complete offloading
         blocker.complete(null);
@@ -355,8 +354,8 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
 
         assertEquals(ledger.getLedgersInfoAsList().size(), 2);
         assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete()).count(), 1);
-        assertTrue(ledger.getLedgersInfoAsList().get(0).getOffloadContext().getComplete());
+                            .filter(e -> e.getOffloadContext().isComplete()).count(), 1);
+        assertTrue(ledger.getLedgersInfoAsList().get(0).getOffloadContext().isComplete());
         assertEquals(offloader.offloadedLedgers().size(), 1);
         assertTrue(offloader.offloadedLedgers().contains(ledger.getLedgersInfoAsList().get(0).getLedgerId()));
     }
@@ -413,7 +412,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         assertEquals(ledger.getLedgersInfoAsList().stream()
                             .filter(e -> e.getLedgerId() == trimmedLedger).count(), 0);
         assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete()).count(), 0);
+                            .filter(e -> e.getOffloadContext().isComplete()).count(), 0);
 
         // complete offloading
         blocker.complete(trimmedLedger);
@@ -421,8 +420,8 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
 
         assertEquals(ledger.getLedgersInfoAsList().size(), 2);
         assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete()).count(), 1);
-        assertTrue(ledger.getLedgersInfoAsList().get(0).getOffloadContext().getComplete());
+                            .filter(e -> e.getOffloadContext().isComplete()).count(), 1);
+        assertTrue(ledger.getLedgersInfoAsList().get(0).getOffloadContext().isComplete());
         assertEquals(offloader.offloadedLedgers().size(), 1);
         assertTrue(offloader.offloadedLedgers().contains(ledger.getLedgersInfoAsList().get(0).getLedgerId()));
     }
@@ -455,7 +454,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
 
         assertEquals(ledger.getLedgersInfoAsList().size(), 3);
         assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete()).count(), 0);
+                            .filter(e -> e.getOffloadContext().isComplete()).count(), 0);
         assertEquals(offloader.offloadedLedgers().size(), 0);
     }
 
@@ -481,7 +480,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
 
         assertEquals(ledger.getLedgersInfoAsList().size(), 3);
         assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete())
+                            .filter(e -> e.getOffloadContext().isComplete())
                             .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
                             offloader.offloadedLedgers());
 
@@ -489,7 +488,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
 
         assertEquals(ledger.getLedgersInfoAsList().size(), 3);
         assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete())
+                            .filter(e -> e.getOffloadContext().isComplete())
                             .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
                             offloader.offloadedLedgers());
 
@@ -524,12 +523,12 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
 
         assertEquals(ledger.getLedgersInfoAsList().size(), 4);
         assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete())
+                            .filter(e -> e.getOffloadContext().isComplete())
                             .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
                             offloader.offloadedLedgers());
         assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete()).count(), 2);
-        assertFalse(ledger.getLedgersInfoAsList().get(failIndex).getOffloadContext().getComplete());
+                            .filter(e -> e.getOffloadContext().isComplete()).count(), 2);
+        assertFalse(ledger.getLedgersInfoAsList().get(failIndex).getOffloadContext().isComplete());
     }
 
     @Test
@@ -632,7 +631,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
                                            ledger.getLedgersInfoAsList().get(0).getOffloadContext().getUidLsb());
         assertEquals(failedOffloads.stream().findFirst().get(),
                             Pair.of(expectedFailedLedger, expectedFailedUUID));
-        assertFalse(ledger.getLedgersInfoAsList().get(0).getOffloadContext().getComplete());
+        assertFalse(ledger.getLedgersInfoAsList().get(0).getOffloadContext().isComplete());
 
         // try offload again
         ledger.offloadPrefix(ledger.getLastConfirmedEntry());
@@ -644,7 +643,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         UUID successUUID = new UUID(ledger.getLedgersInfoAsList().get(0).getOffloadContext().getUidMsb(),
                                     ledger.getLedgersInfoAsList().get(0).getOffloadContext().getUidLsb());
         assertNotEquals(expectedFailedUUID, successUUID);
-        assertTrue(ledger.getLedgersInfoAsList().get(0).getOffloadContext().getComplete());
+        assertTrue(ledger.getLedgersInfoAsList().get(0).getOffloadContext().isComplete());
     }
 
     @Test
@@ -674,8 +673,8 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         assertEquals(ledger.getLedgersInfoAsList().size(), 2);
 
         assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete()).count(), 1);
-        assertTrue(ledger.getLedgersInfoAsList().get(0).getOffloadContext().getComplete());
+                            .filter(e -> e.getOffloadContext().isComplete()).count(), 1);
+        assertTrue(ledger.getLedgersInfoAsList().get(0).getOffloadContext().isComplete());
         long firstLedger = ledger.getLedgersInfoAsList().get(0).getLedgerId();
         long secondLedger = ledger.getLedgersInfoAsList().get(1).getLedgerId();
 
@@ -709,8 +708,8 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         assertEquals(ledger.getLedgersInfoAsList().size(), 2);
 
         assertEquals(ledger.getLedgersInfoAsList().stream()
-                .filter(e -> e.getOffloadContext().getComplete()).count(), 1);
-        assertTrue(ledger.getLedgersInfoAsList().get(0).getOffloadContext().getComplete());
+                .filter(e -> e.getOffloadContext().isComplete()).count(), 1);
+        assertTrue(ledger.getLedgersInfoAsList().get(0).getOffloadContext().isComplete());
 
         Set<Long> offloadedledgers = Sets.newHashSet(offloader.offloadedLedgers());
         assertTrue(offloadedledgers.size() > 0);
@@ -784,7 +783,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         assertEquals(ledger.getLedgersInfoAsList().size(), 2);
 
         assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete()).count(), 0);
+                            .filter(e -> e.getOffloadContext().isComplete()).count(), 0);
         assertEquals(ledger.getLedgersInfoAsList().stream()
                             .filter(e -> e.getOffloadContext().hasUidMsb()).count(), 1);
         assertTrue(ledger.getLedgersInfoAsList().get(0).getOffloadContext().hasUidMsb());
@@ -826,8 +825,8 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         Field ledgersField = ledger.getClass().getDeclaredField("ledgers");
         ledgersField.setAccessible(true);
         Map<Long, LedgerInfo> ledgers = (Map<Long,LedgerInfo>)ledgersField.get(ledger);
-        ledgers.put(secondLedgerId,
-                    ledgers.get(secondLedgerId).toBuilder().setEntries(0).setSize(0).build());
+        ledgers.put(secondLedgerId, new LedgerInfo()
+                .copyFrom(ledgers.get(secondLedgerId)).setEntries(0).setSize(0));
 
         PositionImpl firstUnoffloaded = (PositionImpl)ledger.offloadPrefix(ledger.getLastConfirmedEntry());
         assertEquals(firstUnoffloaded.getLedgerId(), fourthLedgerId);
@@ -835,7 +834,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
 
         assertEquals(ledger.getLedgersInfoAsList().size(), 4);
         assertEquals(ledger.getLedgersInfoAsList().stream()
-                            .filter(e -> e.getOffloadContext().getComplete())
+                            .filter(e -> e.getOffloadContext().isComplete())
                             .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
                             offloader.offloadedLedgers());
         assertEquals(offloader.offloadedLedgers(), Set.of(firstLedgerId, thirdLedgerId));
@@ -1354,7 +1353,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         final LedgerInfo ledgerInfo = ledger.getLedgersInfoAsList().get(0);
         final MLDataFormats.OffloadContext offloadContext = ledgerInfo.getOffloadContext();
         //should not set complete when
-        assertEquals(offloadContext.getComplete(), false);
+        assertEquals(offloadContext.isComplete(), false);
     }
 
     static class ErroringMockLedgerOffloader extends MockLedgerOffloader {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/PositionTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/PositionTest.java
@@ -73,7 +73,11 @@ public class PositionTest {
     @Test
     public void hashes() throws Exception {
         PositionImpl p1 = new PositionImpl(5, 15);
-        PositionImpl p2 = new PositionImpl(PositionInfo.parseFrom(p1.getPositionInfo().toByteArray()));
+
+        PositionInfo pi = new PositionInfo();
+        pi.parseFrom(p1.getPositionInfo().toByteArray());
+
+        PositionImpl p2 = new PositionImpl(pi);
         assertEquals(p2.getLedgerId(), 5);
         assertEquals(p2.getEntryId(), 15);
         assertEquals(new PositionImpl(5, 15).hashCode(), p2.hashCode());

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/offload/OffloadUtilsTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/offload/OffloadUtilsTest.java
@@ -21,7 +21,6 @@ package org.apache.bookkeeper.mledger.offload;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,8 +29,8 @@ public class OffloadUtilsTest {
 
     @Test
     void testOffloadMetadataShouldClearBeforeSet() {
-        MLDataFormats.ManagedLedgerInfo.LedgerInfo.Builder builder =
-                MLDataFormats.ManagedLedgerInfo.LedgerInfo.newBuilder();
+        MLDataFormats.ManagedLedgerInfo.LedgerInfo builder =
+                new MLDataFormats.ManagedLedgerInfo.LedgerInfo();
         builder.setLedgerId(1L);
 
         Map<String, String> map = new HashMap<>();
@@ -45,13 +44,13 @@ public class OffloadUtilsTest {
         OffloadUtils.setOffloadDriverMetadata(builder, "offload", map);
 
         MLDataFormats.OffloadDriverMetadata offloadDriverMetadata =
-                builder.build().getOffloadContext().getDriverMetadata();
+                builder.getOffloadContext().getDriverMetadata();
         Assert.assertEquals(offloadDriverMetadata.getPropertiesList().size(), 2);
 
-        Assert.assertEquals(offloadDriverMetadata.getProperties(0).getKey(), "key1");
-        Assert.assertEquals(offloadDriverMetadata.getProperties(1).getKey(), "key2");
-        Assert.assertEquals(offloadDriverMetadata.getProperties(0).getValue(), "value1");
-        Assert.assertEquals(offloadDriverMetadata.getProperties(1).getValue(), "value2");
+        Assert.assertEquals(offloadDriverMetadata.getPropertyAt(0).getKey(), "key1");
+        Assert.assertEquals(offloadDriverMetadata.getPropertyAt(1).getKey(), "key2");
+        Assert.assertEquals(offloadDriverMetadata.getPropertyAt(0).getValue(), "value1");
+        Assert.assertEquals(offloadDriverMetadata.getPropertyAt(1).getValue(), "value2");
     }
 
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2428,7 +2428,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                             info.ledgerId = li.getLedgerId();
                             info.entries = li.getEntries();
                             info.size = li.getSize();
-                            info.offloaded = li.hasOffloadContext() && li.getOffloadContext().getComplete();
+                            info.offloaded = li.hasOffloadContext() && li.getOffloadContext().isComplete();
                             stats.ledgers.add(info);
                             if (includeLedgerMetadata) {
                                 futures.add(ml.getLedgerMetadata(li.getLedgerId()).handle((lMetadata, ex) -> {

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarConnector.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarConnector.java
@@ -406,7 +406,9 @@ public abstract class TestPulsarConnector {
                     .setProducerName("test-producer").setSequenceId(i)
                     .setPublishTime(currentTimeMicros / 1000 + i);
 
-            Schema schema = topicsToSchemas.get(topicSchemaName).getType() == SchemaType.AVRO ? AvroSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build()) : JSONSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
+            Schema schema = topicsToSchemas.get(topicSchemaName).getType() == SchemaType.AVRO ?
+                    AvroSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build())
+                    : JSONSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
 
             ByteBuf payload = io.netty.buffer.Unpooled
                     .copiedBuffer(schema.encode(foo));
@@ -629,7 +631,8 @@ public abstract class TestPulsarConnector {
                                             .setProducerName("test-producer").setSequenceId(positions.get(topic))
                                             .setPublishTime(System.currentTimeMillis());
 
-                                    Schema schema = topicsToSchemas.get(schemaName).getType() == SchemaType.AVRO ? AvroSchema.of(Foo.class) : JSONSchema.of(Foo.class);
+                                    Schema schema = topicsToSchemas.get(schemaName).getType() == SchemaType.AVRO
+                                            ? AvroSchema.of(Foo.class) : JSONSchema.of(Foo.class);
 
                                     ByteBuf payload = io.netty.buffer.Unpooled
                                             .copiedBuffer(schema.encode(foo));
@@ -696,7 +699,8 @@ public abstract class TestPulsarConnector {
                     }
                 });
 
-                when(readOnlyCursor.getCurrentLedgerInfo()).thenReturn(MLDataFormats.ManagedLedgerInfo.LedgerInfo.newBuilder().setLedgerId(0).build());
+                when(readOnlyCursor.getCurrentLedgerInfo()).thenReturn(new MLDataFormats.ManagedLedgerInfo.LedgerInfo()
+                        .setLedgerId(0));
 
                 return readOnlyCursor;
             }

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarRecordCursor.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarRecordCursor.java
@@ -403,7 +403,8 @@ public class TestPulsarRecordCursor extends TestPulsarConnector {
                     }
                 });
 
-                when(readOnlyCursor.getCurrentLedgerInfo()).thenReturn(MLDataFormats.ManagedLedgerInfo.LedgerInfo.newBuilder().setLedgerId(0).build());
+                when(readOnlyCursor.getCurrentLedgerInfo()).thenReturn(new MLDataFormats.ManagedLedgerInfo.LedgerInfo()
+                        .setLedgerId(0));
 
                 return readOnlyCursor;
             }

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloader.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloader.java
@@ -434,16 +434,16 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
             streamingIndexBuilder.withDataBlockHeaderLength(StreamingDataBlockHeaderImpl.getDataStartOffset());
             streamingIndexBuilder.addBlock(blockLedgerId, beginEntryId, partId, blockSize);
             final MLDataFormats.ManagedLedgerInfo.LedgerInfo ledgerInfo = ml.getLedgerInfo(blockLedgerId).get();
-            final MLDataFormats.ManagedLedgerInfo.LedgerInfo.Builder ledgerInfoBuilder =
-                    MLDataFormats.ManagedLedgerInfo.LedgerInfo.newBuilder();
+            final MLDataFormats.ManagedLedgerInfo.LedgerInfo ledgerInfoBuilder =
+                    new MLDataFormats.ManagedLedgerInfo.LedgerInfo();
             if (ledgerInfo != null) {
-                ledgerInfoBuilder.mergeFrom(ledgerInfo);
+                ledgerInfoBuilder.copyFrom(ledgerInfo);
             }
             if (ledgerInfoBuilder.getEntries() == 0) {
                 //ledger unclosed, use last entry id of the block
                 ledgerInfoBuilder.setEntries(payloadStream.getEndEntryId() + 1);
             }
-            streamingIndexBuilder.addLedgerMeta(blockLedgerId, ledgerInfoBuilder.build());
+            streamingIndexBuilder.addLedgerMeta(blockLedgerId, ledgerInfoBuilder);
             log.debug("UploadMultipartPart. container: {}, blobName: {}, partId: {}, mpu: {}",
                     config.getBucket(), streamingDataBlockKey, partId, streamingMpu.id());
         } catch (Throwable e) {
@@ -569,7 +569,7 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
         BlobStoreLocation bsKey = getBlobStoreLocation(offloadDriverMetadata);
         String readBucket = bsKey.getBucket();
         CompletableFuture<ReadHandle> promise = new CompletableFuture<>();
-        final List<MLDataFormats.OffloadSegment> offloadSegmentList = ledgerContext.getOffloadSegmentList();
+        final List<MLDataFormats.OffloadSegment> offloadSegmentList = ledgerContext.getOffloadSegmentsList();
         List<String> keys = Lists.newLinkedList();
         List<String> indexKeys = Lists.newLinkedList();
         offloadSegmentList.forEach(seg -> {

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/OffloadIndexBlockV2Impl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/OffloadIndexBlockV2Impl.java
@@ -43,6 +43,8 @@ import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.bookkeeper.mledger.impl.LightProtoHelper.createLedgerInfo;
+
 public class OffloadIndexBlockV2Impl implements OffloadIndexBlockV2 {
     private static final Logger log = LoggerFactory.getLogger(OffloadIndexBlockImpl.class);
 
@@ -217,7 +219,7 @@ public class OffloadIndexBlockV2Impl implements OffloadIndexBlockV2 {
     }
 
     private static LedgerInfo parseLedgerInfo(byte[] bytes) throws IOException {
-        LedgerInfo info = new LedgerInfo();
+        LedgerInfo info = createLedgerInfo();
         info.parseFrom(bytes);
         return info;
     }

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/OffloadIndexBlockV2Impl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/OffloadIndexBlockV2Impl.java
@@ -217,7 +217,9 @@ public class OffloadIndexBlockV2Impl implements OffloadIndexBlockV2 {
     }
 
     private static LedgerInfo parseLedgerInfo(byte[] bytes) throws IOException {
-        return LedgerInfo.newBuilder().mergeFrom(bytes).build();
+        LedgerInfo info = new LedgerInfo();
+        info.parseFrom(bytes);
+        return info;
     }
 
     private OffloadIndexBlockV2 fromStream(DataInputStream dis) throws IOException {

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderStreamingTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderStreamingTest.java
@@ -42,7 +42,6 @@ import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.impl.EntryImpl;
 import org.apache.bookkeeper.mledger.offload.jcloud.provider.JCloudBlobStoreProvider;
 import org.apache.bookkeeper.mledger.offload.jcloud.provider.TieredStorageConfiguration;
-import org.apache.bookkeeper.mledger.proto.MLDataFormats;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext;
 import org.jclouds.blobstore.BlobStore;
 import org.mockito.Mockito;
@@ -152,14 +151,12 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
         final LedgerOffloader.OffloadResult offloadResult = offloadHandle.getOffloadResultAsync().get();
         assertEquals(offloadResult.endLedger, 0);
         assertEquals(offloadResult.endEntry, 9);
-        final OffloadContext.Builder contextBuilder = OffloadContext.newBuilder();
-        contextBuilder.addOffloadSegment(
-                MLDataFormats.OffloadSegment.newBuilder()
-                        .setUidLsb(uuid.getLeastSignificantBits())
+        final OffloadContext contextBuilder = new OffloadContext();
+        contextBuilder.addOffloadSegment().setUidLsb(uuid.getLeastSignificantBits())
                         .setUidMsb(uuid.getMostSignificantBits())
-                        .setComplete(true).setEndEntryId(9).build());
+                        .setComplete(true).setEndEntryId(9);
 
-        final ReadHandle readHandle = offloader.readOffloaded(0, contextBuilder.build(), driverMeta).get();
+        final ReadHandle readHandle = offloader.readOffloaded(0, contextBuilder, driverMeta).get();
         final LedgerEntries ledgerEntries = readHandle.readAsync(0, 9).get();
 
         for (LedgerEntry ledgerEntry : ledgerEntries) {
@@ -209,14 +206,14 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
         final LedgerOffloader.OffloadResult offloadResult = offloadHandle.getOffloadResultAsync().get();
         assertEquals(offloadResult.endLedger, 1);
         assertEquals(offloadResult.endEntry, 9);
-        final OffloadContext.Builder contextBuilder = OffloadContext.newBuilder();
-        contextBuilder.addOffloadSegment(
-                MLDataFormats.OffloadSegment.newBuilder()
-                        .setUidLsb(uuid.getLeastSignificantBits())
-                        .setUidMsb(uuid.getMostSignificantBits())
-                        .setComplete(true).setEndEntryId(9).build());
+        final OffloadContext contextBuilder = new OffloadContext();
+        contextBuilder.addOffloadSegment()
+                .setUidLsb(uuid.getLeastSignificantBits())
+                .setUidMsb(uuid.getMostSignificantBits())
+                .setComplete(true)
+                .setEndEntryId(9);
 
-        final ReadHandle readHandle = offloader.readOffloaded(0, contextBuilder.build(), driverMeta).get();
+        final ReadHandle readHandle = offloader.readOffloaded(0, contextBuilder, driverMeta).get();
         final LedgerEntries ledgerEntries = readHandle.readAsync(0, 9).get();
 
         for (LedgerEntry ledgerEntry : ledgerEntries) {
@@ -226,7 +223,7 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
             assertEquals(storedData, entryBytes);
         }
 
-        final ReadHandle readHandle2 = offloader.readOffloaded(1, contextBuilder.build(), driverMeta).get();
+        final ReadHandle readHandle2 = offloader.readOffloaded(1, contextBuilder, driverMeta).get();
         final LedgerEntries ledgerEntries2 = readHandle2.readAsync(0, 9).get();
 
         for (LedgerEntry ledgerEntry : ledgerEntries2) {
@@ -289,19 +286,17 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
         assertEquals(offloadResult2.endLedger, 0);
         assertEquals(offloadResult2.endEntry, 19);
 
-        final OffloadContext.Builder contextBuilder = OffloadContext.newBuilder();
-        contextBuilder.addOffloadSegment(
-                MLDataFormats.OffloadSegment.newBuilder()
+        final OffloadContext contextBuilder = new OffloadContext();
+        contextBuilder.addOffloadSegment()
                         .setUidLsb(uuid.getLeastSignificantBits())
                         .setUidMsb(uuid.getMostSignificantBits())
-                        .setComplete(true).setEndEntryId(9).build()).addOffloadSegment(
-                MLDataFormats.OffloadSegment.newBuilder()
+                        .setComplete(true).setEndEntryId(9);
+        contextBuilder.addOffloadSegment()
                         .setUidLsb(uuid2.getLeastSignificantBits())
                         .setUidMsb(uuid2.getMostSignificantBits())
-                        .setComplete(true).setEndEntryId(19).build()
-        );
+                        .setComplete(true).setEndEntryId(19);
 
-        final ReadHandle readHandle = offloader.readOffloaded(0, contextBuilder.build(), driverMeta).get();
+        final ReadHandle readHandle = offloader.readOffloaded(0, contextBuilder, driverMeta).get();
         final LedgerEntries ledgerEntries = readHandle.readAsync(0, 19).get();
 
         for (LedgerEntry ledgerEntry : ledgerEntries) {
@@ -364,19 +359,17 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
         assertEquals(offloadResult2.endLedger, 0);
         assertEquals(offloadResult2.endEntry, 19);
 
-        final OffloadContext.Builder contextBuilder = OffloadContext.newBuilder();
-        contextBuilder.addOffloadSegment(
-                MLDataFormats.OffloadSegment.newBuilder()
+        final OffloadContext contextBuilder = new OffloadContext();
+        contextBuilder.addOffloadSegment()
                         .setUidLsb(uuid.getLeastSignificantBits())
                         .setUidMsb(uuid.getMostSignificantBits())
-                        .setComplete(true).setEndEntryId(9).build()).addOffloadSegment(
-                MLDataFormats.OffloadSegment.newBuilder()
+                        .setComplete(true).setEndEntryId(9);
+        contextBuilder.addOffloadSegment()
                         .setUidLsb(uuid2.getLeastSignificantBits())
                         .setUidMsb(uuid2.getMostSignificantBits())
-                        .setComplete(true).setEndEntryId(19).build()
-        );
+                        .setComplete(true).setEndEntryId(19);
 
-        final ReadHandle readHandle = offloader.readOffloaded(0, contextBuilder.build(), driverMeta).get();
+        final ReadHandle readHandle = offloader.readOffloaded(0, contextBuilder, driverMeta).get();
 
         for (int i = 0; i <= 19; i++) {
             Random seed = new Random(0);
@@ -428,14 +421,13 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
         final LedgerOffloader.OffloadResult offloadResult = offloadHandle.getOffloadResultAsync().get();
         assertEquals(offloadResult.endLedger, 0);
         assertEquals(offloadResult.endEntry, 9);
-        final OffloadContext.Builder contextBuilder = OffloadContext.newBuilder();
-        contextBuilder.addOffloadSegment(
-                MLDataFormats.OffloadSegment.newBuilder()
+        final OffloadContext contextBuilder = new OffloadContext();
+        contextBuilder.addOffloadSegment()
                         .setUidLsb(uuid.getLeastSignificantBits())
                         .setUidMsb(uuid.getMostSignificantBits())
-                        .setComplete(true).setEndEntryId(9).build());
+                        .setComplete(true).setEndEntryId(9);
 
-        final ReadHandle readHandle = offloader.readOffloaded(0, contextBuilder.build(), driverMeta).get();
+        final ReadHandle readHandle = offloader.readOffloaded(0, contextBuilder, driverMeta).get();
         try {
             readHandle.read(-1, -1);
             Assert.fail("Shouldn't be able to read anything");
@@ -480,14 +472,13 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
         final LedgerOffloader.OffloadResult offloadResult = offloadHandle.getOffloadResultAsync().get();
         assertEquals(offloadResult.endLedger, 0);
         assertEquals(offloadResult.endEntry, 9);
-        final OffloadContext.Builder contextBuilder = OffloadContext.newBuilder();
-        contextBuilder.addOffloadSegment(
-                MLDataFormats.OffloadSegment.newBuilder()
+        final OffloadContext contextBuilder = new OffloadContext();
+        contextBuilder.addOffloadSegment()
                         .setUidLsb(uuid.getLeastSignificantBits())
                         .setUidMsb(uuid.getMostSignificantBits())
-                        .setComplete(true).setEndEntryId(9).build());
+                        .setComplete(true).setEndEntryId(9);
 
-        final ReadHandle readHandle = offloader.readOffloaded(0, contextBuilder.build(), driverMeta).get();
+        final ReadHandle readHandle = offloader.readOffloaded(0, contextBuilder, driverMeta).get();
 
         // delete blob(ledger)
         blobStore.removeBlob(BUCKET, uuid.toString());

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/MockManagedLedger.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/MockManagedLedger.java
@@ -351,13 +351,13 @@ public class MockManagedLedger implements ManagedLedger {
 
     @Override
     public CompletableFuture<LedgerInfo> getLedgerInfo(long ledgerId) {
-        final LedgerInfo build = LedgerInfo.newBuilder().setLedgerId(ledgerId).setSize(100).setEntries(20).build();
+        final LedgerInfo build = new LedgerInfo().setLedgerId(ledgerId).setSize(100).setEntries(20);
         return CompletableFuture.completedFuture(build);
     }
 
     @Override
     public Optional<LedgerInfo> getOptionalLedgerInfo(long ledgerId) {
-        final LedgerInfo build = LedgerInfo.newBuilder().setLedgerId(ledgerId).setSize(100).setEntries(20).build();
+        final LedgerInfo build = new LedgerInfo().setLedgerId(ledgerId).setSize(100).setEntries(20);
         return Optional.of(build);
     }
 

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/MockManagedLedger.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/MockManagedLedger.java
@@ -37,6 +37,8 @@ import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.Ledge
 import org.apache.pulsar.common.api.proto.CommandSubscribe;
 import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats;
 
+import static org.apache.bookkeeper.mledger.impl.LightProtoHelper.createLedgerInfo;
+
 @Slf4j
 public class MockManagedLedger implements ManagedLedger {
     @Override
@@ -351,13 +353,13 @@ public class MockManagedLedger implements ManagedLedger {
 
     @Override
     public CompletableFuture<LedgerInfo> getLedgerInfo(long ledgerId) {
-        final LedgerInfo build = new LedgerInfo().setLedgerId(ledgerId).setSize(100).setEntries(20);
+        final LedgerInfo build = createLedgerInfo().setLedgerId(ledgerId).setSize(100).setEntries(20);
         return CompletableFuture.completedFuture(build);
     }
 
     @Override
     public Optional<LedgerInfo> getOptionalLedgerInfo(long ledgerId) {
-        final LedgerInfo build = new LedgerInfo().setLedgerId(ledgerId).setSize(100).setEntries(20);
+        final LedgerInfo build = createLedgerInfo().setLedgerId(ledgerId).setSize(100).setEntries(20);
         return Optional.of(build);
     }
 

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/OffloadIndexTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/OffloadIndexTest.java
@@ -106,7 +106,7 @@ public class OffloadIndexTest {
         metadataCustom.put("key1", "value1".getBytes(UTF_8));
         metadataCustom.put("key7", "value7".getBytes(UTF_8));
 
-        return LedgerInfo.newBuilder().setLedgerId(id).setEntries(5001).setSize(10000).build();
+        return new LedgerInfo().setLedgerId(id).setEntries(5001).setSize(10000);
     }
 
     // prepare metadata, then use builder to build a OffloadIndexBlockImpl

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/OffloadIndexTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/OffloadIndexTest.java
@@ -35,6 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.LedgerMetadataBuilder;
 import org.apache.bookkeeper.client.api.DigestType;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
+import org.apache.bookkeeper.mledger.impl.LightProtoHelper;
 import org.apache.bookkeeper.mledger.offload.jcloud.OffloadIndexBlock;
 import org.apache.bookkeeper.mledger.offload.jcloud.OffloadIndexBlockBuilder;
 import org.apache.bookkeeper.mledger.offload.jcloud.OffloadIndexEntry;
@@ -106,7 +107,7 @@ public class OffloadIndexTest {
         metadataCustom.put("key1", "value1".getBytes(UTF_8));
         metadataCustom.put("key7", "value7".getBytes(UTF_8));
 
-        return new LedgerInfo().setLedgerId(id).setEntries(5001).setSize(10000);
+        return LightProtoHelper.createLedgerInfo().setLedgerId(id).setEntries(5001).setSize(10000);
     }
 
     // prepare metadata, then use builder to build a OffloadIndexBlockImpl


### PR DESCRIPTION
### Motivation

Speed up protobuf operations, reduce GC pressure

### Modifications

Switched managedLedger subproject to lightproto, updated API usage

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

NO

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


