### PR TITLE
[fix][test] Fixes GetPartitionMetadataTest checking for linux NIC speed

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataTest.java
@@ -144,6 +144,7 @@ public class GetPartitionMetadataTest extends TestRetrySupport {
         conf.setBrokerDeleteInactiveTopicsEnabled(false);
         conf.setBrokerShutdownTimeoutMs(0L);
         conf.setLoadBalancerSheddingEnabled(false);
+        conf.setLoadBalancerOverrideBrokerNicSpeedGbps(Optional.of(1.0d));
     }
 
     protected PulsarClientImpl[] getClientsToTest() {


### PR DESCRIPTION

### Motivation

This PR fixes the GetPartitionMetadataTest and GetPartitionMetadataMultiBrokerTest that is consistently failing in post commit job.


### Modifications

Set `LoadBalancerOverrideBrokerNicSpeedGbps` configuration manually so that the test doesn't try to fetch from the Linux instance.
This test doesn't depend on NIC speed functionally.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


