### PR TITLE
[improve][misc] Added update-datastax-license-version.sh to update datastax jar licenses automatically while releasing 3.1

### DIFF
--- a/src/update-datastax-license-version.sh
+++ b/src/update-datastax-license-version.sh
@@ -1,5 +1,24 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 
+set -e
 if [ "$#" -ne 3 ]; then
   echo "Usage: $0 <filename> <current_version> <new_version>"
   exit 1

--- a/src/update-datastax-license-version.sh
+++ b/src/update-datastax-license-version.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+if [ "$#" -ne 3 ]; then
+  echo "Usage: $0 <filename> <current_version> <new_version>"
+  exit 1
+fi
+
+FILENAME="$1"
+CURRENT_VERSION="$2"
+NEXT_VERSION="$3"
+
+echo "$FILENAME"
+echo "$CURRENT_VERSION"
+echo "$NEXT_VERSION"
+
+if [ ! -f "$FILENAME" ]; then
+  echo "Error: File '$FILENAME' not found!"
+  exit 1
+fi
+
+while IFS= read -r LINE; do
+  if [[ "$LINE" == *"$CURRENT_VERSION"* ]]; then
+    UPDATED_LINE="${LINE/$CURRENT_VERSION/$NEXT_VERSION}"
+    echo "$UPDATED_LINE"
+  else
+    echo "$LINE"
+  fi
+done < "$FILENAME" > "$FILENAME.new"
+
+mv "$FILENAME.new" "$FILENAME"
+echo "License file '$FILENAME' updated successfully."


### PR DESCRIPTION
### Motivation

We used to update the datastax jars licenses manually before releasing the lunastreaming 3.1, like this [commit](https://github.com/datastax/pulsar/commit/23d53f90e202062e747289116542cab274d2937a).
With this fix the licenses will be automatically updated as part of the release process.

### Modifications

Added src/update-datastax-license-version.sh
Related PR: [pulsar-distro fix](https://github.com/riptano/pulsar-distro/pull/118)

### Verifying this change

- [X] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
- [X] `no-need-doc` 
- [ ] `doc` 
 


