### PR TITLE
[improve] AS-5322: alpine-dockerfile-added-missing-dependencies

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -92,6 +92,13 @@ ENV LANG C.UTF-8
 # (abseil-cpp, re2, c-ares, etc.) are correctly resolved in the final image
 RUN apk add --no-cache \
             bash \
+            curl \
+            wget \
+            bind-tools \
+            netcat-openbsd \
+            procps \
+            less \
+            vim \
             python3 \
             py3-pip \
             py3-grpcio \


### PR DESCRIPTION
During the migration from the Ubuntu base image to Alpine Linux (alpine:3.21), several operational, networking, and debugging utilities available in the Ubuntu image were omitted from the final runtime stage.

This PR restores parity with the previous Ubuntu image by adding the Alpine equivalents of these essential tools.

Modifications
Added the following packages via apk in the final stage of docker/pulsar/Dockerfile:

Networking & DNS tools: curl, wget, bind-tools (dig, nslookup), netcat-openbsd (nc)
System & process tools: procps (ps, top, free, pkill), less
Text editor: vim
Verification
Verified that all added utilities install cleanly with no package conflicts.
Verified that network commands (curl, wget, dig, nc), process management tools (ps), and editors (vim) are executable by the non-root user (UID 10000).