### PR TITLE
[improve][io] Add backpressure to kafka-connect-adapter when flush stalled or batchSize reached

### DIFF
--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
@@ -603,8 +603,8 @@ public class KafkaConnectSink implements Sink<GenericObject> {
         try {
             while (isRunning && (flushStalled || currentBatchSize.get() >= maxBatchSize)) {
                 if (log.isDebugEnabled()) {
-                    log.debug("Sink is paused until flush succeeds. currentBatchSize: {}, maxBatchSize:{}, flushStalled:{}",
-                            currentBatchSize.get(), maxBatchSize, flushStalled);
+                    log.debug("Sink is paused until flush succeeds. currentBatchSize: {}, maxBatchSize:{}, "
+                                    + "flushStalled:{}", currentBatchSize.get(), maxBatchSize, flushStalled);
                 }
                 try {
                     notFullOrNotStalled.await();

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
@@ -123,6 +123,14 @@ public class KafkaConnectSink implements Sink<GenericObject> {
             return;
         }
 
+        if (currentBatchSize.get() >= maxBatchSize) {
+            if (log.isDebugEnabled()) {
+                log.debug("Sink is paused until flush succeeds. currentBatchSize: {}, maxBatchSize:{}",
+                        currentBatchSize, maxBatchSize);
+            }
+            return;
+        }
+
         // while sourceRecord.getMessage() is Optional<>
         // it should always be present in Sink which gets instance of PulsarRecord
         // let's avoid checks for .isPresent() in teh rest of the code

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
@@ -590,6 +590,9 @@ public class KafkaConnectSink implements Sink<GenericObject> {
     }
 
     private boolean waitForBackpressure(Record<GenericObject> sourceRecord) {
+        if (!flushStalled && currentBatchSize.get() < maxBatchSize && isRunning) {
+            return true;
+        }
         backpressureLock.lock();
         try {
             while (isRunning && (flushStalled || currentBatchSize.get() >= maxBatchSize)) {

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
@@ -39,6 +39,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -88,6 +90,10 @@ public class KafkaConnectSink implements Sink<GenericObject> {
     private final AtomicBoolean isFlushRunning = new AtomicBoolean(false);
     private volatile boolean isRunning = false;
 
+    private final ReentrantLock backpressureLock = new ReentrantLock();
+    private final Condition notFullOrNotStalled = backpressureLock.newCondition();
+    private volatile boolean flushStalled = false;
+
     private final Properties props = new Properties();
     private PulsarKafkaConnectSinkConfig kafkaSinkConfig;
 
@@ -123,18 +129,14 @@ public class KafkaConnectSink implements Sink<GenericObject> {
             return;
         }
 
-        if (currentBatchSize.get() >= maxBatchSize) {
-            if (log.isDebugEnabled()) {
-                log.debug("Sink is paused until flush succeeds. currentBatchSize: {}, maxBatchSize:{}",
-                        currentBatchSize, maxBatchSize);
-            }
-            return;
-        }
-
         // while sourceRecord.getMessage() is Optional<>
         // it should always be present in Sink which gets instance of PulsarRecord
         // let's avoid checks for .isPresent() in teh rest of the code
         Preconditions.checkArgument(sourceRecord.getMessage().isPresent());
+        if (!waitForBackpressure(sourceRecord)) {
+            return;
+        }
+
         try {
             SinkRecord record = toSinkRecord(sourceRecord);
             task.put(Lists.newArrayList(record));
@@ -151,6 +153,7 @@ public class KafkaConnectSink implements Sink<GenericObject> {
     @Override
     public void close() throws Exception {
         isRunning = false;
+        signalWriters();
         flushIfNeeded(true);
         scheduledExecutor.shutdown();
         if (!scheduledExecutor.awaitTermination(10 * lingerMs, TimeUnit.MILLISECONDS)) {
@@ -262,7 +265,18 @@ public class KafkaConnectSink implements Sink<GenericObject> {
             Map<TopicPartition, OffsetAndMetadata> currentOffsets = taskContext.currentOffsets();
             committedOffsets = task.preCommit(currentOffsets);
             if (committedOffsets == null || committedOffsets.isEmpty()) {
-                log.info("Task returned empty committedOffsets map; skipping flush; task will retry later");
+                if (!currentOffsets.isEmpty()) {
+                    backpressureLock.lock();
+                    try {
+                        flushStalled = true;
+                    } finally {
+                        backpressureLock.unlock();
+                    }
+                    log.warn("Task returned empty committedOffsets while currentOffsets is non-empty; "
+                            + "stalling writes until flush recovers");
+                } else {
+                    log.info("Task returned empty committedOffsets map; skipping flush; task will retry later");
+                }
                 return;
             }
             if (log.isDebugEnabled() && !areMapsEqual(committedOffsets, currentOffsets)) {
@@ -270,6 +284,15 @@ public class KafkaConnectSink implements Sink<GenericObject> {
             }
             taskContext.flushOffsets(committedOffsets);
             ackUntil(lastNotFlushed, committedOffsets, Record::ack);
+
+            backpressureLock.lock();
+            try {
+                flushStalled = false;
+                notFullOrNotStalled.signalAll();
+            } finally {
+                backpressureLock.unlock();
+            }
+
             log.info("Flush succeeded");
         } catch (Throwable t) {
             log.error("error flushing pending records", t);
@@ -575,4 +598,39 @@ public class KafkaConnectSink implements Sink<GenericObject> {
         }
     }
 
+    private boolean waitForBackpressure(Record<GenericObject> sourceRecord) {
+        backpressureLock.lock();
+        try {
+            while (isRunning && (flushStalled || currentBatchSize.get() >= maxBatchSize)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Sink is paused until flush succeeds. currentBatchSize: {}, maxBatchSize:{}, flushStalled:{}",
+                            currentBatchSize.get(), maxBatchSize, flushStalled);
+                }
+                try {
+                    notFullOrNotStalled.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    sourceRecord.fail();
+                    return false;
+                }
+            }
+
+            if (!isRunning) {
+                sourceRecord.fail();
+                return false;
+            }
+            return true;
+        } finally {
+            backpressureLock.unlock();
+        }
+    }
+
+    private void signalWriters() {
+        backpressureLock.lock();
+        try {
+            notFullOrNotStalled.signalAll();
+        } finally {
+            backpressureLock.unlock();
+        }
+    }
 }

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
@@ -282,13 +282,7 @@ public class KafkaConnectSink implements Sink<GenericObject> {
             taskContext.flushOffsets(committedOffsets);
             ackUntil(lastNotFlushed, committedOffsets, Record::ack);
 
-            backpressureLock.lock();
-            try {
-                flushStalled = false;
-                notFullOrNotStalled.signalAll();
-            } finally {
-                backpressureLock.unlock();
-            }
+            signalWriters();
 
             log.info("Flush succeeded");
         } catch (Throwable t) {
@@ -625,6 +619,7 @@ public class KafkaConnectSink implements Sink<GenericObject> {
     private void signalWriters() {
         backpressureLock.lock();
         try {
+            flushStalled = false;
             notFullOrNotStalled.signalAll();
         } finally {
             backpressureLock.unlock();

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
@@ -267,11 +267,8 @@ public class KafkaConnectSink implements Sink<GenericObject> {
             if (committedOffsets == null || committedOffsets.isEmpty()) {
                 if (!currentOffsets.isEmpty()) {
                     backpressureLock.lock();
-                    try {
-                        flushStalled = true;
-                    } finally {
-                        backpressureLock.unlock();
-                    }
+                    flushStalled = true;
+                    backpressureLock.unlock();
                     log.warn("Task returned empty committedOffsets while currentOffsets is non-empty; "
                             + "stalling writes until flush recovers");
                 } else {


### PR DESCRIPTION
<!-- Either this PR fixes an issue, -->

Fixes https://github.com/apache/pulsar-connectors/issues/15

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

The current implementation of `KafkaConnectSink` does not apply effective backpressure when the downstream Kafka Connect task is unable to make progress during flush. Specifically, when task.preCommit(currentOffsets) returns an empty map while currentOffsets is non-empty, it indicates that the connector is not ready to commit offsets (e.g., due to internal buffering, retries, or transient failures).

In this state, the sink continues to accept new records in `write()`, causing `pendingFlushQueue` and `currentBatchSize` to grow unbounded. Over time, this leads to excessive memory usage and can ultimately result in OOM conditions under sustained load.

### Modifications

<!-- Describe the modifications you've done. -->

- Added a `ReentrantLock` and `Condition` to coordinate backpressure between write() and flush().
- Introduced a `flushStalled` flag to detect when `preCommit()` returns empty while there are pending offsets.
- Updated `flush()` to set `flushStalled` on stall and clear it (with signalAll) on successful flush.
- Updated `write()` to block before `task.put(...)` when the batch is full or flush is stalled, instead of continuing ingestion.
- Ensured waiting threads are signaled during shutdown.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
  - *Will be added in the next PR*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
