### PR TITLE
[fix][sec][4.0_ds] Fixing kotlin-stdlib dependency version for pulsar-io-kinesis with CVE-2020-29582

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,6 +293,7 @@ flexible messaging model and an intuitive client API.</description>
     <okhttp3.version>5.3.2</okhttp3.version>
     <!-- use okio version that matches the okhttp3 version -->
     <okio.version>3.17.0</okio.version>
+    <kotlin-stdlib.version>2.2.21</kotlin-stdlib.version>
     <nsq-client.version>1.0</nsq-client.version>
     <cron-utils.version>9.1.6</cron-utils.version>
     <spring.version>6.2.12</spring.version>
@@ -1663,6 +1664,23 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>com.squareup.okio</groupId>
         <artifactId>okio</artifactId>
         <version>${okio.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib</artifactId>
+        <version>${kotlin-stdlib.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-common</artifactId>
+        <version>${kotlin-stdlib.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-jdk8</artifactId>
+        <version>${kotlin-stdlib.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1668,19 +1668,10 @@ flexible messaging model and an intuitive client API.</description>
 
       <dependency>
         <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-stdlib</artifactId>
+        <artifactId>kotlin-bom</artifactId>
         <version>${kotlin-stdlib.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-stdlib-common</artifactId>
-        <version>${kotlin-stdlib.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-stdlib-jdk8</artifactId>
-        <version>${kotlin-stdlib.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
<!-- Either this PR fixes an issue, -->

Fixes https://datastax.jira.com/browse/AS-4628

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
To fix the vulnerabilities of kotlin-stdlib by upgrading it to 2.2.21 for pulsar-io-kinesis.

### Modifications

<!-- Describe the modifications you've done. -->
Updated dependency management to add kotlin-stdlib in pom.xml

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
