### PR TITLE
Prevent ZK connection loss in case of huge cursor status

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
@@ -249,6 +249,8 @@ public class MetaStoreImpl implements MetaStore, Consumer<Notification> {
 
         String path = PREFIX + ledgerName + "/" + cursorName;
         byte[] content = compressCursorInfo(info);
+        log.info("[{}] Persisting cursor={} info with content size {} bytes to metastore",
+                ledgerName, cursorName, content.length);
 
         long expectedVersion;
 
@@ -267,6 +269,7 @@ public class MetaStoreImpl implements MetaStore, Consumer<Notification> {
                 .thenAcceptAsync(optStat -> callback.operationComplete(null, optStat), executor
                         .chooseThread(ledgerName))
                 .exceptionally(ex -> {
+                    log.error("[{}] [{}] Failed to update cursor info", ledgerName, cursorName, ex);
                     executor.executeOrdered(ledgerName,
                             () -> callback.operationFailed(getException(ex)));
                     return null;
@@ -525,6 +528,8 @@ public class MetaStoreImpl implements MetaStore, Consumer<Notification> {
             compositeByteBuf.addComponent(true, encodeByteBuf);
             byte[] dataBytes = new byte[compositeByteBuf.readableBytes()];
             compositeByteBuf.readBytes(dataBytes);
+            log.info("Compressed cursor info, info size {}, metadata size {}, compressed size: {}",
+                    info.length, metadata.length, dataBytes.length);
             return dataBytes;
         } finally {
             if (metadataByteBuf != null) {


### PR DESCRIPTION
Motivation:
- in some cases ManagedCursorImpl dump the list of individuallyDeletedMessages to ZK and writes a znode bigger than 1MB
- this triggers a connection drop from the ZK server, because of the limit of 1MB messages on the wire protocol

Changes:
- log more
- when generating the list of individuallyDeletedMessages, stop at 1MB - 10KB, this is an hard coded limit, to be made configurable in the future
- do not print `individualDeletedMessages.size()` that is rather expensive

Ideal solutions, not possible in a POC:
- change the ZK client and return an error on the client, preventing the server to receive a big message
- ensure that we never write to ZK the cursor info if it is to big (there are 2 cases)