### PR TITLE
[improve][fn]: Added logLevel to change the log level of Function/Source/Sink Pod/Process to desired Level

### DIFF
--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/functions/FunctionConfig.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/functions/FunctionConfig.java
@@ -88,6 +88,7 @@ public class FunctionConfig {
 
     private String outputSerdeClassName;
     private String logTopic;
+    private String logLevel;
     private ProcessingGuarantees processingGuarantees;
     // Do we want function instances to process data in the same order as in the input topics
     // This essentially means that every partition of input topic is consumed by only one instance

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/io/SinkConfig.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/io/SinkConfig.java
@@ -62,6 +62,8 @@ public class SinkConfig {
 
     private String deadLetterTopic;
 
+    private String logLevel;
+
     private Map<String, Object> configs;
     // This is a map of secretName(aka how the secret is going to be
     // accessed in the function via context) to an object that

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/io/SourceConfig.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/io/SourceConfig.java
@@ -48,6 +48,8 @@ public class SourceConfig {
 
     private String schemaType;
 
+    private String logLevel;
+
     private Map<String, Object> configs;
     // This is a map of secretName(aka how the secret is going to be
     // accessed in the function via context) to an object that

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -249,7 +249,7 @@ public class CmdFunctions extends CmdBase {
         @Parameter(names = "--log-topic", description = "The topic to which the logs of a Pulsar Function are produced"
                 + " #Java, Python, Go")
         protected String logTopic;
-        @Parameter(names = "--logLevel", description = "Log level to which the logs of a Pulsar Function is produced"
+        @Parameter(names = "--logLevel", description = "Log level at which the logs of a Pulsar Function are produced"
                 + " #Java")
         protected String logLevel;
         @Parameter(names = {"-st", "--schema-type"}, description = "The builtin schema type or "
@@ -521,7 +521,6 @@ public class CmdFunctions extends CmdBase {
                 functionConfig.setLogTopic(logTopic);
             }
             if (null != logLevel) {
-                log.info("CmdFunctions: " + logLevel);
                 functionConfig.setLogLevel(logLevel);
             }
             if (null != className) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -249,7 +249,9 @@ public class CmdFunctions extends CmdBase {
         @Parameter(names = "--log-topic", description = "The topic to which the logs of a Pulsar Function are produced"
                 + " #Java, Python, Go")
         protected String logTopic;
-
+        @Parameter(names = "--logLevel", description = "The log level to which the logs of a Pulsar Function are produced"
+                + " #Java")
+        protected String logLevel;
         @Parameter(names = {"-st", "--schema-type"}, description = "The builtin schema type or "
                 + "custom schema class name to be used for messages output by the function #Java")
         protected String schemaType = "";
@@ -517,6 +519,9 @@ public class CmdFunctions extends CmdBase {
             }
             if (null != logTopic) {
                 functionConfig.setLogTopic(logTopic);
+            }
+            if (null != logLevel) {
+                functionConfig.setLogLevel(logLevel);
             }
             if (null != className) {
                 functionConfig.setClassName(className);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -249,7 +249,7 @@ public class CmdFunctions extends CmdBase {
         @Parameter(names = "--log-topic", description = "The topic to which the logs of a Pulsar Function are produced"
                 + " #Java, Python, Go")
         protected String logTopic;
-        @Parameter(names = "--logLevel", description = "The log level to which the logs of a Pulsar Function are produced"
+        @Parameter(names = "--logLevel", description = "Log level to which the logs of a Pulsar Function is produced"
                 + " #Java")
         protected String logLevel;
         @Parameter(names = {"-st", "--schema-type"}, description = "The builtin schema type or "
@@ -521,6 +521,7 @@ public class CmdFunctions extends CmdBase {
                 functionConfig.setLogTopic(logTopic);
             }
             if (null != logLevel) {
+                log.info("CmdFunctions: " + logLevel);
                 functionConfig.setLogLevel(logLevel);
             }
             if (null != className) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -410,7 +410,8 @@ public class CmdSinks extends CmdBase {
         @Parameter(names = "--transform-function-config", description = "Configuration of the transform function "
                 + "applied before the Sink")
         protected String transformFunctionConfig;
-
+        @Parameter(names = "--logLevel", description = "Log level to which the logs of a Pulsar Sink is produced")
+        protected String logLevel;
         protected SinkConfig sinkConfig;
 
         private void mergeArgs() {
@@ -604,6 +605,11 @@ public class CmdSinks extends CmdBase {
 
             if (transformFunctionConfig != null) {
                 sinkConfig.setTransformFunctionConfig(transformFunctionConfig);
+            }
+
+            if (null != logLevel) {
+                log.info("CmdSinks: " + logLevel);
+                sinkConfig.setLogLevel(logLevel);
             }
 
             // check if configs are valid

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -410,7 +410,7 @@ public class CmdSinks extends CmdBase {
         @Parameter(names = "--transform-function-config", description = "Configuration of the transform function "
                 + "applied before the Sink")
         protected String transformFunctionConfig;
-        @Parameter(names = "--logLevel", description = "Log level to which the logs of a Pulsar Sink is produced")
+        @Parameter(names = "--logLevel", description = "Log level at which the logs of a Pulsar Sink are produced")
         protected String logLevel;
         protected SinkConfig sinkConfig;
 
@@ -608,7 +608,6 @@ public class CmdSinks extends CmdBase {
             }
 
             if (null != logLevel) {
-                log.info("CmdSinks: " + logLevel);
                 sinkConfig.setLogLevel(logLevel);
             }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -365,7 +365,7 @@ public class CmdSources extends CmdBase {
         @Parameter(names = "--secrets", description = "The map of secretName to an object that encapsulates "
                 + "how the secret is fetched by the underlying secrets provider")
         protected String secretsString;
-        @Parameter(names = "--logLevel", description = "Log level to which the logs of a Pulsar Source is produced")
+        @Parameter(names = "--logLevel", description = "Log level at which the logs of a Pulsar Source are produced")
         protected String logLevel;
 
         protected SourceConfig sourceConfig;
@@ -502,7 +502,6 @@ public class CmdSources extends CmdBase {
             }
 
             if (null != logLevel) {
-                log.info("CmdSources: " + logLevel);
                 sourceConfig.setLogLevel(logLevel);
             }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -365,6 +365,8 @@ public class CmdSources extends CmdBase {
         @Parameter(names = "--secrets", description = "The map of secretName to an object that encapsulates "
                 + "how the secret is fetched by the underlying secrets provider")
         protected String secretsString;
+        @Parameter(names = "--logLevel", description = "Log level to which the logs of a Pulsar Source is produced")
+        protected String logLevel;
 
         protected SourceConfig sourceConfig;
 
@@ -497,6 +499,11 @@ public class CmdSources extends CmdBase {
                     secretsMap = Collections.emptyMap();
                 }
                 sourceConfig.setSecrets(secretsMap);
+            }
+
+            if (null != logLevel) {
+                log.info("CmdSources: " + logLevel);
+                sourceConfig.setLogLevel(logLevel);
             }
 
             // check if source configs are valid

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/go/GoInstanceConfig.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/go/GoInstanceConfig.java
@@ -43,7 +43,6 @@ public class GoInstanceConfig {
     private String name = "";
     private String className = "";
     private String logTopic = "";
-    private String logLevel = "";
     private int processingGuarantees;
     private String secretsMap = "";
     private String userConfig = "";

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/go/GoInstanceConfig.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/go/GoInstanceConfig.java
@@ -43,6 +43,7 @@ public class GoInstanceConfig {
     private String name = "";
     private String className = "";
     private String logTopic = "";
+    private String logLevel = "";
     private int processingGuarantees;
     private String secretsMap = "";
     private String userConfig = "";

--- a/pulsar-functions/proto/src/main/proto/Function.proto
+++ b/pulsar-functions/proto/src/main/proto/Function.proto
@@ -98,6 +98,7 @@ message FunctionDetails {
     bool retainOrdering = 21;
     bool retainKeyOrdering = 22;
     SubscriptionPosition subscriptionPosition = 23;
+    string logLevel = 24;
 }
 
 message ConsumerSpec {

--- a/pulsar-functions/runtime-all/src/main/resources/java_instance_log4j2.xml
+++ b/pulsar-functions/runtime-all/src/main/resources/java_instance_log4j2.xml
@@ -120,7 +120,7 @@
             </AppenderRef>
         </Logger>
         <Root>
-            <level>info</level>
+            <level>${sys:pulsar.log.level}</level>
             <AppenderRef>
                 <ref>${sys:pulsar.log.appender}</ref>
                 <level>${sys:pulsar.log.level}</level>

--- a/pulsar-functions/runtime-all/src/main/resources/kubernetes_instance_log4j2.xml
+++ b/pulsar-functions/runtime-all/src/main/resources/kubernetes_instance_log4j2.xml
@@ -50,7 +50,7 @@
             </AppenderRef>
         </Logger>
         <Root>
-            <level>info</level>
+            <level>${sys:pulsar.log.level}</level>
             <AppenderRef>
                 <ref>Console</ref>
                 <level>${sys:pulsar.log.level}</level>

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
@@ -183,9 +183,6 @@ public class RuntimeUtils {
         if (instanceConfig.getFunctionDetails().getLogTopic() != null) {
             goInstanceConfig.setLogTopic(instanceConfig.getFunctionDetails().getLogTopic());
         }
-        if (instanceConfig.getFunctionDetails().getLogLevel() != null) {
-            goInstanceConfig.setLogLevel(instanceConfig.getFunctionDetails().getLogLevel());
-        }
         if (instanceConfig.getFunctionDetails().getProcessingGuarantees() != null) {
             goInstanceConfig
                     .setProcessingGuarantees(instanceConfig.getFunctionDetails().getProcessingGuaranteesValue());
@@ -359,7 +356,6 @@ public class RuntimeUtils {
                 }
                 args.add(String.format("-D%s=%s", FUNCTIONS_INSTANCE_CLASSPATH, systemFunctionInstanceClasspath));
             }
-            log.info("-Dpulsar.log.level=" + logLevel);
             args.add("-Dpulsar.log.level=" + logLevel);
             args.add("-Dlog4j.configurationFile=" + logConfigFile);
             args.add("-Dpulsar.function.log.dir=" + genFunctionLogFolder(logDirectory, instanceConfig));

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
@@ -359,6 +359,7 @@ public class RuntimeUtils {
                 }
                 args.add(String.format("-D%s=%s", FUNCTIONS_INSTANCE_CLASSPATH, systemFunctionInstanceClasspath));
             }
+            log.info("-Dpulsar.log.level=" + logLevel);
             args.add("-Dpulsar.log.level=" + logLevel);
             args.add("-Dlog4j.configurationFile=" + logConfigFile);
             args.add("-Dpulsar.function.log.dir=" + genFunctionLogFolder(logDirectory, instanceConfig));

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
@@ -78,6 +78,7 @@ public class RuntimeUtils {
                                           Integer grpcPort,
                                           Long expectedHealthCheckInterval,
                                           String logConfigFile,
+                                          String logLevel,
                                           String secretsProviderClassName,
                                           String secretsProviderConfig,
                                           Boolean installUserCodeDependencies,
@@ -92,7 +93,7 @@ public class RuntimeUtils {
         cmd.addAll(getCmd(instanceConfig, instanceFile, extraDependenciesDir, logDirectory,
                 originalCodeFileName, originalTransformFunctionFileName, pulsarServiceUrl, stateStorageServiceUrl,
                 authConfig, shardId, grpcPort, expectedHealthCheckInterval,
-                logConfigFile, secretsProviderClassName, secretsProviderConfig,
+                logConfigFile, logLevel, secretsProviderClassName, secretsProviderConfig,
                 installUserCodeDependencies, pythonDependencyRepository,
                 pythonExtraDependencyRepository, narExtractionDirectory,
                 functionInstanceClassPath, false, pulsarWebServiceUrl));
@@ -181,6 +182,9 @@ public class RuntimeUtils {
 
         if (instanceConfig.getFunctionDetails().getLogTopic() != null) {
             goInstanceConfig.setLogTopic(instanceConfig.getFunctionDetails().getLogTopic());
+        }
+        if (instanceConfig.getFunctionDetails().getLogLevel() != null) {
+            goInstanceConfig.setLogLevel(instanceConfig.getFunctionDetails().getLogLevel());
         }
         if (instanceConfig.getFunctionDetails().getProcessingGuarantees() != null) {
             goInstanceConfig
@@ -309,6 +313,7 @@ public class RuntimeUtils {
                                       Integer grpcPort,
                                       Long expectedHealthCheckInterval,
                                       String logConfigFile,
+                                      String logLevel,
                                       String secretsProviderClassName,
                                       String secretsProviderConfig,
                                       Boolean installUserCodeDependencies,
@@ -354,6 +359,7 @@ public class RuntimeUtils {
                 }
                 args.add(String.format("-D%s=%s", FUNCTIONS_INSTANCE_CLASSPATH, systemFunctionInstanceClasspath));
             }
+            args.add("-Dpulsar.log.level=" + logLevel);
             args.add("-Dlog4j.configurationFile=" + logConfigFile);
             args.add("-Dpulsar.function.log.dir=" + genFunctionLogFolder(logDirectory, instanceConfig));
             args.add("-Dpulsar.function.log.file=" + String.format(

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
@@ -237,9 +237,11 @@ public class KubernetesRuntime implements Runtime {
                 break;
         }
         String logLevel = "info";
+        log.info("KubernetesRuntime: " + instanceConfig.getFunctionDetails().getLogLevel());
         if (null != instanceConfig.getFunctionDetails().getLogLevel()) {
             logLevel = instanceConfig.getFunctionDetails().getLogLevel();
         }
+        log.info("KubernetesRuntime: logLevel: " + logLevel);
 
         this.authConfig = authConfig;
 

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
@@ -238,9 +238,9 @@ public class KubernetesRuntime implements Runtime {
                 break;
         }
         String logLevel = instanceConfig.getFunctionDetails().getLogLevel();
-        if (StringUtils.isBlank(logLevel)) logLevel = "info";
-        log.info("KubernetesRuntime: " + instanceConfig.getFunctionDetails().getLogLevel());
-        log.info("KubernetesRuntime: logLevel: " + logLevel);
+        if (StringUtils.isBlank(logLevel)) {
+            logLevel = "info";
+        }
 
         this.authConfig = authConfig;
 

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
@@ -74,6 +74,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Response;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.functions.auth.KubernetesFunctionAuthProvider;
 import org.apache.pulsar.functions.instance.AuthenticationConfig;
 import org.apache.pulsar.functions.instance.InstanceConfig;
@@ -236,11 +237,9 @@ public class KubernetesRuntime implements Runtime {
             case GO:
                 break;
         }
-        String logLevel = "info";
+        String logLevel = instanceConfig.getFunctionDetails().getLogLevel();
+        if (StringUtils.isBlank(logLevel)) logLevel = "info";
         log.info("KubernetesRuntime: " + instanceConfig.getFunctionDetails().getLogLevel());
-        if (null != instanceConfig.getFunctionDetails().getLogLevel()) {
-            logLevel = instanceConfig.getFunctionDetails().getLogLevel();
-        }
         log.info("KubernetesRuntime: logLevel: " + logLevel);
 
         this.authConfig = authConfig;

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
@@ -236,6 +236,10 @@ public class KubernetesRuntime implements Runtime {
             case GO:
                 break;
         }
+        String logLevel = "info";
+        if (null != instanceConfig.getFunctionDetails().getLogLevel()) {
+            logLevel = instanceConfig.getFunctionDetails().getLogLevel();
+        }
 
         this.authConfig = authConfig;
 
@@ -275,6 +279,7 @@ public class KubernetesRuntime implements Runtime {
                         grpcPort,
                         -1L,
                         logConfigFile,
+                        logLevel,
                         secretsProviderClassName,
                         secretsProviderConfig,
                         installUserCodeDependencies,

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/process/ProcessRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/process/ProcessRuntime.java
@@ -122,7 +122,12 @@ class ProcessRuntime implements Runtime {
             case GO:
                 break;
         }
-        String logLevel = instanceConfig.getFunctionDetails().getLogLevel();
+        String logLevel = "info";
+        log.info("KubernetesRuntime: " + instanceConfig.getFunctionDetails().getLogLevel());
+        if (null != instanceConfig.getFunctionDetails().getLogLevel()) {
+            logLevel = instanceConfig.getFunctionDetails().getLogLevel();
+        }
+        log.info("ProcessRuntime: logLevel: " + logLevel);
         this.extraDependenciesDir = extraDependenciesDir;
         this.narExtractionDirectory = narExtractionDirectory;
         this.processArgs = RuntimeUtils.composeCmd(

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/process/ProcessRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/process/ProcessRuntime.java
@@ -123,9 +123,10 @@ class ProcessRuntime implements Runtime {
                 break;
         }
         String logLevel = instanceConfig.getFunctionDetails().getLogLevel();
-        if (StringUtils.isBlank(logLevel)) logLevel = "info";
-        log.info("KubernetesRuntime: " + instanceConfig.getFunctionDetails().getLogLevel());
-        log.info("ProcessRuntime: logLevel: " + logLevel);
+        if (StringUtils.isBlank(logLevel)) {
+            logLevel = "info";
+        }
+
         this.extraDependenciesDir = extraDependenciesDir;
         this.narExtractionDirectory = narExtractionDirectory;
         this.processArgs = RuntimeUtils.composeCmd(

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/process/ProcessRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/process/ProcessRuntime.java
@@ -122,11 +122,9 @@ class ProcessRuntime implements Runtime {
             case GO:
                 break;
         }
-        String logLevel = "info";
+        String logLevel = instanceConfig.getFunctionDetails().getLogLevel();
+        if (StringUtils.isBlank(logLevel)) logLevel = "info";
         log.info("KubernetesRuntime: " + instanceConfig.getFunctionDetails().getLogLevel());
-        if (null != instanceConfig.getFunctionDetails().getLogLevel()) {
-            logLevel = instanceConfig.getFunctionDetails().getLogLevel();
-        }
         log.info("ProcessRuntime: logLevel: " + logLevel);
         this.extraDependenciesDir = extraDependenciesDir;
         this.narExtractionDirectory = narExtractionDirectory;

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/process/ProcessRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/process/ProcessRuntime.java
@@ -122,6 +122,7 @@ class ProcessRuntime implements Runtime {
             case GO:
                 break;
         }
+        String logLevel = instanceConfig.getFunctionDetails().getLogLevel();
         this.extraDependenciesDir = extraDependenciesDir;
         this.narExtractionDirectory = narExtractionDirectory;
         this.processArgs = RuntimeUtils.composeCmd(
@@ -142,6 +143,7 @@ class ProcessRuntime implements Runtime {
             instanceConfig.getPort(),
             expectedHealthCheckInterval,
             logConfigFile,
+            logLevel,
             secretsProviderClassName,
             secretsProviderConfig,
             false,

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/RuntimeUtilsTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/RuntimeUtilsTest.java
@@ -213,6 +213,7 @@ public class RuntimeUtilsTest {
                 23,
                 1234L,
                 "logConfigFile",
+                "info",
                 "secretsProviderClassName",
                 "secretsProviderConfig",
                 false,

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeTest.java
@@ -475,6 +475,7 @@ public class KubernetesRuntimeTest {
         String expectedArgs = "exec java -cp " + classpath
                 + extraDepsEnv
                 + " -Dpulsar.functions.instance.classpath=/pulsar/lib/*"
+                + " -Dpulsar.log.level=info"
                 + " -Dlog4j.configurationFile=kubernetes_instance_log4j2.xml "
                 + "-Dpulsar.function.log.dir=" + logDirectory + "/" + FunctionCommon.getFullyQualifiedName(config.getFunctionDetails())
                 + " -Dpulsar.function.log.file=" + config.getFunctionDetails().getName() + "-$SHARD_ID"

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/process/ProcessRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/process/ProcessRuntimeTest.java
@@ -324,6 +324,7 @@ public class ProcessRuntimeTest {
         String expectedArgs = "java -cp " + classpath
                 + extraDepsEnv
                 + " -Dpulsar.functions.instance.classpath=/pulsar/lib/*"
+                + " -Dpulsar.log.level=info"
                 + " -Dlog4j.configurationFile=java_instance_log4j2.xml "
                 + "-Dpulsar.function.log.dir=" + logDirectory + "/functions/" + FunctionCommon.getFullyQualifiedName(config.getFunctionDetails())
                 + " -Dpulsar.function.log.file=" + config.getFunctionDetails().getName() + "-" + config.getInstanceId()

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -274,6 +274,9 @@ public class FunctionConfigUtils {
         if (functionConfig.getLogTopic() != null) {
             functionDetailsBuilder.setLogTopic(functionConfig.getLogTopic());
         }
+        if (functionConfig.getLogLevel() != null) {
+            functionDetailsBuilder.setLogLevel(functionConfig.getLogLevel());
+        }
         if (functionConfig.getRuntime() != null) {
             functionDetailsBuilder.setRuntime(FunctionCommon.convertRuntime(functionConfig.getRuntime()));
         }
@@ -448,6 +451,9 @@ public class FunctionConfigUtils {
         }
         if (!isEmpty(functionDetails.getLogTopic())) {
             functionConfig.setLogTopic(functionDetails.getLogTopic());
+        }
+        if (!isEmpty(functionDetails.getLogLevel())) {
+            functionConfig.setLogLevel(functionDetails.getLogLevel());
         }
         if (functionDetails.getSink().getForwardSourceMessageProperty()) {
             functionConfig.setForwardSourceMessageProperty(functionDetails.getSink().getForwardSourceMessageProperty());
@@ -809,6 +815,7 @@ public class FunctionConfigUtils {
         }
 
         if (!isEmpty(functionConfig.getLogLevel())) {
+            log.info("functionConfig.getLogLevel(): " + functionConfig.getLogLevel());
             if (!VALID_LOG_LEVELS.contains(functionConfig.getLogLevel().toUpperCase())) {
                 throw new IllegalArgumentException(
                         String.format("LogLevel %s is invalid", functionConfig.getLogLevel()));

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -815,7 +815,6 @@ public class FunctionConfigUtils {
         }
 
         if (!isEmpty(functionConfig.getLogLevel())) {
-            log.info("functionConfig.getLogLevel(): " + functionConfig.getLogLevel());
             if (!VALID_LOG_LEVELS.contains(functionConfig.getLogLevel().toUpperCase())) {
                 throw new IllegalArgumentException(
                         String.format("LogLevel %s is invalid", functionConfig.getLogLevel()));

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -32,6 +32,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import java.io.File;
 import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -70,6 +71,7 @@ public class FunctionConfigUtils {
 
     static final Integer MAX_PENDING_ASYNC_REQUESTS_DEFAULT = 1000;
     static final Boolean FORWARD_SOURCE_MESSAGE_PROPERTY_DEFAULT = Boolean.TRUE;
+    private static final List<String> VALID_LOG_LEVELS = Arrays.asList("INFO", "DEBUG", "WARN", "ERROR");
 
     private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.create();
 
@@ -806,6 +808,13 @@ public class FunctionConfigUtils {
             }
         }
 
+        if (!isEmpty(functionConfig.getLogLevel())) {
+            if (!VALID_LOG_LEVELS.contains(functionConfig.getLogLevel().toUpperCase())) {
+                throw new IllegalArgumentException(
+                        String.format("LogLevel %s is invalid", functionConfig.getLogLevel()));
+            }
+        }
+
         if (functionConfig.getParallelism() != null && functionConfig.getParallelism() <= 0) {
             throw new IllegalArgumentException("Function parallelism must be a positive number");
         }
@@ -1016,6 +1025,9 @@ public class FunctionConfigUtils {
         }
         if (!StringUtils.isEmpty(newConfig.getLogTopic())) {
             mergedConfig.setLogTopic(newConfig.getLogTopic());
+        }
+        if (!StringUtils.isEmpty(newConfig.getLogLevel())) {
+            mergedConfig.setLogLevel(newConfig.getLogLevel());
         }
         if (newConfig.getProcessingGuarantees() != null && !newConfig.getProcessingGuarantees()
                 .equals(existingConfig.getProcessingGuarantees())) {

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
@@ -31,6 +31,7 @@ import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -62,6 +63,8 @@ import org.apache.pulsar.functions.proto.Function.FunctionDetails;
 @Slf4j
 public class SinkConfigUtils {
 
+    private static final List<String> VALID_LOG_LEVELS = Arrays.asList("INFO", "DEBUG", "WARN", "ERROR");
+
     @Getter
     @Setter
     @AllArgsConstructor
@@ -88,6 +91,9 @@ public class SinkConfigUtils {
             functionDetailsBuilder.setName(sinkConfig.getName());
         }
         functionDetailsBuilder.setRuntime(FunctionDetails.Runtime.JAVA);
+        if (sinkConfig.getLogLevel() != null) {
+            functionDetailsBuilder.setLogLevel(sinkConfig.getLogLevel());
+        }
         if (sinkConfig.getParallelism() != null) {
             functionDetailsBuilder.setParallelism(sinkConfig.getParallelism());
         } else {
@@ -396,6 +402,9 @@ public class SinkConfigUtils {
         if (!isEmpty(functionDetails.getUserConfig())) {
             sinkConfig.setTransformFunctionConfig(functionDetails.getUserConfig());
         }
+        if (!isEmpty(functionDetails.getLogLevel())) {
+            sinkConfig.setLogLevel(functionDetails.getLogLevel());
+        }
 
 
         return sinkConfig;
@@ -546,6 +555,14 @@ public class SinkConfigUtils {
         if (sinkConfig.getRetainKeyOrdering() != null && sinkConfig.getRetainKeyOrdering()
                 && sinkConfig.getRetainOrdering() != null && sinkConfig.getRetainOrdering()) {
             throw new IllegalArgumentException("Only one of retain ordering or retain key ordering can be set");
+        }
+
+        if (!isEmpty(sinkConfig.getLogLevel())) {
+            log.info("sinkConfig.getLogLevel(): " + sinkConfig.getLogLevel());
+            if (!VALID_LOG_LEVELS.contains(sinkConfig.getLogLevel().toUpperCase())) {
+                throw new IllegalArgumentException(
+                        String.format("LogLevel %s is invalid", sinkConfig.getLogLevel()));
+            }
         }
 
         // validate user defined config if enabled and classloading is enabled
@@ -711,6 +728,9 @@ public class SinkConfigUtils {
         }
         if (newConfig.getSourceSubscriptionPosition() != null) {
             mergedConfig.setSourceSubscriptionPosition(newConfig.getSourceSubscriptionPosition());
+        }
+        if (!StringUtils.isEmpty(newConfig.getLogLevel())) {
+            mergedConfig.setLogLevel(newConfig.getLogLevel());
         }
         return mergedConfig;
     }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
@@ -558,7 +558,6 @@ public class SinkConfigUtils {
         }
 
         if (!isEmpty(sinkConfig.getLogLevel())) {
-            log.info("sinkConfig.getLogLevel(): " + sinkConfig.getLogLevel());
             if (!VALID_LOG_LEVELS.contains(sinkConfig.getLogLevel().toUpperCase())) {
                 throw new IllegalArgumentException(
                         String.format("LogLevel %s is invalid", sinkConfig.getLogLevel()));

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
@@ -367,7 +367,6 @@ public class SourceConfigUtils {
             }
         }
         if (!isEmpty(sourceConfig.getLogLevel())) {
-            log.info("sourceConfig.getLogLevel(): " + sourceConfig.getLogLevel());
             if (!VALID_LOG_LEVELS.contains(sourceConfig.getLogLevel().toUpperCase())) {
                 throw new IllegalArgumentException(
                         String.format("LogLevel %s is invalid", sourceConfig.getLogLevel()));

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
@@ -28,7 +28,9 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -55,6 +57,8 @@ import org.apache.pulsar.io.core.Source;
 
 @Slf4j
 public class SourceConfigUtils {
+
+    private static final List<String> VALID_LOG_LEVELS = Arrays.asList("INFO", "DEBUG", "WARN", "ERROR");
 
     @Getter
     @Setter
@@ -180,6 +184,9 @@ public class SourceConfigUtils {
         if (!StringUtils.isEmpty(sourceConfig.getCustomRuntimeOptions())) {
             functionDetailsBuilder.setCustomRuntimeOptions(sourceConfig.getCustomRuntimeOptions());
         }
+        if (sourceConfig.getLogLevel() != null) {
+            functionDetailsBuilder.setLogLevel(sourceConfig.getLogLevel());
+        }
 
         return FunctionConfigUtils.validateFunctionDetails(functionDetailsBuilder.build());
     }
@@ -249,6 +256,9 @@ public class SourceConfigUtils {
 
         if (!isEmpty(functionDetails.getCustomRuntimeOptions())) {
             sourceConfig.setCustomRuntimeOptions(functionDetails.getCustomRuntimeOptions());
+        }
+        if (!isEmpty(functionDetails.getLogLevel())) {
+            sourceConfig.setLogLevel(functionDetails.getLogLevel());
         }
 
         return sourceConfig;
@@ -356,6 +366,13 @@ public class SourceConfigUtils {
                 log.warn("Skipping annotation based validation of sink config as classloading is disabled");
             }
         }
+        if (!isEmpty(sourceConfig.getLogLevel())) {
+            log.info("sourceConfig.getLogLevel(): " + sourceConfig.getLogLevel());
+            if (!VALID_LOG_LEVELS.contains(sourceConfig.getLogLevel().toUpperCase())) {
+                throw new IllegalArgumentException(
+                        String.format("LogLevel %s is invalid", sourceConfig.getLogLevel()));
+            }
+        }
 
         return new ExtractedSourceDetails(sourceClassName, typeArg.asErasure().getTypeName());
     }
@@ -424,6 +441,9 @@ public class SourceConfigUtils {
         }
         if (newConfig.getProducerConfig() != null) {
             mergedConfig.setProducerConfig(newConfig.getProducerConfig());
+        }
+        if (!StringUtils.isEmpty(newConfig.getLogLevel())) {
+            mergedConfig.setLogLevel(newConfig.getLogLevel());
         }
         return mergedConfig;
     }

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
@@ -596,6 +596,7 @@ public class FunctionConfigUtilsTest {
                 .build();
         boolean autoAck = true;
         String logTopic = "log-topic1";
+        String logLevel = "debug";
         Function.Resources resources = Function.Resources.newBuilder().setCpu(1.5).setDisk(1024 * 20).setRam(1024 * 10).build();
         String packageUrl = "http://package.url";
         Map<String, String> secretsMap = new HashMap<>();
@@ -616,6 +617,7 @@ public class FunctionConfigUtilsTest {
                 .setSource(sourceSpec)
                 .setAutoAck(autoAck)
                 .setLogTopic(logTopic)
+                .setLogLevel(logLevel)
                 .setResources(resources)
                 .setPackageUrl(packageUrl)
                 .setSecretsMap(new Gson().toJson(secretsMap))
@@ -629,6 +631,7 @@ public class FunctionConfigUtilsTest {
         assertEquals(functionConfig.getName(), name);
         assertEquals(functionConfig.getClassName(), classname);
         assertEquals(functionConfig.getLogTopic(), logTopic);
+        assertEquals(functionConfig.getLogLevel(), logLevel);
         assertEquals((Object) functionConfig.getResources().getCpu(), resources.getCpu());
         assertEquals(functionConfig.getResources().getDisk().longValue(), resources.getDisk());
         assertEquals(functionConfig.getResources().getRam().longValue(), resources.getRam());


### PR DESCRIPTION
Master Issue: #23783

### Motivation:

The `pulsar.log.level` property in`kubernetes_instance_log4j2.xml` & `java_instance_log4j2.xml` files in the Pulsar Functions runtime is responsible for configuring the log settings for function pods when using the Java runtime in Kubernetes StatefulSets & for process runtime respectively. Currently, this configuration file is hardcoded to use the `INFO` log level, which restricts flexibility when more granular logging (such as `DEBUG` level) is needed for troubleshooting or deeper monitoring. This limitation is particularly impactful when debugging issues related to sources, sinks, or function executions, where more detailed logs could be beneficial.

Presently, adjusting the log level requires manual changes to the `kubernetes_instance_log4j2.xml` or `java_instance_log4j2.xml` file, which is inefficient and error-prone, especially in dynamic environments. There is no built-in way to modify the log level dynamically without altering the configuration file directly.

This PR introduces a new argument (`logLevel`) to override the JVM property `-Dpulsar.log.level=info` at runtime for functions, sources, and sinks. This change provides a more flexible and dynamic approach to adjust log verbosity based on specific needs, such as enabling `DEBUG` or `ERROR` logs for better diagnostics during troubleshooting.

### Modifications:

- **Introduction of `logLevel` Argument**: Added a new `logLevel` argument for Pulsar Functions, Sources, and Sinks, which allows the user to override the default JVM property `-Dpulsar.log.level=info`. This enables setting custom log levels (e.g., `DEBUG`, `ERROR`) dynamically at runtime without modifying the `kubernetes_instance_log4j2.xml` or `java_instance_log4j2.xml` file.
  
- **JVM Property Override**: The new `logLevel` argument directly overrides the `-Dpulsar.log.level` property, giving users control over the logging level without needing to edit the underlying configuration file.

- **Backward Compatibility**: The default log level remains `INFO` unless the new `logLevel` argument is provided. This ensures that existing deployments continue to function as before.

This update enhances the troubleshooting and monitoring capabilities of Pulsar Functions, offering greater flexibility while preserving the simplicity and stability of existing configurations.


### Verifying this change

- [X] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: yes.  Added a cli arg `logLevel` for creating/updating function/source/sink
  - Anything that affects deployment: no

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [X] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


