### PR TITLE
[fix] AS-5322: Fix root permissions 

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -42,6 +42,7 @@ RUN for SUBDIRECTORY in conf data download logs instances/deps packages-storage;
 
 RUN chmod -R g+rx /pulsar/bin
 RUN chmod -R ug+rwx /pulsar
+RUN chown 10000:0 /pulsar
 
 # Trino writes logs to this directory (at least during tests), so we need to give the process permission
 # to create those log directories. This should be removed when Trino is removed.


### PR DESCRIPTION
Fix permission denied on /pulsar/superuser_token.jwt by ensuring /pulsar directory is owned by uid 10000:gid 0, allowing the pulsar components to read JWT credentials at startup.
