### PR TITLE
[fix] [docker] AS-5322: bug fix in dockerfile for pulsar 3.x

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -34,14 +34,14 @@ COPY scripts/* /pulsar/bin/
 # container when gid=0 is prohibited. In that case, the container must be run with uid 10000 with
 # any group id != 0 (for example 10001).
 # The file permissions are preserved when copying files from this builder image to the target image.
-RUN for SUBDIRECTORY in conf data download logs instances/deps; do \
+RUN for SUBDIRECTORY in conf data download logs instances/deps packages-storage; do \
      mkdir -p /pulsar/$SUBDIRECTORY; \
      chmod -R ug+rwx /pulsar/$SUBDIRECTORY; \
      chown -R 10000:0 /pulsar/$SUBDIRECTORY; \
      done
 
 RUN chmod -R g+rx /pulsar/bin
-RUN chmod -R o+rx /pulsar
+RUN chmod -R ug+rwx /pulsar
 
 # Trino writes logs to this directory (at least during tests), so we need to give the process permission
 # to create those log directories. This should be removed when Trino is removed.

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -104,7 +104,8 @@ RUN apk add --no-cache \
             py3-grpcio \
             py3-yaml \
             gcompat \
-            ca-certificates
+            ca-certificates \
+            openssl
 
 # Install GLibc compatibility library
 COPY --from=glibc /root/packages /root/packages


### PR DESCRIPTION
packages-storage directory: Pre-creates the folder with UID 10000 ownership so the Packages Management Service can initialize properly without failing due to permission errors when running as a non-root user.

chmod -R ug+rwx /pulsar: Grants full read/write/execute permissions to the user and root group (GID 0), ensuring non-root and OpenShift arbitrary UIDs can create dynamic runtime files under /pulsar.
