### PR TITLE
[fix][broker] Allow broker deployment in heterogeneous hw config cluster without restricting nic speed detection

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -83,7 +83,6 @@ import org.apache.pulsar.broker.intercept.BrokerInterceptor;
 import org.apache.pulsar.broker.intercept.BrokerInterceptors;
 import org.apache.pulsar.broker.loadbalance.LeaderBroker;
 import org.apache.pulsar.broker.loadbalance.LeaderElectionService;
-import org.apache.pulsar.broker.loadbalance.LinuxInfoUtils;
 import org.apache.pulsar.broker.loadbalance.LoadManager;
 import org.apache.pulsar.broker.loadbalance.LoadReportUpdaterTask;
 import org.apache.pulsar.broker.loadbalance.LoadResourceQuotaUpdaterTask;
@@ -745,14 +744,6 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                                 + "the retention time duration is %d",
                         config.getBacklogQuotaDefaultLimitSecond(),
                         config.getDefaultRetentionTimeInMinutes() * 60));
-            }
-
-            if (config.getLoadBalancerOverrideBrokerNicSpeedGbps().isEmpty()
-                    && config.isLoadBalancerEnabled()
-                    && LinuxInfoUtils.isLinux()
-                    && !LinuxInfoUtils.checkHasNicSpeeds()) {
-                throw new IllegalStateException("Unable to read VM NIC speed. You must set "
-                        + "[loadBalancerOverrideBrokerNicSpeedGbps] to override it when load balancer is enabled.");
             }
 
             localMetadataSynchronizer = StringUtils.isNotBlank(config.getMetadataSyncEventTopic())

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -224,6 +224,14 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
         TopicName topicName = TopicName.get(defaultTestNamespace + "/test-check-ownership");
         NamespaceBundle bundle = getBundleAsync(pulsar1, topicName).get();
         // 1. The bundle is never assigned.
+        retryStrategically((test) -> {
+            try {
+                return !primaryLoadManager.checkOwnershipAsync(Optional.empty(), bundle).get()
+                        && !secondaryLoadManager.checkOwnershipAsync(Optional.empty(), bundle).get();
+            } catch (Exception e) {
+                return false;
+            }
+        }, 5, 200);
         assertFalse(primaryLoadManager.checkOwnershipAsync(Optional.empty(), bundle).get());
         assertFalse(secondaryLoadManager.checkOwnershipAsync(Optional.empty(), bundle).get());
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.tests.integration.loadbalance;
 
 import static org.apache.pulsar.tests.integration.containers.PulsarContainer.BROKER_HTTP_PORT;
+import static org.apache.pulsar.tests.integration.suites.PulsarTestSuite.retryStrategically;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -388,7 +389,9 @@ public class ExtensibleLoadManagerTest extends TestRetrySupport {
 
         Awaitility.await().atMost(60, TimeUnit.SECONDS).ignoreExceptions().untilAsserted(() -> {
             String ownerBroker = admin.lookups().lookupTopicAsync(topic).get(5, TimeUnit.SECONDS);
-            assertEquals(extractBrokerIndex(ownerBroker), 1);
+            final String brokerName = broker;
+        retryStrategically((test) -> extractBrokerIndex(brokerName) == 1, 100, 200);
+        assertEquals(extractBrokerIndex(ownerBroker), 1);
         });
 
         for (BrokerContainer container : pulsarCluster.getBrokers()) {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.tests.integration.loadbalance;
 
 import static org.apache.pulsar.tests.integration.containers.PulsarContainer.BROKER_HTTP_PORT;
-import static org.apache.pulsar.tests.integration.suites.PulsarTestSuite.retryStrategically;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -389,9 +388,7 @@ public class ExtensibleLoadManagerTest extends TestRetrySupport {
 
         Awaitility.await().atMost(60, TimeUnit.SECONDS).ignoreExceptions().untilAsserted(() -> {
             String ownerBroker = admin.lookups().lookupTopicAsync(topic).get(5, TimeUnit.SECONDS);
-            final String brokerName = broker;
-        retryStrategically((test) -> extractBrokerIndex(brokerName) == 1, 100, 200);
-        assertEquals(extractBrokerIndex(ownerBroker), 1);
+            assertEquals(extractBrokerIndex(ownerBroker), 1);
         });
 
         for (BrokerContainer container : pulsarCluster.getBrokers()) {


### PR DESCRIPTION
### Motivation

Broker service unavailability during upgrades in heterogeneous hardware clusters occurs because the PR fails to account for varying NIC speeds across different VM types. Consequently, broker startups are failing on all VMs, and the workaround using `loadBalancerOverrideBrokerNicSpeedGbps` is ineffective due to the inability to manage diverse configurations for each broker.

Additionally, the changes were removed from `ExtensibleLoadManagerTest.java` as the test was failing. Here is the commit that removed the changes: (https://github.com/datastax/pulsar/pull/345/commits/0c07ca28db2ef1bcee1868ffc8fac742ac0b5fd0).

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

Need to update docs? 

- [ ] `doc-required` 
  
- [x] `no-need-doc` 
  
- [ ] `doc` 
