### PR TITLE
AS-4027: add string write function

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/SimpleTextOutputStream.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/SimpleTextOutputStream.java
@@ -56,6 +56,15 @@ public class SimpleTextOutputStream {
         return this;
     }
 
+    public SimpleTextOutputStream write(String s) {
+        if (s == null) {
+            return this;
+        }
+
+        buffer.writeCharSequence(s, CharsetUtil.UTF_8);
+        return this;
+    }
+
     public SimpleTextOutputStream write(CharSequence s) {
         if (s == null) {
             return this;


### PR DESCRIPTION
Addresses
```
2024-08-23T20:40:42,618+0000 [pulsar-stats-updater-OrderedScheduler-0-0] WARN  org.apache.bookkeeper.common.util.SingleThreadSafeScheduledExecutorService - Unexpected throwable from task class com.google.common.util.concurrent.MoreExecutors$ScheduledListeningDecorator$NeverSuccessfulListenableFutureTask: 'org.apache.pulsar.common.util.SimpleTextOutputStream org.apache.pulsar.common.util.SimpleTextOutputStream.write(java.lang.String)'
java.lang.NoSuchMethodError: 'org.apache.pulsar.common.util.SimpleTextOutputStream org.apache.pulsar.common.util.SimpleTextOutputStream.write(java.lang.String)'
        at org.apache.pulsar.utils.StatsOutputStream.startObject(StatsOutputStream.java:41) ~[com.datastax.oss-pulsar-broker-3.1.3.1.jar:3.1.3.1]
        at org.apache.pulsar.broker.service.PulsarStats.lambda$updateStats$4(PulsarStats.java:126) ~[com.datastax.oss-pulsar-broker-3.1.3.1.jar:3.1.3.1]
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.forEach(ConcurrentOpenHashMap.java:563) ~[com.datastax.oss-pulsar-common-3.1.3.1.jar:3.1.3.1]
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.forEach(ConcurrentOpenHashMap.java:277) ~[com.datastax.oss-pulsar-common-3.1.3.1.jar:3.1.3.1]
        at org.apache.pulsar.broker.service.PulsarStats.updateStats(PulsarStats.java:120) ~[com.datastax.oss-pulsar-broker-3.1.3.1.jar:3.1.3.1]
        at org.apache.pulsar.broker.service.BrokerService.updateRates(BrokerService.java:2065) ~[com.datastax.oss-pulsar-broker-3.1.3.1.jar:3.1.3.1]
        at com.google.common.util.concurrent.MoreExecutors$ScheduledListeningDecorator$NeverSuccessfulListenableFutureTask.run(MoreExecutors.java:741) ~[com.google.guava-guava-32.1.1-jre.jar:?]
        at org.apache.bookkeeper.common.util.SingleThreadSafeScheduledExecutorService$SafeRunnable.run(SingleThreadSafeScheduledExecutorService.java:46) ~[org.apache.bookkeeper-bookkeeper-common-4.16.4.jar:4.16.4]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) ~[?:?]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) ~[?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.108.Final.jar:4.1.108.Final]
        at java.lang.Thread.run(Thread.java:840) ~[?:?]
```
which happens in metrics end point