### PR TITLE
[broker] EntryFilters fix NoClassDefFoundError due to closed classloader

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/plugin/EntryFilterProvider.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/plugin/EntryFilterProvider.java
@@ -197,7 +197,8 @@ public class EntryFilterProvider implements AutoCloseable {
                         + " does not implement entry filter interface");
             }
             EntryFilter pi = (EntryFilter) filter;
-            return new EntryFilterWithClassLoader(pi, ncl);
+            // the classloader is shared with the broker, the instance doesn't own it
+            return new EntryFilterWithClassLoader(pi, ncl, false);
         } catch (Throwable e) {
             if (e instanceof IOException) {
                 throw (IOException) e;


### PR DESCRIPTION
Reproducer:
- configure one EntryFilter in broker.conf
- create a topic (this in turn creates an `EntryFilterWithClassLoader` instance)
- do not use the EntryFilter (don't consume messages)
- unload the topic (this calls EntryFilterWithClassLoader.close() that calls ClassLoader.close())
- consume data from any topic that uses the entry filter
- CRASH ! because the Classloader is closed and it cannot load any other classes

Mofications:
- make it clear that EntryFilterWithClassLoader is not owning the classloader
- enforce also using the Thread ContextClassloader in EntryFilterWithClassLoader (this is another problem, but it didn't affect the specific usecase reported by the user)


Stacktrace:
```
2024-05-09T13:16:13,145+0000 [broker-topic-workers-OrderedExecutor-0-0] ERROR org.apache.bookkeeper.common.util.SingleThreadExecutor - Error while running task: com/datastax/oss/pulsar/jms/selectors/SelectorSupport
java.lang.NoClassDefFoundError: com/datastax/oss/pulsar/jms/selectors/SelectorSupport
        at com.datastax.oss.pulsar.jms.selectors.JMSFilter.parseSelector(JMSFilter.java:309) ~[?:?]
        at com.datastax.oss.pulsar.jms.selectors.JMSFilter.filterEntry(JMSFilter.java:245) ~[?:?]
        at com.datastax.oss.pulsar.jms.selectors.JMSFilter.filterEntry(JMSFilter.java:130) ~[?:?]
        at org.apache.pulsar.broker.service.plugin.EntryFilterWithClassLoader.filterEntry(EntryFilterWithClassLoader.java:41) ~[com.datastax.oss-pulsar-broker-3.1.4.1-SNAPSHOT.jar:3.1.4.1-SNAPSHOT]
        at org.apache.pulsar.broker.service.EntryFilterSupport.getFilterResult(EntryFilterSupport.java:85) ~[com.datastax.oss-pulsar-broker-3.1.4.1-SNAPSHOT.jar:3.1.4.1-SNAPSHOT]
        at org.apache.pulsar.broker.service.EntryFilterSupport.runFiltersForEntry(EntryFilterSupport.java:66) ~[com.datastax.oss-pulsar-broker-3.1.4.1-SNAPSHOT.jar:3.1.4.1-SNAPSHOT]
        at org.apache.pulsar.broker.service.AbstractBaseDispatcher.filterEntriesForConsumer(AbstractBaseDispatcher.java:151) ~[com.datastax.oss-pulsar-broker-3.1.4.1-SNAPSHOT.jar:3.1.4.1-SNAPSHOT]
        at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers.trySendMessagesToConsumers(PersistentDispatcherMultipleConsumers.java:749) ~[com.datastax.oss-pulsar-broker-3.1.4.1-SNAPSHOT.jar:3.1.4.1-SNAPSHOT]
        at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers.sendMessagesToConsumers(PersistentDispatcherMultipleConsumers.java:654) ~[com.datastax.oss-pulsar-broker-3.1.4.1-SNAPSHOT.jar:3.1.4.1-SNAPSHOT]
        at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers.lambda$readEntriesComplete$8(PersistentDispatcherMultipleConsumers.java:619) ~[com.datastax.oss-pulsar-broker-3.1.4.1-SNAPSHOT.jar:3.1.4.1-SNAPSHOT]
        at org.apache.bookkeeper.common.util.SingleThreadExecutor.safeRunTask(SingleThreadExecutor.java:137) ~[org.apache.bookkeeper-bookkeeper-common-4.16.5-fx-796523d3ea.jar:4.16.5-fx-796523d3ea]
        at org.apache.bookkeeper.common.util.SingleThreadExecutor.run(SingleThreadExecutor.java:113) ~[org.apache.bookkeeper-bookkeeper-common-4.16.5-fx-796523d3ea.jar:4.16.5-fx-796523d3ea]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.108.Final.jar:4.1.108.Final]
        at java.lang.Thread.run(Thread.java:842) ~[?:?]
Caused by: java.lang.ClassNotFoundException: com.datastax.oss.pulsar.jms.selectors.SelectorSupport
        at java.net.URLClassLoader.findClass(URLClassLoader.java:445) ~[?:?]
        at java.lang.ClassLoader.loadClass(ClassLoader.java:587) ~[?:?]
        at java.lang.ClassLoader.loadClass(ClassLoader.java:520) ~[?:?]
        ... 14 more
```